### PR TITLE
Update a few comments in ct-server.cc.

### DIFF
--- a/cpp/log/log_lookup.h
+++ b/cpp/log/log_lookup.h
@@ -16,6 +16,7 @@
 template <class Logged>
 class LogLookup {
  public:
+  // The constructor loads the content from the database.
   explicit LogLookup(const Database<Logged>* db);
   ~LogLookup();
 

--- a/cpp/server/ct-server.cc
+++ b/cpp/server/ct-server.cc
@@ -220,8 +220,11 @@ int main(int argc, char* argv[]) {
   TreeSigner<LoggedCertificate> tree_signer(db, &log_signer);
   LogLookup<LoggedCertificate> log_lookup(db);
 
-  // This function is called "sign", but it also loads the LogLookup
-  // object from the database as a side-effect.
+  // Make sure that we have an STH, even if the tree is empty.
+  // TODO(pphaneuf): We should be remaining in an "unhealthy state"
+  // (either not accepting any requests, or returning some internal
+  // server error) until we have an STH to serve. We can sign for now,
+  // but we might not be a signer.
   SignMerkleTree(&tree_signer, &log_lookup);
 
   const time_t last_update(


### PR DESCRIPTION
It's true that the SignMerkleTree function would call LogLookup<>::Update,
but that's not the real reason we need to call it at startup. LogLookup
loaded whatever was in the database in its constructor already, the real
problem is when there's nothing at all in the database, we'd serve an invalid
(unsigned) empty STH.
