### PR TITLE
Add the build status to the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 certificate-transparency
 ========================
 
+[![Build Status](https://travis-ci.org/google/certificate-transparency.svg?branch=master)](https://travis-ci.org/google/certificate-transparency)
+
 Auditing for TLS certificates.
 
 ## Dependencies ##


### PR DESCRIPTION
You can see it in action [here](https://github.com/pphaneuf/certificate-transparency/tree/build_status).
