### PR TITLE
Remove an unused variable and function.

### DIFF
--- a/cpp/log/signer_verifier_test.cc
+++ b/cpp/log/signer_verifier_test.cc
@@ -19,11 +19,6 @@ namespace {
 
 const char kTestString[] = "abc";
 
-// A slightly shorter notation for constructing hex strings from binary blobs.
-string H(const string &byte_string) {
-  return util::HexString(byte_string);
-}
-
 class SignerVerifierTest : public ::testing::Test {
  protected:
   SignerVerifierTest() : signer_(NULL),

--- a/cpp/log/test_signer.cc
+++ b/cpp/log/test_signer.cc
@@ -105,9 +105,6 @@ const char kDefaultDerTbsCert[] =
     "41310e300c0603550408130557616c65733110300e060355040713074572772057656e8201"
     "0030090603551d1304023000";
 
-const char kDefaultDerCertHash[] =
-    "50335d9cd3649871d0c95397648bf7814c297b3bad7020b2c13d2b0aef6e3b49";
-
 // Some time in September 2012.
 const uint64_t kDefaultSCTTimestamp = 1348589665525LL;
 


### PR DESCRIPTION
Found while building with Clang, not sure why I didn't hit this before?
