### PR TITLE
Clean up #include ordering and add missing ones.

### DIFF
--- a/cpp/client/client.cc
+++ b/cpp/client/client.cc
@@ -1,3 +1,5 @@
+#include "client/client.h"
+
 #include <arpa/inet.h>
 #include <glog/logging.h>
 #include <netinet/in.h>
@@ -5,8 +7,6 @@
 #include <stdint.h>
 #include <sys/socket.h>
 #include <unistd.h>
-
-#include "client/client.h"
 
 #ifdef __MACH__
 // does not exist on MacOS

--- a/cpp/client/client.h
+++ b/cpp/client/client.h
@@ -2,6 +2,7 @@
 #define CLIENT_H
 
 #include <stdint.h>
+#include <string>
 
 // Socket creation for client connections.
 class Client {

--- a/cpp/client/http_log_client.cc
+++ b/cpp/client/http_log_client.cc
@@ -1,20 +1,20 @@
 /* -*- indent-tabs-mode: nil -*- */
 #include "client/http_log_client.h"
+
+#include <curl/curl.h>
+#include <glog/logging.h>
+#include <sstream>
+
 #include "log/cert.h"
 #include "proto/ct.pb.h"
 #include "proto/serializer.h"
 #include "util/json_wrapper.h"
 #include "util/util.h"
 
-#include <curl/curl.h>
-#include <glog/logging.h>
-#include <sstream>
-
-using std::string;
-using std::ostringstream;
-
 using ct::Cert;
 using ct::CertChain;
+using std::ostringstream;
+using std::string;
 
 namespace {
 

--- a/cpp/client/log_client.cc
+++ b/cpp/client/log_client.cc
@@ -1,21 +1,22 @@
+#include "client/log_client.h"
+
 #include <glog/logging.h>
 #include <stdint.h>
 
-#include "include/ct.h"
 #include "client/client.h"
-#include "client/log_client.h"
+#include "include/ct.h"
 #include "proto/ct.pb.h"
 #include "proto/serializer.h"
 
-using ct::LogEntry;
 using ct::ClientLookup;
 using ct::ClientMessage;
+using ct::LogEntry;
+using ct::MerkleAuditProof;
 using ct::ServerError;
 using ct::ServerMessage;
-using ct::MerkleAuditProof;
 using ct::SignedCertificateTimestamp;
-using ct::protocol::kPacketPrefixLength;
 using ct::protocol::kMaxPacketLength;
+using ct::protocol::kPacketPrefixLength;
 using std::string;
 
 const ct::protocol::Version LogClient::kProtocolVersion = ct::protocol::V1;

--- a/cpp/client/ssl_client.cc
+++ b/cpp/client/ssl_client.cc
@@ -1,10 +1,11 @@
+#include "client/ssl_client.h"
+
 #include <glog/logging.h>
 #include <openssl/bio.h>
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
 
 #include "client/client.h"
-#include "client/ssl_client.h"
 #include "log/cert.h"
 #include "log/cert_submission_handler.h"
 #include "log/ct_extensions.h"
@@ -12,14 +13,13 @@
 #include "merkletree/serial_hasher.h"
 #include "proto/serializer.h"
 
-using ct::SignedCertificateTimestamp;
-using ct::SignedCertificateTimestampList;
-using ct::SSLClientCTData;
-using ct::LogEntry;
-using std::string;
-
 using ct::Cert;
 using ct::CertChain;
+using ct::LogEntry;
+using ct::SSLClientCTData;
+using ct::SignedCertificateTimestamp;
+using ct::SignedCertificateTimestampList;
+using std::string;
 
 const uint16_t CT_EXTENSION_TYPE = 18;
 

--- a/cpp/include/ct.h
+++ b/cpp/include/ct.h
@@ -1,6 +1,8 @@
 #ifndef CT_H
 #define CT_H
 
+#include <stddef.h>
+
 namespace ct {
 namespace protocol {
 

--- a/cpp/log/cert.cc
+++ b/cpp/log/cert.cc
@@ -17,6 +17,9 @@
 #include "merkletree/serial_hasher.h"
 #include "util/openssl_util.h"  // For LOG_OPENSSL_ERRORS
 
+using std::string;
+using util::ClearOpenSSLErrors;
+
 #if OPENSSL_VERSION_NUMBER < 0x10002000L
 # define X509_get_cert_info(x509) (x509)->cert_info
 # define X509_CINF_set_modified(c) ((c)->enc.modified = 1)
@@ -26,9 +29,6 @@
 #endif
 
 namespace ct {
-
-using std::string;
-using util::ClearOpenSSLErrors;
 
 Cert::Cert(X509 *x509) : x509_(x509) {
 }

--- a/cpp/log/cert_checker.cc
+++ b/cpp/log/cert_checker.cc
@@ -1,26 +1,26 @@
 /* -*- indent-tabs-mode: nil -*- */
+#include "log/cert_checker.h"
+
 #include <glog/logging.h>
-#include <string.h>
 #include <openssl/asn1.h>
 #include <openssl/bio.h>
 #include <openssl/pem.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
-
+#include <string.h>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "log/cert.h"
-#include "log/cert_checker.h"
 #include "log/ct_extensions.h"
 #include "util/openssl_util.h"  // for LOG_OPENSSL_ERRORS
 #include "util/util.h"
 
-namespace  ct {
-
 using std::string;
 using util::ClearOpenSSLErrors;
+
+namespace  ct {
 
 CertChecker::CertChecker() : trusted_() {
 }

--- a/cpp/log/cert_submission_handler.cc
+++ b/cpp/log/cert_submission_handler.cc
@@ -1,23 +1,23 @@
+#include "log/cert_submission_handler.h"
+
 #include <glog/logging.h>
 #include <string>
 
 #include "log/cert.h"
 #include "log/cert_checker.h"
-#include "log/cert_submission_handler.h"
 #include "log/ct_extensions.h"
 #include "proto/ct.pb.h"
 #include "proto/serializer.h"
 
-using ct::LogEntry;
-using ct::PrecertChainEntry;
-using ct::X509ChainEntry;
-using std::string;
-
 using ct::Cert;
 using ct::CertChain;
 using ct::CertChecker;
+using ct::LogEntry;
 using ct::PreCertChain;
+using ct::PrecertChainEntry;
 using ct::TbsCertificate;
+using ct::X509ChainEntry;
+using std::string;
 
 // TODO(ekasper): handle Cert errors consistently and log some errors here
 // if they fail.

--- a/cpp/log/ct_extensions.cc
+++ b/cpp/log/ct_extensions.cc
@@ -1,11 +1,10 @@
 #include "log/ct_extensions.h"
 
+#include <glog/logging.h>
 #include <openssl/asn1.h>
 #include <openssl/objects.h>
 #include <openssl/x509v3.h>
 #include <string.h>
-
-#include <glog/logging.h>
 
 namespace ct {
 int NID_ctSignedCertificateTimestampList = 0;

--- a/cpp/log/file_db.cc
+++ b/cpp/log/file_db.cc
@@ -1,4 +1,6 @@
 /* -*- indent-tabs-mode: nil -*- */
+#include "log/file_db.h"
+
 #include <glog/logging.h>
 #include <map>
 #include <set>
@@ -6,7 +8,6 @@
 #include <utility>  // for std::pair
 #include <vector>
 
-#include "log/file_db.h"
 #include "log/file_storage.h"
 #include "proto/ct.pb.h"
 #include "proto/serializer.h"

--- a/cpp/log/file_storage.cc
+++ b/cpp/log/file_storage.cc
@@ -1,4 +1,5 @@
 /* -*- indent-tabs-mode: nil -*- */
+#include "log/file_storage.h"
 
 #include <assert.h>
 #include <cstdlib>
@@ -9,7 +10,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include "log/file_storage.h"
 #include "log/filesystem_op.h"
 #include "util/util.h"
 

--- a/cpp/log/filesystem_op.cc
+++ b/cpp/log/filesystem_op.cc
@@ -1,9 +1,9 @@
+#include "log/filesystem_op.h"
+
 #include <errno.h>
 #include <stdio.h>
 #include <sys/stat.h>
 #include <unistd.h>
-
-#include "log/filesystem_op.h"
 
 BasicFilesystemOp::BasicFilesystemOp() {}
 

--- a/cpp/log/filesystem_op.h
+++ b/cpp/log/filesystem_op.h
@@ -1,6 +1,8 @@
 #ifndef FILESYSTEM_OP_H
 #define FILESYSTEM_OP_H
 
+#include <sys/types.h>
+
 // Make filesystem operations virtual so that we can override
 // to simulate filesystem errors.
 class FilesystemOp {

--- a/cpp/log/frontend.cc
+++ b/cpp/log/frontend.cc
@@ -1,9 +1,10 @@
 /* -*- indent-tabs-mode: nil -*- */
+#include "log/frontend.h"
+
 #include <glog/logging.h>
 
 #include "log/cert.h"
 #include "log/cert_submission_handler.h"
-#include "log/frontend.h"
 #include "log/frontend_signer.h"
 #include "proto/ct.pb.h"
 

--- a/cpp/log/frontend_signer.cc
+++ b/cpp/log/frontend_signer.cc
@@ -1,8 +1,9 @@
 /* -*- indent-tabs-mode: nil -*- */
+#include "log/frontend_signer.h"
+
 #include <glog/logging.h>
 
 #include "log/database.h"
-#include "log/frontend_signer.h"
 #include "log/log_signer.h"
 #include "merkletree/serial_hasher.h"
 #include "proto/ct.pb.h"

--- a/cpp/log/log_lookup.cc
+++ b/cpp/log/log_lookup.cc
@@ -1,11 +1,12 @@
 /* -*- indent-tabs-mode: nil -*- */
+#include "log/log_lookup.h"
+
 #include <glog/logging.h>
 #include <map>
 #include <stdint.h>
 #include <stdlib.h>
 
 #include "log/database.h"
-#include "log/log_lookup.h"
 #include "merkletree/merkle_tree.h"
 #include "merkletree/serial_hasher.h"
 #include "proto/ct.pb.h"

--- a/cpp/log/log_lookup.h
+++ b/cpp/log/log_lookup.h
@@ -1,12 +1,13 @@
 /* -*- mode: c++; indent-tabs-mode: nil -*- */
-
 #ifndef LOG_LOOKUP_H
 #define LOG_LOOKUP_H
 
 #include <map>
 #include <stdint.h>
+#include <string>
 
 #include "merkletree/merkle_tree.h"
+#include "proto/ct.pb.h"
 
 template <class Logged> class Database;
 

--- a/cpp/log/log_signer.cc
+++ b/cpp/log/log_signer.cc
@@ -1,24 +1,26 @@
 /* -*- indent-tabs-mode: nil -*- */
+#include "log/log_signer.h"
+
 #include <glog/logging.h>
 #include <openssl/evp.h>
 #include <openssl/opensslv.h>
-#if OPENSSL_VERSION_NUMBER < 0x10000000
-# error "Need OpenSSL >= 1.0.0"
-#endif
 #include <stdint.h>
 
-#include "log/log_signer.h"
 #include "merkletree/serial_hasher.h"
 #include "proto/ct.pb.h"
 #include "proto/serializer.h"
 #include "util/util.h"
 
+using ct::DigitallySigned;
 using ct::LogEntry;
 using ct::LogEntryType;
-using ct::DigitallySigned;
 using ct::SignedCertificateTimestamp;
 using ct::SignedTreeHead;
 using std::string;
+
+#if OPENSSL_VERSION_NUMBER < 0x10000000
+# error "Need OpenSSL >= 1.0.0"
+#endif
 
 namespace {
 

--- a/cpp/log/log_verifier.cc
+++ b/cpp/log/log_verifier.cc
@@ -1,9 +1,10 @@
+#include "log/log_verifier.h"
+
 #include <glog/logging.h>
 #include <stdint.h>
 
 #include "log/cert_submission_handler.h"
 #include "log/log_signer.h"
-#include "log/log_verifier.h"
 #include "merkletree/merkle_verifier.h"
 #include "proto/ct.pb.h"
 #include "proto/serializer.h"

--- a/cpp/log/signer.cc
+++ b/cpp/log/signer.cc
@@ -4,14 +4,15 @@
 #include <glog/logging.h>
 #include <openssl/evp.h>
 #include <openssl/opensslv.h>
-#if OPENSSL_VERSION_NUMBER < 0x10000000
-# error "Need OpenSSL >= 1.0.0"
-#endif
 #include <stdint.h>
 
 #include "log/verifier.h"
 #include "proto/ct.pb.h"
 #include "util/util.h"
+
+#if OPENSSL_VERSION_NUMBER < 0x10000000
+# error "Need OpenSSL >= 1.0.0"
+#endif
 
 namespace ct {
 
@@ -67,4 +68,3 @@ std::string Signer::RawSign(const std::string &data) const {
 }
 
 }  // namespace ct
-

--- a/cpp/log/sqlite_db.cc
+++ b/cpp/log/sqlite_db.cc
@@ -1,11 +1,11 @@
 /* -*- indent-tabs-mode: nil -*- */
+#include "log/sqlite_db.h"
 
 #include <glog/logging.h>
 #include <sqlite3.h>
 
-#include "log/sqlite_db.h"
-#include "util/util.h"
 #include "log/sqlite_statement.h"
+#include "util/util.h"
 
 using std::string;
 using sqlite::Statement;

--- a/cpp/log/sqlite_statement.h
+++ b/cpp/log/sqlite_statement.h
@@ -1,11 +1,11 @@
 #ifndef SQLITE_STATEMENT_H
 #define SQLITE_STATEMENT_H
 
+#include <glog/logging.h>
 #include <sqlite3.h>
+#include <string>
 
 namespace sqlite {
-
-using std::string;
 
 // Reduce the ugliness of the sqlite3 API.
 class Statement {
@@ -23,7 +23,7 @@ class Statement {
   // Fields start at 0! |value| must have lifetime that covers its
   // use, which is up until the SQL statement finishes executing
   // (i.e. after the last Step()).
-  void BindBlob(unsigned field, const string &value) {
+  void BindBlob(unsigned field, const std::string &value) {
     CHECK_EQ(SQLITE_OK, sqlite3_bind_blob(stmt_, field + 1, value.data(),
                                           value.length(), NULL));
   }
@@ -32,7 +32,7 @@ class Statement {
     CHECK_EQ(SQLITE_OK, sqlite3_bind_int64(stmt_, field + 1, value));
   }
 
-  void GetBlob(unsigned column, string *value) {
+  void GetBlob(unsigned column, std::string *value) {
     const void *data = sqlite3_column_blob(stmt_, column);
     CHECK_NOTNULL(data);
     value->assign(static_cast<const char *>(data),

--- a/cpp/log/test_db.h
+++ b/cpp/log/test_db.h
@@ -1,7 +1,8 @@
 /* -*- mode: c++; indent-tabs-mode: nil -*- */
-
 #ifndef LOG_TEST_DB_H
 #define LOG_TEST_DB_H
+
+#include <sys/stat.h>
 
 #include "util/test_db.h"
 #include "log/database.h"

--- a/cpp/log/test_signer.cc
+++ b/cpp/log/test_signer.cc
@@ -1,3 +1,5 @@
+#include "log/test_signer.h"
+
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 #include <openssl/bio.h>
@@ -10,15 +12,12 @@
 #include "log/log_signer.h"
 #include "log/logged_certificate.h"
 #include "log/signer.h"
-#include "log/test_signer.h"
 #include "log/verifier.h"
 #include "merkletree/serial_hasher.h"
 #include "merkletree/tree_hasher.h"
 #include "proto/ct.pb.h"
 #include "proto/serializer.h"
 #include "util/util.h"
-
-namespace {
 
 using ct::DigitallySigned;
 using ct::LogEntry;
@@ -28,6 +27,8 @@ using ct::SignedCertificateTimestamp;
 using ct::SignedTreeHead;
 using ct::X509ChainEntry;
 using std::string;
+
+namespace {
 
 // A slightly shorter notation for constructing binary blobs from test vectors.
 string B(const char *hexstring) {

--- a/cpp/log/tree_signer.cc
+++ b/cpp/log/tree_signer.cc
@@ -1,11 +1,12 @@
 /* -*- indent-tabs-mode: nil -*- */
+#include "log/tree_signer.h"
+
 #include <glog/logging.h>
 #include <set>
 #include <stdint.h>
 
 #include "log/database.h"
 #include "log/log_signer.h"
-#include "log/tree_signer.h"
 #include "merkletree/compact_merkle_tree.h"
 #include "proto/serializer.h"
 #include "util/util.h"

--- a/cpp/log/verifier.cc
+++ b/cpp/log/verifier.cc
@@ -4,14 +4,15 @@
 #include <glog/logging.h>
 #include <openssl/evp.h>
 #include <openssl/opensslv.h>
-#if OPENSSL_VERSION_NUMBER < 0x10000000
-# error "Need OpenSSL >= 1.0.0"
-#endif
 #include <stdint.h>
 
 #include "merkletree/serial_hasher.h"
 #include "proto/ct.pb.h"
 #include "util/util.h"
+
+#if OPENSSL_VERSION_NUMBER < 0x10000000
+# error "Need OpenSSL >= 1.0.0"
+#endif
 
 namespace ct {
 
@@ -83,4 +84,3 @@ bool Verifier::RawVerify(const std::string &data,
 }
 
 }  // namespace ct
-

--- a/cpp/merkletree/compact_merkle_tree.cc
+++ b/cpp/merkletree/compact_merkle_tree.cc
@@ -1,14 +1,13 @@
+#include "merkletree/compact_merkle_tree.h"
+
 #include <glog/logging.h>
 #include <stddef.h>
 #include <string>
 #include <vector>
 
-#include "merkletree/compact_merkle_tree.h"
 #include "merkletree/merkle_tree_math.h"
 
 using std::string;
-
-class SerialHasher;
 
 CompactMerkleTree::CompactMerkleTree(SerialHasher *hasher)
     : ct::MerkleTreeInterface(),

--- a/cpp/merkletree/merkle_tree.cc
+++ b/cpp/merkletree/merkle_tree.cc
@@ -1,14 +1,13 @@
+#include "merkletree/merkle_tree.h"
+
 #include <glog/logging.h>
 #include <stddef.h>
 #include <string>
 #include <vector>
 
-#include "merkletree/merkle_tree.h"
 #include "merkletree/merkle_tree_math.h"
 
 using std::string;
-
-class SerialHasher;
 
 MerkleTree::MerkleTree(SerialHasher *hasher)
     : ct::MerkleTreeInterface(),

--- a/cpp/merkletree/merkle_tree_interface.h
+++ b/cpp/merkletree/merkle_tree_interface.h
@@ -4,6 +4,9 @@
 #ifndef SRC_MERKLETREE_MERKLE_TREE_INTERFACE_H_
 #define SRC_MERKLETREE_MERKLE_TREE_INTERFACE_H_
 
+#include <stddef.h>
+#include <string>
+
 namespace ct {
 
 // An interface for Merkle trees.  See specializations in

--- a/cpp/merkletree/merkle_tree_math.cc
+++ b/cpp/merkletree/merkle_tree_math.cc
@@ -1,6 +1,6 @@
-#include <stddef.h>
-
 #include "merkletree/merkle_tree_math.h"
+
+#include <stddef.h>
 
 // static
 bool MerkleTreeMath::IsPowerOfTwoPlusOne(size_t leaf_count) {

--- a/cpp/merkletree/merkle_verifier.cc
+++ b/cpp/merkletree/merkle_verifier.cc
@@ -1,11 +1,9 @@
+#include "merkletree/merkle_verifier.h"
+
 #include <stddef.h>
 #include <vector>
 
-#include "merkletree/merkle_verifier.h"
-
 using std::string;
-
-class SerialHasher;
 
 MerkleVerifier::MerkleVerifier(SerialHasher *hasher) : treehasher_(hasher) {
 }

--- a/cpp/merkletree/serial_hasher.cc
+++ b/cpp/merkletree/serial_hasher.cc
@@ -1,7 +1,7 @@
+#include "merkletree/serial_hasher.h"
+
 #include <openssl/sha.h>
 #include <stddef.h>
-
-#include "merkletree/serial_hasher.h"
 
 using std::string;
 

--- a/cpp/merkletree/tree_hasher.cc
+++ b/cpp/merkletree/tree_hasher.cc
@@ -1,5 +1,6 @@
-#include "merkletree/serial_hasher.h"
 #include "merkletree/tree_hasher.h"
+
+#include "merkletree/serial_hasher.h"
 
 using std::string;
 

--- a/cpp/monitor/sqlite_db.cc
+++ b/cpp/monitor/sqlite_db.cc
@@ -5,8 +5,8 @@
 
 #include "log/sqlite_statement.h"
 
-using std::string;
 using sqlite::Statement;
+using std::string;
 
 namespace monitor {
 

--- a/cpp/proto/serializer.cc
+++ b/cpp/proto/serializer.cc
@@ -1,11 +1,24 @@
 /* -*- indent-tabs-mode: nil -*- */
+#include "proto/serializer.h"
+
 #include <glog/logging.h>
-#include <string>
 #include <math.h>
+#include <string>
 
 #include "include/types.h"
 #include "proto/ct.pb.h"
-#include "proto/serializer.h"
+
+using ct::DigitallySigned;
+using ct::DigitallySigned_HashAlgorithm_IsValid;
+using ct::DigitallySigned_SignatureAlgorithm_IsValid;
+using ct::LogEntry;
+using ct::LogEntryType_IsValid;
+using ct::PrecertChainEntry;
+using ct::SignedCertificateTimestamp;
+using ct::SignedCertificateTimestampList;
+using ct::Version_IsValid;
+using ct::X509ChainEntry;
+using std::string;
 
 const size_t Serializer::kMaxCertificateLength = (1 << 24) - 1;
 const size_t Serializer::kMaxCertificateChainLength = (1 << 24) - 1;
@@ -23,18 +36,6 @@ const size_t Serializer::kKeyIDLengthInBytes = 32;
 const size_t Serializer::kMerkleLeafTypeLengthInBytes = 1;
 const size_t Serializer::kKeyHashLengthInBytes = 32;
 const size_t Serializer::kTimestampLengthInBytes = 8;
-
-using ct::LogEntry;
-using ct::LogEntryType_IsValid;
-using ct::DigitallySigned;
-using ct::DigitallySigned_HashAlgorithm_IsValid;
-using ct::DigitallySigned_SignatureAlgorithm_IsValid;
-using ct::SignedCertificateTimestamp;
-using ct::SignedCertificateTimestampList;
-using ct::X509ChainEntry;
-using ct::PrecertChainEntry;
-using ct::Version_IsValid;
-using std::string;
 
 // static
 // Returns the number of bytes needed to store a value up to max_length.

--- a/cpp/server/event.cc
+++ b/cpp/server/event.cc
@@ -1,9 +1,9 @@
 /* -*- indent-tabs-mode: nil -*- */
+#include "event.h"
+
 #include <limits.h>
 #include <openssl/evp.h>
 #include <openssl/pem.h>
-
-#include "event.h"
 
 time_t Services::rough_time_;
 

--- a/cpp/server/logged_blob.h
+++ b/cpp/server/logged_blob.h
@@ -1,5 +1,8 @@
 /* -*- mode: c++; indent-tabs-mode: nil -*- */
 
+#include <glog/logging.h>
+#include <stdint.h>
+
 #include "merkletree/serial_hasher.h"
 
 class LoggedBlob {

--- a/cpp/util/json_wrapper_test.cc
+++ b/cpp/util/json_wrapper_test.cc
@@ -1,4 +1,5 @@
 #include "util/json_wrapper.h"
+
 #include "util/testing.h"
 #include "util/util.h"
 

--- a/cpp/util/openssl_util.cc
+++ b/cpp/util/openssl_util.cc
@@ -3,12 +3,11 @@
 #include <openssl/bio.h>
 #include <openssl/err.h>
 #include <openssl/pem.h>
-
 #include <string>
 
-namespace util {
-
 using std::string;
+
+namespace util {
 
 string DumpOpenSSLErrorStack() {
   if (ERR_peek_error() == 0)

--- a/cpp/util/test_db.h
+++ b/cpp/util/test_db.h
@@ -3,6 +3,7 @@
 
 #include <gflags/gflags.h>
 #include <glog/logging.h>
+#include <stdlib.h>
 
 #include "util/util.h"
 

--- a/cpp/util/testing.cc
+++ b/cpp/util/testing.cc
@@ -1,8 +1,8 @@
+#include "testing.h"
+
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <gtest/gtest.h>
-
-#include "testing.h"
 
 namespace ct {
 namespace test {

--- a/cpp/util/util.cc
+++ b/cpp/util/util.cc
@@ -1,3 +1,5 @@
+#include "util/util.h"
+
 #include <assert.h>
 #include <cstring>
 #include <fstream>
@@ -11,11 +13,9 @@
 #include <sys/time.h>
 #include <unistd.h>
 
-#include "util/util.h"
+using std::string;
 
 namespace util {
-
-using std::string;
 
 namespace {
 const char nibble[] = "0123456789abcdef";

--- a/go/merkletree/merkle_tree_go.cc
+++ b/go/merkletree/merkle_tree_go.cc
@@ -1,9 +1,9 @@
+#include "merkletree/merkle_tree.h"
+
 #include <cstdlib>
 #include <cstring>
 #include <vector>
 #include <glog/logging.h>
-
-#include "merkletree/merkle_tree.h"
 
 #include "_cgo_export.h"
 #include "merkle_tree_go.h"


### PR DESCRIPTION
Make sure any header that has a corresponding .cc file includes that header
first, to validate that it can stand by itself (as per the style guide). Also
do some simple reformatting (mainly sorting "using" statements, or moving
them to the location prescribed by the style guide).
