### PR TITLE
Remove the HttpRequest::get() method.

### DIFF
--- a/cpp/util/libevent_wrapper.cc
+++ b/cpp/util/libevent_wrapper.cc
@@ -208,7 +208,7 @@ HttpConnection::~HttpConnection() {
 
 void HttpConnection::MakeRequest(HttpRequest* req, evhttp_cmd_type type,
                                  const string& uri) {
-  CHECK_EQ(evhttp_make_request(conn_, req->get(), type, uri.c_str()), 0);
+  CHECK_EQ(evhttp_make_request(conn_, req->req_, type, uri.c_str()), 0);
 }
 
 

--- a/cpp/util/libevent_wrapper.h
+++ b/cpp/util/libevent_wrapper.h
@@ -97,11 +97,25 @@ class HttpRequest {
   explicit HttpRequest(const Callback& callback);
   ~HttpRequest();
 
-  evhttp_request* get() {
-    return req_;
+  int GetResponseCode() const {
+    return evhttp_request_get_response_code(req_);
+  }
+  evkeyvalq* GetInputHeaders() const {
+    return evhttp_request_get_input_headers(req_);
+  }
+  evbuffer* GetInputBuffer() const {
+    return evhttp_request_get_input_buffer(req_);
+  }
+  evkeyvalq* GetOutputHeaders() const {
+    return evhttp_request_get_output_headers(req_);
+  }
+  evbuffer* GetOutputBuffer() const {
+    return evhttp_request_get_output_buffer(req_);
   }
 
  private:
+  friend class HttpConnection;
+
   static void Done(evhttp_request* req, void* userdata);
 
   const Callback callback_;


### PR DESCRIPTION
I'm in the process of adding support for cancelling HTTP requests, and I need to really make sure no one is messing around with the evhttp_request, otherwise we're all going to lose our marbles.
