### PR TITLE
Update the path to the Go modules.

### DIFF
--- a/go/README
+++ b/go/README
@@ -9,8 +9,8 @@ Installation:
 This go code must be imported into your go workspace before you can use it, you
 can do that with:
 
-  go get code.google.com/p/certificate-transparency/go/client
-  go get code.google.com/p/certificate-transparency/go/scanner
+  go get github.com/google/certificate-transparency/go/client
+  go get github.com/google/certificate-transparency/go/scanner
   etc.
 
 
@@ -26,7 +26,7 @@ the relevant go package src directories so that they will be automatically
 picked up during cgo compilation.
 
 To compile the log scanner run:
-  go build code.google.com/p/certificate-transparency/go/scanner/main/scanner.go
+  go build github.com/google/certificate-transparency/go/scanner/main/scanner.go
 
 
 Contributing:

--- a/go/client/types.go
+++ b/go/client/types.go
@@ -3,7 +3,7 @@ package client
 import (
 	"fmt"
 
-	"code.google.com/p/certificate-transparency/go/x509"
+	"github.com/google/certificate-transparency/go/x509"
 )
 
 ///////////////////////////////////////////////////////////////////////////////////

--- a/go/scanner/main/scanner.go
+++ b/go/scanner/main/scanner.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"regexp"
 
-	"code.google.com/p/certificate-transparency/go/client"
-	"code.google.com/p/certificate-transparency/go/scanner"
-	"code.google.com/p/certificate-transparency/go/x509"
+	"github.com/google/certificate-transparency/go/client"
+	"github.com/google/certificate-transparency/go/scanner"
+	"github.com/google/certificate-transparency/go/x509"
 )
 
 const (

--- a/go/scanner/scanner.go
+++ b/go/scanner/scanner.go
@@ -10,8 +10,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"code.google.com/p/certificate-transparency/go/client"
-	"code.google.com/p/certificate-transparency/go/x509"
+	"github.com/google/certificate-transparency/go/client"
+	"github.com/google/certificate-transparency/go/x509"
 )
 
 // Clients wishing to implement their own Matchers should implement this interface:

--- a/go/scanner/scanner_test.go
+++ b/go/scanner/scanner_test.go
@@ -8,8 +8,8 @@ import (
 	"regexp"
 	"testing"
 
-	"code.google.com/p/certificate-transparency/go/client"
-	"code.google.com/p/certificate-transparency/go/x509"
+	"github.com/google/certificate-transparency/go/client"
+	"github.com/google/certificate-transparency/go/x509"
 )
 
 func CertMatchesRegex(r *regexp.Regexp, cert *x509.Certificate) bool {

--- a/go/x509/pkcs1.go
+++ b/go/x509/pkcs1.go
@@ -7,7 +7,7 @@ package x509
 import (
 	"crypto/rsa"
 	// START CT CHANGES
-	"code.google.com/p/certificate-transparency/go/asn1"
+	"github.com/google/certificate-transparency/go/asn1"
 	// END CT CHANGES
 	"errors"
 	"math/big"

--- a/go/x509/pkcs8.go
+++ b/go/x509/pkcs8.go
@@ -6,8 +6,8 @@ package x509
 
 import (
 	// START CT CHANGES
-	"code.google.com/p/certificate-transparency/go/asn1"
-	"code.google.com/p/certificate-transparency/go/x509/pkix"
+	"github.com/google/certificate-transparency/go/asn1"
+	"github.com/google/certificate-transparency/go/x509/pkix"
 	// END CT CHANGES
 	"errors"
 	"fmt"

--- a/go/x509/pkix/pkix.go
+++ b/go/x509/pkix/pkix.go
@@ -8,7 +8,7 @@ package pkix
 
 import (
 	// START CT CHANGES
-	"code.google.com/p/certificate-transparency/go/asn1"
+	"github.com/google/certificate-transparency/go/asn1"
 	// END CT CHANGES
 	"math/big"
 	"time"

--- a/go/x509/sec1.go
+++ b/go/x509/sec1.go
@@ -8,7 +8,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	// START CT CHANGES
-	"code.google.com/p/certificate-transparency/go/asn1"
+	"github.com/google/certificate-transparency/go/asn1"
 	// START CT CHANGES
 	"errors"
 	"fmt"

--- a/go/x509/verify_test.go
+++ b/go/x509/verify_test.go
@@ -6,7 +6,7 @@ package x509
 
 import (
 	// START CT CHANGES
-	"code.google.com/p/certificate-transparency/go/x509/pkix"
+	"github.com/google/certificate-transparency/go/x509/pkix"
 	// END CT CHANGES
 	"encoding/pem"
 	"errors"

--- a/go/x509/x509.go
+++ b/go/x509/x509.go
@@ -20,8 +20,8 @@ import (
 	"crypto/rsa"
 	"crypto/sha1"
 	// START CT CHANGES
-	"code.google.com/p/certificate-transparency/go/asn1"
-	"code.google.com/p/certificate-transparency/go/x509/pkix"
+	"github.com/google/certificate-transparency/go/asn1"
+	"github.com/google/certificate-transparency/go/x509/pkix"
 	// END CT CHANGES
 	"encoding/pem"
 	"errors"

--- a/go/x509/x509_test.go
+++ b/go/x509/x509_test.go
@@ -14,8 +14,8 @@ import (
 	_ "crypto/sha256"
 	_ "crypto/sha512"
 	// START CT CHANGES
-	"code.google.com/p/certificate-transparency/go/asn1"
-	"code.google.com/p/certificate-transparency/go/x509/pkix"
+	"github.com/google/certificate-transparency/go/asn1"
+	"github.com/google/certificate-transparency/go/x509/pkix"
 	// END CT CHANGES
 	"encoding/base64"
 	"encoding/hex"


### PR DESCRIPTION
I realized that doing a "go get github.com/google/certificate-transparency" would **also** fetch the Google Code version, and actually use that for most of it!
