### PR TITLE
Certificate signatureAlgorithm type is too general.

### DIFF
--- a/python/ct/crypto/asn1/x509.py
+++ b/python/ct/crypto/asn1/x509.py
@@ -32,6 +32,6 @@ class TBSCertificate(types.Sequence):
 class Certificate(types.Sequence):
     components = (
         (types.Component("tbsCertificate", TBSCertificate)),
-        (types.Component("signatureAlgorithm", types.Any)),
+        (types.Component("signatureAlgorithm", x509_common.AlgorithmIdentifier)),
         (types.Component("signatureValue", types.BitString))
         )


### PR DESCRIPTION
According to ASN.1 structure in RFC 5280 signatureAlgorithm type should be AlgorithmIdentifier (the same as signature in TBSCertificate).
