### PR TITLE
Long running monitor of logs.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -30,6 +30,7 @@ Emilia Kasper <ekasper@google.com>
 Eran Messeri <eranm@google.com> <eran.mes@gmail.com>
 Jeff Trawick <trawick@gmail.com>
 Katriel Cohn-Gordon <katriel.cohn-gordon@cybersecurity.ox.ac.uk>
+Konrad Kraszewski <kraszewski@google.com> <laiquendir@gmail.com>
 Linus Nordberg <linus@nordu.net>
 Mark Schloesser <ms@mwcollect.org>
 Nicholas Galbreath <nickg@client9.com>

--- a/python/ct/client/monitor_test.py
+++ b/python/ct/client/monitor_test.py
@@ -219,7 +219,11 @@ class MonitorTest(unittest.TestCase):
         client = FakeLogClient(sth)
 
         m = self.create_monitor(client)
+        m._verify_consistency = mock.Mock(return_value=True)
         self.assertFalse(m._update_sth())
+        self.assertTrue(m._verify_consistency.called)
+        args, _ = m._verify_consistency.call_args
+        self.assertTrue(args[0].timestamp < args[1].timestamp)
 
         # Check that we kept the state.
         expected_state = client_pb2.MonitorState()

--- a/python/utilities/logobserver/logobserver.py
+++ b/python/utilities/logobserver/logobserver.py
@@ -1,0 +1,57 @@
+import gflags
+from google.protobuf import text_format
+import logging
+import os
+import sys
+import time
+
+from ct.client import sqlite_connection as sqlitecon
+from ct.client import prober
+from ct.client import sqlite_log_db
+from ct.client import sqlite_temp_db
+from ct.proto import client_pb2
+
+
+FLAGS = gflags.FLAGS
+gflags.DEFINE_string("ctlog_config", "ct/config/logs.config",
+                     "Configuration file for log servers to monitor")
+gflags.DEFINE_string("log_level", "WARNING", "logging level")
+gflags.DEFINE_string("ct_sqlite_db", "/tmp/ct", "Location of the CT database")
+gflags.DEFINE_string("ct_sqlite_temp_dir", "/tmp/ct_tmp", "Directory for "
+                     "temporary CT data.")
+gflags.DEFINE_string("monitor_state_dir", "/tmp/ct_monitor",
+                     "Filename prefix for monitor state. State for a given log "
+                     "will be stored in a monitor_state_dir/log_id file")
+
+def create_directory(directory):
+    if not os.path.exists(directory):
+        logging.info("Creating directory: %s" % directory)
+        os.makedirs(directory)
+
+if __name__ == '__main__':
+    sys.argv = FLAGS(sys.argv)
+    logging.basicConfig(level=FLAGS.log_level)
+
+    sqlite_log_db = sqlite_log_db.SQLiteLogDB(
+        sqlitecon.SQLiteConnectionManager(FLAGS.ct_sqlite_db))
+
+    create_directory(FLAGS.ct_sqlite_temp_dir)
+    create_directory(FLAGS.monitor_state_dir)
+
+    sqlite_temp_db_factory = sqlite_temp_db.SQLiteTempDBFactory(
+        sqlitecon.SQLiteConnectionManager(FLAGS.ct_sqlite_temp_dir + "/meta"),
+                                          FLAGS.ct_sqlite_temp_dir)
+    ctlogs = client_pb2.CtLogs()
+    with open(FLAGS.ctlog_config, "r") as config:
+        log_config = config.read()
+    text_format.Merge(log_config, ctlogs)
+
+    ct_server_list = []
+    for log in ctlogs.ctlog:
+        sqlite_log_db.update_log(log)
+        ct_server_list.append(log.log_server)
+
+    prober_thread = prober.ProberThread(ctlogs, sqlite_log_db,
+                                      sqlite_temp_db_factory,
+                                      FLAGS.monitor_state_dir)
+    prober_thread.start()


### PR DESCRIPTION
logobserver.py simply runs already implemented ProberThread which does most of heavy lifting. If there are any inconsistencies detected they will be logged. I also changed monitor.py slightly, so if it receives older STH than currently verified, it still checks if it's consistent, and if it is then it only logs a warning. Soon I'll implement proper alerts.
