### PR TITLE
Use LogLookup instead of TreeSigner to get the STH.

### DIFF
--- a/cpp/server/ct_log_manager.cc
+++ b/cpp/server/ct_log_manager.cc
@@ -124,7 +124,7 @@ CTLogManager::LookupReply CTLogManager::GetEntry(
 
 
 const ct::SignedTreeHead CTLogManager::GetSTH() const {
-  return signer_->LatestSTH();
+  return lookup_->GetSTH();
 }
 
 


### PR DESCRIPTION
Just a one-liner, but this is more about getting peer review on the logic. The `LogLookup` object is used for all the other read operations, it seems to me that it would make more sense to do all the read operations using the same object, for a consistent view. This is relevant, because in my development branch, not all nodes are signers, so there may not be a `TreeSigner` object. From my reading of the code, this should be safe, as the call to `TreeSigner::UpdateTree` (that creates a new STH and writes it to the database) is immediately followed by a call to `LogLookup:::Update` (which loads the latest STH from the database).

Also: https://codereview.appspot.com/136230043/
