### PR TITLE
Enable Travis caching of APT packages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 
 language: cpp
 
+cache: apt
+
 before_install:
  - sudo apt-add-repository -y ppa:prantlf/cpp-netlib
  - sudo apt-add-repository -y ppa:fcitx-team/nightly


### PR DESCRIPTION
Hopefully makes the continuous build a bit faster...
