### PR TITLE
Do a signing run at startup.

### DIFF
--- a/cpp/server/ct-server.cc
+++ b/cpp/server/ct-server.cc
@@ -200,11 +200,16 @@ int main(int argc, char * argv[]) {
 
   evthread_use_pthreads();
   const shared_ptr<libevent::Base> event_base(make_shared<libevent::Base>());
+
   CTLogManager manager(
       new Frontend(new CertSubmissionHandler(&checker),
                    new FrontendSigner(db, &log_signer)),
       new TreeSigner<LoggedCertificate>(db, &log_signer),
       new LogLookup<LoggedCertificate>(db));
+  // This method is called "sign", but it also loads the LogLookup
+  // object from the database as a side-effect.
+  manager.SignMerkleTree();
+
   ThreadPool pool;
   HttpHandler handler(&manager, &pool);
 


### PR DESCRIPTION
This makes sure that we do not serve invalid empty tree heads (fixing issue #143), as a side-effect.

See also: http://codereview.appspot.com/143970043/
