### PR TITLE
Have the makefile include local.mk if it exists.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 # More specific files.
 /cpp/client/ct
 /cpp/gtest/
+/cpp/local.mk
 /cpp/log/cert_checker_test
 /cpp/log/cert_submission_handler_test
 /cpp/log/cert_test

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -1,3 +1,10 @@
+
+# Make sure this is always first.
+.PHONY: default
+default: all
+
+-include local.mk
+
 CXXFLAG = -Wall -Werror -g -O3
 
 INCLUDE = -I.


### PR DESCRIPTION
This is to allow setting local variables (such as `OPENSSLDIR` or `CURLDIR`) in a persistent way.
