### PR TITLE
Refer to the json-c library as per their examples.

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -52,7 +52,9 @@ ifneq ($(JSONCLIBDIR),)
 	INCLUDE += -I $(JSONCLIBDIR)/include
 	LDLIBS += -L $(JSONCLIBDIR)/lib -Wl,-rpath,$(JSONCLIBDIR)/lib -ljson-c
 else
-	LDLIBS += -ljson
+	# TODO(pphaneuf): json-c would like us to use pkg-config...
+	INCLUDE += -I/usr/include/json-c
+	LDLIBS += -ljson-c
 endif
 
 # Need gtest

--- a/cpp/util/json_wrapper.h
+++ b/cpp/util/json_wrapper.h
@@ -1,10 +1,9 @@
 /* -*- mode: c++; indent-tabs-mode: nil -*- */
-
 #ifndef JSON_WRAPPER_H
 #define JSON_WRAPPER_H
 
 #include <glog/logging.h>
-#include <json/json.h>
+#include <json.h>
 #undef TRUE  // json.h pollution
 #undef FALSE  // json.h pollution
 


### PR DESCRIPTION
Not using -I makes more sense to me, but it appears that some distributions
put the headers in different locations, and all the example code refers only
to json.h, so we'll follow suit...

Also link against the correct library.
