### PR TITLE
Sync up the two implementation of Database<>::LatestTreeHead.

### DIFF
--- a/cpp/log/file_db-inl.h
+++ b/cpp/log/file_db-inl.h
@@ -179,17 +179,12 @@ typename Database<Logged>::LookupResult FileDB<Logged>::LatestTreeHead(
     return this->NOT_FOUND;
 
   std::string tree_data;
-  FileStorage::FileStorageResult db_result =
-      tree_storage_->LookupEntry(latest_timestamp_key_, &tree_data);
-  assert(db_result == FileStorage::OK);
+  CHECK_EQ(tree_storage_->LookupEntry(latest_timestamp_key_, &tree_data),
+           FileStorage::OK);
 
-  ct::SignedTreeHead local_sth;
+  CHECK(result->ParseFromString(tree_data));
+  CHECK_EQ(result->timestamp(), latest_tree_timestamp_);
 
-  bool ret = local_sth.ParseFromString(tree_data);
-  assert(ret);
-  assert(local_sth.timestamp() == latest_tree_timestamp_);
-
-  result->CopyFrom(local_sth);
   return this->LOOKUP_OK;
 }
 

--- a/cpp/log/sqlite_db-inl.h
+++ b/cpp/log/sqlite_db-inl.h
@@ -238,7 +238,7 @@ typename Database<Logged>::LookupResult SQLiteDB<Logged>::LatestTreeHead(
 
   std::string sth;
   statement.GetBlob(0, &sth);
-  result->ParseFromString(sth);
+  CHECK(result->ParseFromString(sth));
 
   return this->LOOKUP_OK;
 }


### PR DESCRIPTION
Also use the CHECK family of macros instead of assert(), to make sure they are always active (if one of these things aren't true, something is very, very wrong!).

See also: https://codereview.appspot.com/160770045/
