### PR TITLE
Use shared_ptr for running HttpRequest.

### DIFF
--- a/cpp/util/etcd.h
+++ b/cpp/util/etcd.h
@@ -73,8 +73,9 @@ class EtcdClient {
   // If MaybeUpdateLeader returns true, the handling of the response
   // should be aborted, as a new leader was found, and the request has
   // been retried on the new leader.
-  bool MaybeUpdateLeader(libevent::HttpRequest* req, Request* etcd_req);
-  void RequestDone(libevent::HttpRequest* req, Request* etcd_req);
+  bool MaybeUpdateLeader(const libevent::HttpRequest& req, Request* etcd_req);
+  void RequestDone(const std::shared_ptr<libevent::HttpRequest>& req,
+                   Request* etcd_req);
 
   std::shared_ptr<libevent::HttpConnection> GetConnection(
       const std::string& host, uint16_t port);

--- a/cpp/util/libevent_wrapper.h
+++ b/cpp/util/libevent_wrapper.h
@@ -92,7 +92,7 @@ class HttpServer {
 
 class HttpRequest {
  public:
-  typedef std::function<void(HttpRequest*)> Callback;
+  typedef std::function<void(const std::shared_ptr<HttpRequest>&)> Callback;
 
   explicit HttpRequest(const Callback& callback);
   ~HttpRequest();
@@ -121,6 +121,10 @@ class HttpRequest {
   const Callback callback_;
   evhttp_request* req_;
 
+  // A self-reference to keep the request object alive, as long as
+  // it's running.
+  std::shared_ptr<HttpRequest> self_ref_;
+
   DISALLOW_COPY_AND_ASSIGN(HttpRequest);
 };
 
@@ -132,8 +136,8 @@ class HttpConnection {
 
   // Takes ownership of "req", which will be automatically deleted
   // after its callback is called.
-  void MakeRequest(HttpRequest* req, evhttp_cmd_type type,
-                   const std::string& uri);
+  void MakeRequest(const std::shared_ptr<HttpRequest>& req,
+                   evhttp_cmd_type type, const std::string& uri);
 
  private:
   evhttp_connection* const conn_;


### PR DESCRIPTION
This makes the ownership model _slightly_ more sensible. Also, for cancellation support, I can't have the HttpRequest objects just disappear out of the blue, we need something to be able to call `->Cancel()` on! :stuck_out_tongue: 
