### PR TITLE
Forward-declaring Database<> isn't enough in log_lookup.h.

### DIFF
--- a/cpp/log/log_lookup-inl.h
+++ b/cpp/log/log_lookup-inl.h
@@ -12,7 +12,6 @@
 #include <utility>
 #include <vector>
 
-#include "log/database.h"
 #include "merkletree/merkle_tree.h"
 #include "merkletree/serial_hasher.h"
 #include "proto/ct.pb.h"

--- a/cpp/log/log_lookup.h
+++ b/cpp/log/log_lookup.h
@@ -7,10 +7,9 @@
 #include <string>
 
 #include "base/macros.h"
+#include "log/database.h"
 #include "merkletree/merkle_tree.h"
 #include "proto/ct.pb.h"
-
-template <class Logged> class Database;
 
 // Lookups into the database. Read-only, so could also be a mirror.
 // Keeps the entire Merkle Tree in memory to serve audit proofs.


### PR DESCRIPTION
The inline `LogLookup<>::GetEntry` method uses members of `Database<>`, so a forward declaration of `Database<>` is not sufficient.
