### PR TITLE
get_entries is now sending multiple queries.

### DIFF
--- a/python/ct/client/log_client_test.py
+++ b/python/ct/client/log_client_test.py
@@ -21,6 +21,7 @@ class LogClientTest(unittest.TestCase):
             def __init__(self, code, reason, json_content=None):
                 self.status_code = code
                 self.reason = reason
+                self.headers = ''
                 if json_content is not None:
                     self.content = json.dumps(json_content)
                 else:

--- a/python/ct/client/log_client_test_util.py
+++ b/python/ct/client/log_client_test_util.py
@@ -1,7 +1,8 @@
+import copy
+
 from ct.client import log_client
 from ct.crypto import merkle
 from ct.proto import client_pb2
-
 
 DEFAULT_STH = client_pb2.SthResponse()
 DEFAULT_STH.timestamp = 1234
@@ -20,7 +21,7 @@ class FakeHandlerBase(log_client.RequestHandler):
         self._uri = uri
         self._entry_limit = entry_limit
 
-        self._sth = DEFAULT_STH
+        self._sth = copy.deepcopy(DEFAULT_STH)
         # Override with custom size
         if tree_size > 0:
             self._sth.tree_size = tree_size


### PR DESCRIPTION
Now get_entries can send multiple requests at the same time to fetch the entries (you can set how many entries are fetched at the same time). Also while testing it I found out that error headers are not attached in logs, so I squeezed that change here.  I removed one unit test for async client (one that checks if client returns partial result if range was too big), because currently all classes that use async log client care more about getting exception as soon as possible than getting partial result.
