### PR TITLE
Move ReadPrivateKey to a separate file.

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -303,15 +303,17 @@ client/ct: client/ct.o client/client.o client/log_client.o client/ssl_client.o \
            $(LOCAL_LIBS)
 
 # server
-server/ct-server: server/ct-server.o server/event.o $(LOCAL_LIBS)
+server/ct-server: server/ct-server.o server/event.o util/read_private_key.o \
+	$(LOCAL_LIBS)
 
 server/ct-dns-server: server/ct-dns-server.o server/event.o $(LOCAL_LIBS)
 
-server/ct-rfc-server: server/ct-rfc-server.o server/event.o $(LOCAL_LIBS)
+server/ct-rfc-server: server/ct-rfc-server.o util/read_private_key.o \
+	$(LOCAL_LIBS)
 
 server/blob-server: server/blob-server.o server/event.o \
                     server/sqlite_db_blob.o server/tree_signer_blob.o \
-                    server/log_lookup_blob.o \
+                    server/log_lookup_blob.o util/read_private_key.o \
                     $(LOCAL_LIBS)
 
 dns_tests: server/ct-dns-server

--- a/cpp/server/blob-server.cc
+++ b/cpp/server/blob-server.cc
@@ -12,10 +12,12 @@
 #include "log/tree_signer.h"
 #include "server/event.h"
 #include "server/logged_blob.h"
+#include "util/read_private_key.h"
 
 // TODO(benl): Make this client/server, make a configurable server
 // (and client?) pipeline which this shares with ct-server.
 
+using cert_trans::util::ReadPrivateKey;
 using google::RegisterFlagValidator;
 using std::string;
 
@@ -56,7 +58,7 @@ static TreeSigner<LoggedBlob> *GetTreeSigner(Database<LoggedBlob> *db) {
 
   if (tree_signer == NULL) {
     EVP_PKEY *pkey = NULL;
-    CHECK_EQ(Services::ReadPrivateKey(&pkey, FLAGS_key), Services::KEY_OK);
+    CHECK_EQ(ReadPrivateKey(&pkey, FLAGS_key), cert_trans::util::KEY_OK);
     tree_signer = new TreeSigner<LoggedBlob>(db, new LogSigner(pkey));
   }
 

--- a/cpp/server/ct-rfc-server.cc
+++ b/cpp/server/ct-rfc-server.cc
@@ -25,9 +25,9 @@
 #include "log/sqlite_db.h"
 #include "log/tree_signer.h"
 #include "proto/ct.pb.h"
-#include "server/event.h"
 #include "util/json_wrapper.h"
 #include "util/openssl_util.h"
+#include "util/read_private_key.h"
 
 DEFINE_string(server, "localhost", "Server host");
 DEFINE_string(port, "9999", "Server port");
@@ -59,6 +59,7 @@ DEFINE_int32(tree_signing_frequency_seconds, 600,
 namespace http = boost::network::http;
 namespace uri = boost::network::uri;
 
+using cert_trans::util::ReadPrivateKey;
 using ct::Cert;
 using ct::CertChain;
 using ct::CertChecker;
@@ -621,7 +622,7 @@ int main(int argc, char * argv[]) {
   ct::LoadCtExtensions();
 
   EVP_PKEY *pkey = NULL;
-  CHECK_EQ(Services::ReadPrivateKey(&pkey, FLAGS_key), Services::KEY_OK);
+  CHECK_EQ(ReadPrivateKey(&pkey, FLAGS_key), cert_trans::util::KEY_OK);
 
   CertChecker checker;
   CHECK(checker.LoadTrustedCertificates(FLAGS_trusted_cert_file))
@@ -647,7 +648,7 @@ int main(int argc, char * argv[]) {
 
   // Hmm, there is no EVP_PKEY_dup, so let's read the key again...
   EVP_PKEY *pkey2 = NULL;
-  CHECK_EQ(Services::ReadPrivateKey(&pkey2, FLAGS_key), Services::KEY_OK);
+  CHECK_EQ(ReadPrivateKey(&pkey2, FLAGS_key), cert_trans::util::KEY_OK);
 
   CTLogManager manager(
       new Frontend(new CertSubmissionHandler(&checker),

--- a/cpp/server/ct-server.cc
+++ b/cpp/server/ct-server.cc
@@ -33,6 +33,7 @@
 #include "proto/ct.pb.h"
 #include "proto/serializer.h"
 #include "server/event.h"
+#include "util/read_private_key.h"
 #include "util/util.h"  // FIXME: debug
 
 DEFINE_int32(port, 0, "Server port");
@@ -61,11 +62,11 @@ DEFINE_int32(tree_signing_frequency_seconds, 600,
              "last signing. Set this well below the MMD to ensure we sign "
              "in a timely manner. Must be greater than 0.");
 
+using cert_trans::util::ReadPrivateKey;
+using ct::CertChecker;
 using ct::LoggedCertificate;
 using google::RegisterFlagValidator;
 using std::string;
-
-using ct::CertChecker;
 
 // Basic sanity checks on flag values.
 static bool ValidatePort(const char *flagname, int port) {
@@ -477,7 +478,7 @@ int main(int argc, char **argv) {
   ct::LoadCtExtensions();
 
   EVP_PKEY *pkey = NULL;
-  CHECK_EQ(Services::ReadPrivateKey(&pkey, FLAGS_key), Services::KEY_OK);
+  CHECK_EQ(ReadPrivateKey(&pkey, FLAGS_key), cert_trans::util::KEY_OK);
 
   int fd;
   CHECK(Services::InitServer(&fd, FLAGS_port, NULL, SOCK_STREAM));
@@ -508,7 +509,7 @@ int main(int argc, char **argv) {
 
   // Hmm, there is no EVP_PKEY_dup, so let's read the key again...
   EVP_PKEY *pkey2 = NULL;
-  CHECK_EQ(Services::ReadPrivateKey(&pkey2, FLAGS_key), Services::KEY_OK);
+  CHECK_EQ(ReadPrivateKey(&pkey2, FLAGS_key), cert_trans::util::KEY_OK);
 
   CTLogManager manager(
       new Frontend(new CertSubmissionHandler(&checker),

--- a/cpp/server/event.cc
+++ b/cpp/server/event.cc
@@ -282,21 +282,3 @@ err:
   }
   return ret;
 }
-
-Services::KeyError Services::ReadPrivateKey(EVP_PKEY **pkey,
-                                            const std::string &file) {
-  FILE *fp = fopen(file.c_str(), "r");
-
-  if(fp == static_cast<FILE*>(NULL))
-    return NO_SUCH_FILE;
-
-  // No password.
-  PEM_read_PrivateKey(fp, pkey, NULL, NULL);
-  Services::KeyError retval(KEY_OK);
-  if (*pkey == static_cast<EVP_PKEY*>(NULL))
-    retval = INVALID_KEY;
-
-  fclose(fp);
-
-  return retval;
-}

--- a/cpp/server/event.h
+++ b/cpp/server/event.h
@@ -2,7 +2,6 @@
 
 #include <deque>
 #include <glog/logging.h>
-#include <openssl/evp.h>
 #include <netinet/in.h>
 #include <string>
 #include <sys/socket.h>
@@ -10,9 +9,7 @@
 #include <time.h>
 
 class Services {
- 
  public:
-
   // because time is expensive, for most tasks we can just use some
   // time sampled within this event handling loop. So, the main loop
   // needs to call SetRoughTime() appropriately.
@@ -25,14 +22,6 @@ class Services {
   static void SetRoughTime() { rough_time_ = 0; }
 
   static bool InitServer(int *sock, int port, const char *ip, int type);
-
-  enum KeyError {
-    KEY_OK,
-    NO_SUCH_FILE,
-    INVALID_KEY,
-  };
-
-  static KeyError ReadPrivateKey(EVP_PKEY **pkey, const std::string &file);
 
  private:
 

--- a/cpp/util/read_private_key.cc
+++ b/cpp/util/read_private_key.cc
@@ -1,0 +1,28 @@
+#include "util/read_private_key.h"
+
+#include <openssl/pem.h>
+
+namespace cert_trans {
+namespace util {
+
+
+KeyError ReadPrivateKey(EVP_PKEY **pkey, const std::string &file) {
+  FILE *fp = fopen(file.c_str(), "r");
+
+  if (!fp)
+    return NO_SUCH_FILE;
+
+  // No password.
+  PEM_read_PrivateKey(fp, pkey, NULL, NULL);
+  KeyError retval(KEY_OK);
+  if (!*pkey)
+    retval = INVALID_KEY;
+
+  fclose(fp);
+
+  return retval;
+}
+
+
+}  // namespace util
+}  // namespace cert_trans

--- a/cpp/util/read_private_key.h
+++ b/cpp/util/read_private_key.h
@@ -1,0 +1,23 @@
+#ifndef CERT_TRANS_UTIL_READ_PRIVATE_KEY_H_
+#define CERT_TRANS_UTIL_READ_PRIVATE_KEY_H_
+
+#include <openssl/evp.h>
+#include <string>
+
+namespace cert_trans {
+namespace util {
+
+
+enum KeyError {
+  KEY_OK,
+  NO_SUCH_FILE,
+  INVALID_KEY,
+};
+
+KeyError ReadPrivateKey(EVP_PKEY **pkey, const std::string &file);
+
+
+}  // namespace util
+}  // namespace cert_trans
+
+#endif  // CERT_TRANS_UTIL_READ_PRIVATE_KEY_H_


### PR DESCRIPTION
`ct-rfc-server` does not need anything else from `event.h`.
