### PR TITLE
Fix a make error when there is no *.pyc files.

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -30,4 +30,4 @@ test: all
 
 clean:
 	cd ct/proto && rm -f *_pb2.py *.pb.cc *.pb.h
-	find . -name '*.pyc' | xargs rm
+	find . -name '*.pyc' | xargs -r rm


### PR DESCRIPTION
When there is no *.pyc to delete, GNU xargs will still run the command once
with no arguments, which causes an error, stopping make. The -r flag prevents
this.
