### PR TITLE
Always use the HTTP protocol for testing.

### DIFF
--- a/test/run_apache_server.sh
+++ b/test/run_apache_server.sh
@@ -4,8 +4,6 @@ HTTPD_DIR=$1
 OPENSSL_DIR=$2
 SERVER=${2:-"127.0.0.1:8888"}
 
-HTTP_LOG=--http_log
-
 . generate_certs.sh
 
 ../cpp/client/ct extension_data --sct_token=testdata/test-cert.proof \

--- a/test/run_openssl_server.sh
+++ b/test/run_openssl_server.sh
@@ -4,8 +4,6 @@ CERT_DIR=$1
 CT_KEY=$2
 SERVER=${3:-"127.0.0.1:8888"}
 
-HTTP_LOG=--http_log
-
 . generate_certs.sh
 
 if [ ! -e $CERT_DIR/ca-database ]
@@ -14,8 +12,7 @@ then
   ca_setup $CERT_DIR ca false
 fi
 
-# FIXME: should be able to specify "" for port (arg 5, currently == 1)
-make_cert $CERT_DIR test ca $SERVER 1 false $CT_KEY
+make_cert $CERT_DIR test ca $SERVER false $CT_KEY
 
 ../cpp/client/ct extension_data --sct_token=$CERT_DIR/test-cert.proof \
     --tls_extension_data_out=/tmp/xx.pem

--- a/test/sslconnect_test.sh
+++ b/test/sslconnect_test.sh
@@ -60,7 +60,7 @@ audit() {
   port=$3
 
   set +e
-  ../cpp/client/ct audit --ct_server="127.0.0.1" --ct_server_port=8124 \
+  ../cpp/client/ct audit --ct_server="127.0.0.1:8124" --http_log \
     --ct_server_public_key=$cert_dir/$log_server-key-public.pem \
     --ssl_client_ct_data_in=$cert_dir/$port.sct --logtostderr=true
   local retcode=$?
@@ -147,7 +147,8 @@ test_ct_server() {
 
   # Set the tree signing frequency to 0 to ensure we sign as often as possible.
   echo "Starting CT server with trusted certs in $ca_file"
-  ../cpp/server/ct-server --port=8124 --key="$cert_dir/$log_server-key.pem" \
+  ../cpp/server/ct-rfc-server --port=8124 \
+    --key="$cert_dir/$log_server-key.pem" \
     --trusted_cert_file="$ca_file" --logtostderr=true \
     --tree_signing_frequency_seconds=1 $flags &
 
@@ -155,23 +156,23 @@ test_ct_server() {
   sleep 2
 
   echo "Generating test certificates"
-  make_cert `pwd`/tmp test ca 127.0.0.1 8124 false \
+  make_cert `pwd`/tmp test ca 127.0.0.1:8124 false \
     `pwd`/tmp/ct-server-key-public.pem
   make_embedded_cert `pwd`/tmp test-embedded ca \
-    127.0.0.1 8124 false false `pwd`/tmp/ct-server-key-public.pem
+    127.0.0.1:8124 false false `pwd`/tmp/ct-server-key-public.pem
   make_embedded_cert `pwd`/tmp test-embedded-with-preca \
-    ca 127.0.0.1 8124 false true `pwd`/tmp/ct-server-key-public.pem
+    ca 127.0.0.1:8124 false true `pwd`/tmp/ct-server-key-public.pem
   # Generate a second set of certs that chain through an intermediate
   make_intermediate_ca_certs `pwd`/tmp intermediate ca
 
   make_cert `pwd`/tmp test-intermediate intermediate \
-    127.0.0.1 8124 true `pwd`/tmp/ct-server-key-public.pem
+    127.0.0.1:8124 true `pwd`/tmp/ct-server-key-public.pem
   make_embedded_cert `pwd`/tmp \
-    test-embedded-with-intermediate intermediate 127.0.0.1 8124 true \
-      false `pwd`/tmp/ct-server-key-public.pem
+    test-embedded-with-intermediate intermediate 127.0.0.1:8124 \
+    true false `pwd`/tmp/ct-server-key-public.pem
   make_embedded_cert `pwd`/tmp \
-    test-embedded-with-intermediate-preca intermediate 127.0.0.1 \
-      8124 true true `pwd`/tmp/ct-server-key-public.pem
+    test-embedded-with-intermediate-preca intermediate 127.0.0.1:8124 \
+    true true `pwd`/tmp/ct-server-key-public.pem
 
   # Wait a bit to ensure the server signs the tree.
   sleep 5

--- a/test/test_running_server.sh
+++ b/test/test_running_server.sh
@@ -17,11 +17,7 @@ fi
 
 CERT_DIR=$1
 CT_KEY=$2
-SERVER=${3:-"127.0.0.1"}
-# Note: not actually used for HTTP logs...
-PORT=${4:-8124}
-
-HTTP_LOG=--http_log
+SERVER=${3:-"127.0.0.1:8124"}
 
 echo $SERVER
 
@@ -40,9 +36,9 @@ audit() {
   sct=$3
 
   set +e
-  ../cpp/client/ct audit --ct_server="$SERVER" --ct_server_port=$PORT \
+  ../cpp/client/ct audit --ct_server="$SERVER" --http_log \
     --ct_server_public_key=$CT_KEY \
-    --ssl_client_ct_data_in=$sct --logtostderr=true $HTTP_LOG
+    --ssl_client_ct_data_in=$sct --logtostderr=true
   retcode=$?
   set -e
 }
@@ -74,8 +70,8 @@ do_audit() {
 get_sth() {
   local file=$1
 
-  ../cpp/client/ct sth --ct_server="$SERVER" --ct_server_port=$PORT \
-    --ct_server_public_key=$CT_KEY --logtostderr=true $HTTP_LOG \
+  ../cpp/client/ct sth --ct_server="$SERVER" --http_log \
+    --ct_server_public_key=$CT_KEY --logtostderr=true \
     --ct_server_response_out=$file
 }
 
@@ -83,8 +79,8 @@ consistency() {
   local file1=$1
   local file2=$2
 
-  ../cpp/client/ct consistency --ct_server="$SERVER" --ct_server_port=$PORT \
-    --ct_server_public_key=$CT_KEY --logtostderr=true $HTTP_LOG \
+  ../cpp/client/ct consistency --ct_server="$SERVER" --http_log \
+    --ct_server_public_key=$CT_KEY --logtostderr=true \
     --sth1=$file1 --sth2=$file2
 }
 
@@ -92,16 +88,15 @@ get_entries() {
   local first=$1
   local last=$2
 
-  ../cpp/client/ct get_entries --ct_server="$SERVER" --ct_server_port=$PORT \
-    --ct_server_public_key=$CT_KEY --logtostderr=true $HTTP_LOG \
+  ../cpp/client/ct get_entries --ct_server="$SERVER" --http_log \
+    --ct_server_public_key=$CT_KEY --logtostderr=true \
       --get_first=$first --get_last=$last --certificate_base=$CERT_DIR/cert.
 }
 
 get_sth $CERT_DIR/sth1
 
-make_cert $CERT_DIR test ca $SERVER $PORT false $CT_KEY
-make_embedded_cert $CERT_DIR test-embedded ca $SERVER $PORT false \
-    false $CT_KEY
+make_cert $CERT_DIR test ca $SERVER false $CT_KEY
+make_embedded_cert $CERT_DIR test-embedded ca $SERVER false false $CT_KEY
 
 # Do the audits together, quicker that way.
 # test-*-cert.ctdata is made by make_cert.


### PR DESCRIPTION
In preparation for eradicating the non-HTTP server.
