### PR TITLE
Update link for Protocol Buffers project.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -24,6 +24,7 @@
 
 Al Cutter <al@google.com>
 Ben Laurie <benl@google.com> <ben@links.org>
+Chris Kennelly <ckennelly@google.com> <ckennelly@ckennelly.com>
 Deyan Bektchiev <deyan.bektchiev@venafi.com> <deyan@bektchiev.net>
 Emilia Kasper <ekasper@google.com>
 Eran Messeri <eranm@google.com> <eran.mes@gmail.com>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Unpack googletest, but do not build it. Upstream recommends to build a new copy 
 
 Some systems make the googletest source available as a package; on Debian, this is in the libgtest-dev package, which puts it in ```/usr/src/gtest```. Our ```Makefile``` looks in that location by default, but if your googletest sources are in a different location, set the ```GTESTDIR``` environment variable to point at them.
 
- - [protobuf](https://code.google.com/p/protobuf/) (tested with 2.4.1)
+ - [protobuf](https://github.com/google/protobuf) (tested with 2.4.1)
  - [gflags](https://code.google.com/p/gflags/) (tested with 1.6 and 2.0)
  - [glog](https://code.google.com/p/google-glog/) (tested with 0.3.1)
 


### PR DESCRIPTION
The Google Code page indicates they've moved to Github.
