### PR TITLE
Add and use a DISALLOW_COPY_AND_ASSIGN macro.

### DIFF
--- a/cpp/base/macros.h
+++ b/cpp/base/macros.h
@@ -1,0 +1,12 @@
+#ifndef CERT_TRANS_BASE_MACROS_H_
+#define CERT_TRANS_BASE_MACROS_H_
+
+
+// A macro to disallow the copy constructor and operator= functions
+// This should be used in the private: declarations for a class
+#define DISALLOW_COPY_AND_ASSIGN(TypeName) \
+  TypeName(const TypeName&);               \
+  void operator=(const TypeName&)
+
+
+#endif  // CERT_TRANS_BASE_MACROS_H_

--- a/cpp/client/client.h
+++ b/cpp/client/client.h
@@ -4,6 +4,8 @@
 #include <stdint.h>
 #include <string>
 
+#include "base/macros.h"
+
 // Socket creation for client connections.
 class Client {
 public:
@@ -32,5 +34,7 @@ public:
   const std::string server_;
   const uint16_t port_;
   int fd_;
+
+  DISALLOW_COPY_AND_ASSIGN(Client);
 };
 #endif

--- a/cpp/client/ssl_client.h
+++ b/cpp/client/ssl_client.h
@@ -9,6 +9,7 @@
 #include "client/ssl_client.h"
 #include "log/log_verifier.h"
 #include "proto/ct.pb.h"
+#include "base/macros.h"
 
 class LogVerifier;
 
@@ -98,5 +99,7 @@ class SSLClient {
   void ResetVerifyCallbackArgs(bool strict);
 
   HandshakeResult SSLConnect(bool strict);
+
+  DISALLOW_COPY_AND_ASSIGN(SSLClient);
 };
 #endif

--- a/cpp/log/cert.h
+++ b/cpp/log/cert.h
@@ -7,6 +7,8 @@
 #include <string>
 #include <vector>
 
+#include "base/macros.h"
+
 namespace ct {
 
 class Cert {
@@ -185,6 +187,8 @@ class Cert {
   static std::string PrintTime(ASN1_TIME* when);
   static Status DerEncodedName(X509_NAME *name, std::string *result);
   X509 *x509_;
+
+  DISALLOW_COPY_AND_ASSIGN(Cert);
 };
 
 // A wrapper around X509_CINF for chopping at the TBS to CT-sign it or verify
@@ -227,6 +231,8 @@ class TbsCertificate {
   bool ExtensionsLoaded() const { return cert_info_->extensions != NULL; }
   Cert::Status ExtensionIndex(int extension_nid, int *extension_index) const;
   X509_CINF *cert_info_;
+
+  DISALLOW_COPY_AND_ASSIGN(TbsCertificate);
 };
 
 class CertChain {
@@ -297,6 +303,8 @@ class CertChain {
  private:
   void ClearChain();
   std::vector<Cert*> chain_;
+
+  DISALLOW_COPY_AND_ASSIGN(CertChain);
 };
 
 // Note: CT extensions must be loaded to use this class. See

--- a/cpp/log/cert_checker.h
+++ b/cpp/log/cert_checker.h
@@ -7,6 +7,7 @@
 #include <map>
 #include <string>
 
+#include "base/macros.h"
 #include "log/cert.h"
 
 namespace ct {
@@ -96,6 +97,8 @@ class CertChecker {
   // All code manipulating this container must ensure contained elements are
   // deallocated appropriately.
   std::multimap<std::string, const Cert *> trusted_;
+
+  DISALLOW_COPY_AND_ASSIGN(CertChecker);
 };
 
 }  // namespace ct

--- a/cpp/log/cert_submission_handler.h
+++ b/cpp/log/cert_submission_handler.h
@@ -3,6 +3,7 @@
 
 #include <string>
 
+#include "base/macros.h"
 #include "log/cert_checker.h"
 #include "proto/ct.pb.h"
 #include "proto/serializer.h"
@@ -64,5 +65,7 @@ class CertSubmissionHandler {
   static SubmitResult GetFormatError(Serializer::SerializeResult result);
 
   static SubmitResult GetVerifyError(ct::CertChecker::CertVerifyResult result);
+
+  DISALLOW_COPY_AND_ASSIGN(CertSubmissionHandler);
 };
 #endif

--- a/cpp/log/database.h
+++ b/cpp/log/database.h
@@ -6,6 +6,7 @@
 #include <glog/logging.h>
 #include <set>
 
+#include "base/macros.h"
 #include "proto/ct.pb.h"
 
 // The |Logged| class needs to provide this interface:
@@ -135,6 +136,12 @@ template <class Logged> class Database {
 
   // Return the tree head with the freshest timestamp.
   virtual LookupResult LatestTreeHead(ct::SignedTreeHead *result) const = 0;
+
+ protected:
+  Database() {}
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(Database);
 };
 
 #endif  // ndef DATABASE_H

--- a/cpp/log/file_db.h
+++ b/cpp/log/file_db.h
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <vector>
 
+#include "base/macros.h"
 #include "log/database.h"
 #include "proto/ct.pb.h"
 
@@ -68,5 +69,7 @@ template <class Logged> class FileDB : public Database<Logged> {
   uint64_t latest_tree_timestamp_;
   // The same as a string;
   std::string latest_timestamp_key_;
+
+  DISALLOW_COPY_AND_ASSIGN(FileDB);
 };
 #endif

--- a/cpp/log/file_storage.h
+++ b/cpp/log/file_storage.h
@@ -5,6 +5,8 @@
 #include <stdint.h>
 #include <string>
 
+#include "base/macros.h"
+
 class FilesystemOp;
 
 // A simple filesystem-based database for (key, data) entries,
@@ -88,5 +90,7 @@ class FileStorage {
   const std::string tmp_file_template_;
   unsigned int storage_depth_;
   FilesystemOp *file_op_;
+
+  DISALLOW_COPY_AND_ASSIGN(FileStorage);
 };
 #endif

--- a/cpp/log/filesystem_op.h
+++ b/cpp/log/filesystem_op.h
@@ -3,6 +3,8 @@
 
 #include <sys/types.h>
 
+#include "base/macros.h"
+
 // Make filesystem operations virtual so that we can override
 // to simulate filesystem errors.
 class FilesystemOp {
@@ -16,6 +18,12 @@ class FilesystemOp {
   virtual int rename(const char *old_name, const char *new_name) = 0;
 
   virtual int access(const char *path, int amode) = 0;
+
+ protected:
+  FilesystemOp() {}
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(FilesystemOp);
 };
 
 class BasicFilesystemOp : public FilesystemOp {

--- a/cpp/log/frontend.h
+++ b/cpp/log/frontend.h
@@ -2,6 +2,7 @@
 #ifndef FRONTEND_H
 #define FRONTEND_H
 
+#include "base/macros.h"
 #include "log/cert_submission_handler.h"
 #include "log/submit_result.h"
 #include "proto/ct.pb.h"
@@ -101,5 +102,7 @@ class Frontend {
   void UpdateStats(ct::LogEntryType type, SubmitResult result);
   void UpdateX509Stats(SubmitResult result);
   void UpdatePrecertStats(SubmitResult result);
+
+  DISALLOW_COPY_AND_ASSIGN(Frontend);
 };
 #endif

--- a/cpp/log/frontend_signer.h
+++ b/cpp/log/frontend_signer.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <string>
 
+#include "base/macros.h"
 #include "log/logged_certificate.h"
 
 template <class Logged> class Database;
@@ -34,5 +35,7 @@ class FrontendSigner {
 
   void TimestampAndSign(const ct::LogEntry &entry,
                         ct::SignedCertificateTimestamp *sct) const;
+
+  DISALLOW_COPY_AND_ASSIGN(FrontendSigner);
 };
 #endif

--- a/cpp/log/log_lookup.h
+++ b/cpp/log/log_lookup.h
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <string>
 
+#include "base/macros.h"
 #include "merkletree/merkle_tree.h"
 #include "proto/ct.pb.h"
 
@@ -77,5 +78,7 @@ template <class Logged> class LogLookup {
   const Database<Logged> *db_;
   MerkleTree cert_tree_;
   ct::SignedTreeHead latest_tree_head_;
+
+  DISALLOW_COPY_AND_ASSIGN(LogLookup);
 };
 #endif

--- a/cpp/log/log_verifier.h
+++ b/cpp/log/log_verifier.h
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 
+#include "base/macros.h"
 #include "log/log_signer.h"
 #include "proto/ct.pb.h"
 
@@ -108,5 +109,7 @@ class LogVerifier {
   MerkleVerifier *merkle_verifier_;
 
   static bool IsBetween(uint64_t timestamp, uint64_t earliest, uint64_t latest);
+
+  DISALLOW_COPY_AND_ASSIGN(LogVerifier);
 };
 #endif

--- a/cpp/log/signer.h
+++ b/cpp/log/signer.h
@@ -7,6 +7,7 @@
 #include <openssl/x509.h>  // for i2d_PUBKEY
 #include <stdint.h>
 
+#include "base/macros.h"
 #include "proto/ct.pb.h"
 
 namespace ct {
@@ -31,6 +32,8 @@ class Signer {
   DigitallySigned::HashAlgorithm hash_algo_;
   DigitallySigned::SignatureAlgorithm sig_algo_;
   std::string key_id_;
+
+  DISALLOW_COPY_AND_ASSIGN(Signer);
 };
 
 }  // namespace ct

--- a/cpp/log/sqlite_db.h
+++ b/cpp/log/sqlite_db.h
@@ -4,6 +4,7 @@
 #define SQLITE_DB_H
 #include <string>
 
+#include "base/macros.h"
 #include "log/database.h"
 
 struct sqlite3;
@@ -47,6 +48,8 @@ template <class Logged> class SQLiteDB : public Database<Logged> {
 
  private:
   sqlite3 *db_;
+
+  DISALLOW_COPY_AND_ASSIGN(SQLiteDB);
 };
 
 #endif

--- a/cpp/log/sqlite_statement.h
+++ b/cpp/log/sqlite_statement.h
@@ -7,6 +7,8 @@
 #include <sqlite3.h>
 #include <string>
 
+#include "base/macros.h"
+
 namespace sqlite {
 
 // Reduce the ugliness of the sqlite3 API.
@@ -60,6 +62,8 @@ class Statement {
 
  private:
   sqlite3_stmt *stmt_;
+
+  DISALLOW_COPY_AND_ASSIGN(Statement);
 };
 
 } // namespace sqlite

--- a/cpp/log/verifier.h
+++ b/cpp/log/verifier.h
@@ -8,6 +8,7 @@
 #include <openssl/x509.h>  // for i2d_PUBKEY
 #include <stdint.h>
 
+#include "base/macros.h"
 #include "proto/ct.pb.h"
 
 namespace ct {
@@ -42,6 +43,8 @@ class Verifier {
   DigitallySigned::HashAlgorithm hash_algo_;
   DigitallySigned::SignatureAlgorithm sig_algo_;
   std::string key_id_;
+
+  DISALLOW_COPY_AND_ASSIGN(Verifier);
 };
 
 }  // namespace ct

--- a/cpp/merkletree/merkle_tree_interface.h
+++ b/cpp/merkletree/merkle_tree_interface.h
@@ -7,6 +7,8 @@
 #include <stddef.h>
 #include <string>
 
+#include "base/macros.h"
+
 namespace ct {
 
 // An interface for Merkle trees.  See specializations in
@@ -54,6 +56,9 @@ class MerkleTreeInterface {
   // Returns the hash of an empty string if the tree has no leaves
   // (and hence, no root).
   virtual std::string CurrentRoot() = 0;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(MerkleTreeInterface);
 };
 
 }  // namespace ct

--- a/cpp/merkletree/serial_hasher.h
+++ b/cpp/merkletree/serial_hasher.h
@@ -5,6 +5,8 @@
 #include <stddef.h>
 #include <string>
 
+#include "base/macros.h"
+
 class SerialHasher {
  public:
   SerialHasher() {}
@@ -24,6 +26,9 @@ class SerialHasher {
 
   // A virtual constructor.  The caller gets ownership of the returned object.
   virtual SerialHasher* Create() const = 0;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(SerialHasher);
 };
 
 class Sha256Hasher : public SerialHasher {
@@ -45,5 +50,7 @@ class Sha256Hasher : public SerialHasher {
   SHA256_CTX ctx_;
   bool initialized_;
   static const size_t kDigestSize;
+
+  DISALLOW_COPY_AND_ASSIGN(Sha256Hasher);
 };
 #endif

--- a/cpp/merkletree/tree_hasher.h
+++ b/cpp/merkletree/tree_hasher.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 
+#include "base/macros.h"
 #include "merkletree/serial_hasher.h"
 
 class TreeHasher {
@@ -29,5 +30,7 @@ class TreeHasher {
   static const std::string kNodePrefix;
   // The dummy hash of an empty tree.
   std::string emptyhash_;
+
+  DISALLOW_COPY_AND_ASSIGN(TreeHasher);
 };
 #endif

--- a/cpp/monitor/database.h
+++ b/cpp/monitor/database.h
@@ -4,6 +4,7 @@
 #include <glog/logging.h>
 #include <stdint.h>
 
+#include "base/macros.h"
 #include "log/logged_certificate.h"
 
 namespace monitor {
@@ -32,6 +33,7 @@ class Database {
     UNDEFINED, // Let this be last.
   };
 
+  Database() {}
   virtual ~Database() {}
 
   virtual void BeginTransaction() {
@@ -100,6 +102,8 @@ class Database {
 
   virtual WriteResult SetVerificationLevel_(const ct::SignedTreeHead &sth,
                                             VerificationLevel verify_level) = 0;
+
+  DISALLOW_COPY_AND_ASSIGN(Database);
 };
 
 } // namespace monitor

--- a/cpp/monitor/monitor.h
+++ b/cpp/monitor/monitor.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <string>
 
+#include "base/macros.h"
 #include "client/http_log_client.h"
 #include "monitor/sqlite_db.h"
 
@@ -76,6 +77,8 @@ class Monitor
                              const ct::SignedTreeHead &new_sth);
 
   VerifyResult VerifySTHWithInvalidTimestamp(const ct::SignedTreeHead &sth);
+
+  DISALLOW_COPY_AND_ASSIGN(Monitor);
 };
 
 } // namespace monitor

--- a/cpp/monitor/sqlite_db.h
+++ b/cpp/monitor/sqlite_db.h
@@ -1,10 +1,11 @@
 #ifndef MONITOR_SQLITE_DB_H
 #define MONITOR_SQLITE_DB_H
 
-#include "monitor/database.h"
-
 #include <stdint.h>
 #include <string>
+
+#include "base/macros.h"
+#include "monitor/database.h"
 
 struct sqlite3;
 
@@ -48,6 +49,8 @@ class SQLiteDB : public Database {
                                             VerificationLevel verify_level);
 
   sqlite3 *db_;
+
+  DISALLOW_COPY_AND_ASSIGN(SQLiteDB);
 };
 
 } // namespace monitor

--- a/cpp/proto/serializer.h
+++ b/cpp/proto/serializer.h
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <string>
 
+#include "base/macros.h"
 #include "proto/ct.pb.h"
 
 // A utility class for writing protocol buffer fields in canonical TLS style.
@@ -302,5 +303,7 @@ class Deserializer {
 
   const char *current_pos_;
   size_t bytes_remaining_;
+
+  DISALLOW_COPY_AND_ASSIGN(Deserializer);
 };
 #endif

--- a/cpp/server/ct-server.cc
+++ b/cpp/server/ct-server.cc
@@ -12,6 +12,7 @@
 #include <openssl/x509.h>
 #include <string>
 
+#include "base/macros.h"
 #include "log/cert.h"
 #include "log/cert_checker.h"
 #include "log/ct_extensions.h"
@@ -306,6 +307,8 @@ class CTLogManager {
   Frontend *frontend_;
   TreeSigner<LoggedCertificate> *signer_;
   LogLookup<LoggedCertificate> *lookup_;
+
+  DISALLOW_COPY_AND_ASSIGN(CTLogManager);
 };
 
 class TreeSigningEvent : public AsioRepeatedEvent {

--- a/cpp/server/event.h
+++ b/cpp/server/event.h
@@ -10,6 +10,8 @@
 #include <sys/types.h>
 #include <time.h>
 
+#include "base/macros.h"
+
 class Services {
  public:
   // because time is expensive, for most tasks we can just use some
@@ -86,6 +88,8 @@ class FD {
   // also.
   static const int kFDLimit = 1000;
   static const int kFDLimitWindow = 1;
+
+  DISALLOW_COPY_AND_ASSIGN(FD);
 };
 
 class Listener : public FD {
@@ -123,8 +127,8 @@ class RepeatedEvent {
     last_activity_ = Services::RoughTime();
   }
  private:
- time_t frequency_;
- time_t last_activity_;
+  time_t frequency_;
+  time_t last_activity_;
 };
 
 class EventLoop {
@@ -161,6 +165,8 @@ class EventLoop {
   static const time_t kIdleTime = 20;
 
   bool go_;
+
+  DISALLOW_COPY_AND_ASSIGN(EventLoop);
 };
 
 class Server : public FD {

--- a/cpp/util/json_wrapper.h
+++ b/cpp/util/json_wrapper.h
@@ -9,6 +9,7 @@
 
 #include <sstream>
 
+#include "base/macros.h"
 #include "proto/serializer.h"
 #include "util/util.h"
 
@@ -112,6 +113,7 @@ class JsonObject {
     json_object_object_add(obj_, name, obj);
   }
 
+  DISALLOW_COPY_AND_ASSIGN(JsonObject);
 };
 
 class JsonBoolean : public JsonObject {

--- a/cpp/util/test_db.h
+++ b/cpp/util/test_db.h
@@ -5,6 +5,7 @@
 #include <glog/logging.h>
 #include <stdlib.h>
 
+#include "base/macros.h"
 #include "util/util.h"
 
 DEFINE_string(database_test_dir, "/tmp",
@@ -63,6 +64,8 @@ class TestDB {
  private:
   TmpStorage tmp_;
   T *db_;
+
+  DISALLOW_COPY_AND_ASSIGN(TestDB);
 };
 
 #endif // UTIL_TEST_DB_H


### PR DESCRIPTION
Macro taken from the Google C++ style guide. Used on interfaces and classes
with pointers or other copiable single-owner resources (such as file
descriptors).
