### PR TITLE
Have Monitor keep HTTPLogClient as a pointer.

### DIFF
--- a/cpp/client/ct.cc
+++ b/cpp/client/ct.cc
@@ -848,10 +848,9 @@ int Monitor() {
   CHECK_NE(FLAGS_monitor_action, "");
   CHECK_NE(FLAGS_ct_server, "");
 
-  monitor::Monitor monitor(GetMonitorDBFromFlags(),
-                           GetLogVerifierFromFlags(),
-                           HTTPLogClient(FLAGS_ct_server),
-                           FLAGS_monitor_sleep_time_secs);
+  HTTPLogClient client(FLAGS_ct_server);
+  monitor::Monitor monitor(GetMonitorDBFromFlags(), GetLogVerifierFromFlags(),
+                           &client, FLAGS_monitor_sleep_time_secs);
 
   int ret = 0;
   if (FLAGS_monitor_action == "get_sth") {

--- a/cpp/monitor/monitor.h
+++ b/cpp/monitor/monitor.h
@@ -2,16 +2,19 @@
 #define MONITOR_H
 
 #include <stdint.h>
-#include <string>
 
 #include "base/macros.h"
-#include "client/http_log_client.h"
-#include "monitor/sqlite_db.h"
 
+class HTTPLogClient;
 class LogVerifier;
-class Database;
+
+namespace ct {
+class SignedTreeHead;
+}
 
 namespace monitor {
+
+class Database;
 
 class Monitor
 {
@@ -36,7 +39,7 @@ class Monitor
 
   Monitor(Database *database,
           LogVerifier *verifier,
-          const HTTPLogClient &client,
+          HTTPLogClient *client,
           uint64_t sleep_time_sec);
 
   GetResult GetSTH();
@@ -59,10 +62,10 @@ class Monitor
     REFRESHED = 3,
   };
 
-  Database *db_;
-  LogVerifier *verifier_;
-  HTTPLogClient client_;
-  uint64_t sleep_time_;
+  Database *const db_;
+  LogVerifier *const verifier_;
+  HTTPLogClient *const client_;
+  const uint64_t sleep_time_;
 
   VerifyResult VerifySTHInternal();
   VerifyResult VerifySTHInternal(const ct::SignedTreeHead &sth);


### PR DESCRIPTION
Also some minor cleanups.

The constness of the HTTPLogClient is in the way of changes I'm making to it, as well as the copy that's being made, so stop that.

Note the forward declaration of Database that was incorrect, naughty naughty!
