### PR TITLE
Convert HTTPLogClient to use libevent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,6 @@ Make sure to install glog **after** gflags, to avoid linking errors.
 
  - [Boost](http://www.boost.org/), at least 1.48
  - [sqlite3](http://www.sqlite.org/)
- - [cURL](http://curl.haxx.se/) (tested with 7.36.0)
-
-There are multiple Debian packages for this library (```libcurl4-gnutls-dev```, ```libcurl4-nss-dev```, or ```libcurl4-openssl-dev```, for example), any of them should do, but if you compile your own version of OpenSSL, it will conflict with the one cURL uses.
-
-To avoid this, either avoid the package that OpenSSL (```libcurl4-openssl-dev```), or you can build your own cURL that uses the same OpenSSL that you built, instead of the packaged version.
-
  - [JSON-C](https://github.com/json-c/json-c/), at least 0.11
 
 You can specify a JSON-C library in a non-standard location using the ```JSONCLIBDIR``` environment variable. Version 0.10 would work as well, except the ```json_object_iterator.h``` header is not properly copied when installing. If you can install the missing header manually, it should work.

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -13,7 +13,7 @@ LOCAL_LIBS = log/libcert.a log/libdatabase.a log/liblog.a \
              merkletree/libmerkletree.a \
              proto/libproto.a util/libutil.a
 LDLIBS = -lpthread -lgflags -lglog -lssl -lcrypto -lldns -lsqlite3 \
-         -lprotobuf -lcurl -levent_core -levent_extra -levent_pthreads
+         -lprotobuf -levent_core -levent_extra -levent_pthreads
 
 PLATFORM := $(shell uname -s)
 ifeq ($(PLATFORM), FreeBSD)
@@ -33,13 +33,6 @@ ifneq ($(OPENSSLDIR),)
   INCLUDE += -I $(OPENSSLDIR)/include
   LDLIBS += -L $(OPENSSLDIR) -L $(OPENSSLDIR)/lib -Wl,-rpath,$(OPENSSLDIR) \
             -Wl,-rpath,$(OPENSSLDIR)/lib
-endif
-
-# Allow non-system version of curl to be used.
-# Useful if it was built with a custom OpenSSL version.
-ifneq ($(CURLDIR),)
-  INCLUDE += -I $(CURLDIR)/include
-  LDLIBS += -L $(CURLDIR)/lib/.libs -Wl,-rpath,$(CURLDIR)/lib/.libs
 endif
 
 # Need libevent

--- a/cpp/client/http_log_client.h
+++ b/cpp/client/http_log_client.h
@@ -2,12 +2,13 @@
 #ifndef HTTP_LOG_CLIENT_H
 #define HTTP_LOG_CLIENT_H
 
-#include "proto/ct.pb.h"
-
 #include <boost/shared_ptr.hpp>
 #include <stdint.h>
-
 #include <string>
+
+#include "base/macros.h"
+#include "proto/ct.pb.h"
+#include "util/libevent_wrapper.h"
 
 namespace ct {
 class Cert;
@@ -17,7 +18,8 @@ class SignedCertificateTimestamp;
 
 class HTTPLogClient {
  public:
-  HTTPLogClient(const std::string &server) : server_(server) {}
+  explicit HTTPLogClient(const std::string &server);
+  ~HTTPLogClient();
 
   enum Status {
     OK,
@@ -30,17 +32,17 @@ class HTTPLogClient {
   };
 
   Status UploadSubmission(const std::string &submission, bool pre,
-                          ct::SignedCertificateTimestamp *sct) const;
+                          ct::SignedCertificateTimestamp *sct);
 
-  Status GetSTH(ct::SignedTreeHead *sth) const;
+  Status GetSTH(ct::SignedTreeHead *sth);
 
-  Status GetRoots(std::vector<boost::shared_ptr<ct::Cert> > *roots) const;
+  Status GetRoots(std::vector<boost::shared_ptr<ct::Cert> > *roots);
 
   Status QueryAuditProof(const std::string &merkle_leaf_hash,
-                         ct::MerkleAuditProof *proof) const;
+                         ct::MerkleAuditProof *proof);
 
   Status GetSTHConsistency(uint64_t size1, uint64_t size2,
-                           std::vector<std::string> *proof) const;
+                           std::vector<std::string> *proof);
 
   struct LogEntry {
     ct::MerkleTreeLeaf leaf;
@@ -49,12 +51,14 @@ class HTTPLogClient {
 
   // This does not clear |entries| before appending the retrieved
   // entries.
-  Status GetEntries(int first, int last, std::vector<LogEntry> *entries) const;
+  Status GetEntries(int first, int last, std::vector<LogEntry> *entries);
 
 private:
-  void BaseUrl(std::ostringstream *url) const;
+  evhttp_uri *const server_;
+  const boost::shared_ptr<cert_trans::libevent::Base> base_;
+  cert_trans::libevent::HttpConnection conn_;
 
-  std::string server_;
+  DISALLOW_COPY_AND_ASSIGN(HTTPLogClient);
 };
 
 #endif


### PR DESCRIPTION
This removes the dependency on libcurl.

See also: https://codereview.appspot.com/151090043/
