### PR TITLE
Make HttpHandler::GetEntries non-blocking.

### DIFF
--- a/cpp/server/handler.h
+++ b/cpp/server/handler.h
@@ -40,6 +40,7 @@ class HttpHandler {
   void AddChain(evhttp_request *req);
   void AddPreChain(evhttp_request *req);
 
+  void BlockingGetEntries(evhttp_request *req, int start, int end) const;
   void BlockingAddChain(evhttp_request *req,
                         const boost::shared_ptr<ct::CertChain> &chain) const;
   void BlockingAddPreChain(


### PR DESCRIPTION
This operation goes to disk with both our Database implementations, so do it on the thread pool, rather than synchronously.

See also: https://codereview.appspot.com/143230044/
