### PR TITLE
Fix two cases of using the wrong delete.

### DIFF
--- a/cpp/client/ct.cc
+++ b/cpp/client/ct.cc
@@ -181,7 +181,7 @@ static void AddOctetExtension(X509 *cert, int nid, const unsigned char *data,
 
   ASN1_OCTET_STRING_free(inner);
   ASN1_OCTET_STRING_free(asn1_data);
-  delete buf;
+  delete[] buf;
 }
 
 static bool CheckSCT(const SignedCertificateTimestamp &sct,

--- a/cpp/server/blob-server.cc
+++ b/cpp/server/blob-server.cc
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
   CHECK(blobf.eof());
 
   std::string blob(buffer, length);
-  delete buffer;
+  delete[] buffer;
 
   LoggedBlob logged_blob(blob);
 


### PR DESCRIPTION
The only real positives found with Clang's static analyzer! All the others were false positives where CHECK or LOG(FATAL) was involved, but they are not annotated to indicate that they do not return.

Pretty nice!
