### PR TITLE
Use the Database directly from HttpHandler::GetEntries.

### DIFF
--- a/cpp/log/log_lookup.h
+++ b/cpp/log/log_lookup.h
@@ -54,13 +54,6 @@ template <class Logged> class LogLookup {
     return cert_tree_.SnapshotConsistency(first, second);
   }
 
-  // Get the |index|th log entry.
-  LookupResult GetEntry(size_t index, Logged *result) const {
-    if (db_->LookupByIndex(index, result) != Database<Logged>::LOOKUP_OK)
-      return NOT_FOUND;
-    return OK;
-  }
-
   // TODO(pphaneuf): If GetSTH and Update were to be called
   // concurrently, you'd have a race. This class should be made
   // threadsafe.

--- a/cpp/server/ct-dns-server.cc
+++ b/cpp/server/ct-dns-server.cc
@@ -43,7 +43,7 @@ class CTUDPDNSServer : public UDPServer {
  public:
   CTUDPDNSServer(const string &domain, Database<LoggedCertificate> *db,
 		 EventLoop *loop, int fd)
-    : UDPServer(loop, fd), domain_(domain), lookup_(db) {}
+    : UDPServer(loop, fd), domain_(domain), lookup_(db), db_(db) {}
 
   virtual void PacketRead(const sockaddr_in &from, const char *buf,
                           size_t len) {
@@ -168,7 +168,7 @@ private:
   string LeafHash(const string &index_str) const {
     int index = atoi(index_str.c_str());
     LoggedCertificate cert;
-    if (lookup_.GetEntry(index, &cert) != lookup_.OK)
+    if (db_->LookupByIndex(index, &cert) != db_->LOOKUP_OK)
       return "No such index";
     return util::ToBase64(lookup_.LeafHash(cert));
   }
@@ -235,6 +235,7 @@ private:
 
   string domain_;
   LogLookup<LoggedCertificate> lookup_;
+  const Database<LoggedCertificate> *const db_;
 };
 
 class Keyboard : public Server {

--- a/cpp/server/ct-server.cc
+++ b/cpp/server/ct-server.cc
@@ -229,7 +229,7 @@ int main(int argc, char * argv[]) {
   }
 
   ThreadPool pool;
-  HttpHandler handler(&log_lookup, &checker, &frontend, &pool);
+  HttpHandler handler(&log_lookup, db, &checker, &frontend, &pool);
 
   PeriodicCallback tree_event(
       event_base, FLAGS_tree_signing_frequency_seconds,

--- a/cpp/server/handler.cc
+++ b/cpp/server/handler.cc
@@ -244,9 +244,11 @@ int GetIntParam(const multimap<string, string> &query, const string &param) {
 
 
 HttpHandler::HttpHandler(LogLookup<LoggedCertificate> *log_lookup,
+                         const Database<LoggedCertificate> *db,
                          const CertChecker *cert_checker, Frontend *frontend,
                          ThreadPool *pool)
     : log_lookup_(CHECK_NOTNULL(log_lookup)),
+      db_(CHECK_NOTNULL(db)),
       cert_checker_(CHECK_NOTNULL(cert_checker)),
       frontend_(frontend),
       pool_(CHECK_NOTNULL(pool)) {
@@ -310,7 +312,8 @@ void HttpHandler::GetEntries(evhttp_request *req) const {
   for (int i = start; i <= end; ++i) {
     LoggedCertificate cert;
 
-    if (log_lookup_->GetEntry(i, &cert) != LogLookup<LoggedCertificate>::OK) {
+    if (db_->LookupByIndex(i, &cert) !=
+        Database<LoggedCertificate>::LOOKUP_OK) {
       return SendError(req, HTTP_BADREQUEST, "Entry not found.");
     }
 

--- a/cpp/server/handler.h
+++ b/cpp/server/handler.h
@@ -5,8 +5,9 @@
 
 #include "util/libevent_wrapper.h"
 
-template<class T> class LogLookup;
 class Frontend;
+template<class T> class Database;
+template<class T> class LogLookup;
 
 namespace ct {
 class CertChain;
@@ -24,6 +25,7 @@ class ThreadPool;
 class HttpHandler {
  public:
   HttpHandler(LogLookup<ct::LoggedCertificate> *log_lookup,
+              const Database<ct::LoggedCertificate> *db,
               const ct::CertChecker *cert_checker, Frontend *frontend,
               ThreadPool *pool);
 
@@ -45,6 +47,7 @@ class HttpHandler {
       const boost::shared_ptr<ct::PreCertChain> &chain) const;
 
   LogLookup<ct::LoggedCertificate> *const log_lookup_;
+  const Database<ct::LoggedCertificate> *const db_;
   const ct::CertChecker *const cert_checker_;
   Frontend *const frontend_;
   ThreadPool *const pool_;


### PR DESCRIPTION
And also CTUDPDNSServer::LeafHash, for completeness.

This momentarily helped prove to myself that I didn't have to consider the thread safety of LogLookup, only that of Database, while I was moving it to the thread pool (in a separate, upcoming pull request). Having one less silly forwarder method is just a bonus. :wink: 

See also: https://codereview.appspot.com/142240043/
