### PR TITLE
Log new STHs being served from LogLookup.

### DIFF
--- a/cpp/log/log_lookup-inl.h
+++ b/cpp/log/log_lookup-inl.h
@@ -12,10 +12,16 @@
 #include <utility>
 #include <vector>
 
+#include "base/time_support.h"
 #include "merkletree/merkle_tree.h"
 #include "merkletree/serial_hasher.h"
 #include "proto/ct.pb.h"
 #include "proto/serializer.h"
+
+using cert_trans::kNumMillisPerSecond;
+
+
+static const int kCtimeBufSize = 26;
 
 
 template <class Logged>
@@ -82,6 +88,12 @@ typename LogLookup<Logged>::UpdateResult LogLookup<Logged>::Update() {
   LOG(INFO) << "Found " << sth.tree_size() - latest_tree_head_.tree_size()
             << " new log entries";
   latest_tree_head_.CopyFrom(sth);
+
+  const time_t last_update(static_cast<time_t>(latest_tree_head_.timestamp() /
+                                               kNumMillisPerSecond));
+  char buf[kCtimeBufSize];
+  LOG(INFO) << "Tree successfully updated at " << ctime_r(&last_update, buf);
+
   return UPDATE_OK;
 }
 

--- a/cpp/server/ct-server.cc
+++ b/cpp/server/ct-server.cc
@@ -67,8 +67,6 @@ using cert_trans::util::ReadPrivateKey;
 using google::RegisterFlagValidator;
 using std::string;
 
-static const int kCtimeBufSize = 26;
-
 // Basic sanity checks on flag values.
 static bool ValidatePort(const char* flagname, int port) {
   if (port <= 0 || port > 65535) {
@@ -169,12 +167,9 @@ class PeriodicCallback {
 void SignMerkleTree(TreeSigner<LoggedCertificate>* tree_signer,
                     LogLookup<LoggedCertificate>* log_lookup) {
   CHECK_EQ(tree_signer->UpdateTree(), TreeSigner<LoggedCertificate>::OK);
+  // There should always be an update here, since we just signed a new
+  // tree head.
   CHECK_EQ(log_lookup->Update(), LogLookup<LoggedCertificate>::UPDATE_OK);
-
-  const time_t last_update(
-      static_cast<time_t>(tree_signer->LastUpdateTime() / 1000));
-  char buf[kCtimeBufSize];
-  LOG(INFO) << "Tree successfully updated at " << ctime_r(&last_update, buf);
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
This is to be certain that we log this event, no matter what called/caused it.

See also: https://codereview.appspot.com/152480043/
