### PR TITLE
The callback shouldn't be running once HttpRequest::Cancel returns.

### DIFF
--- a/cpp/util/libevent_wrapper.h
+++ b/cpp/util/libevent_wrapper.h
@@ -99,7 +99,9 @@ class HttpRequest {
   ~HttpRequest();
 
   // After calling this, the object becomes invalid, and any reference
-  // to it should be disposed of.
+  // to it should be disposed of. If it is too late to cancel and the
+  // callback is still running, this method will block until the
+  // callback has returned.
   void Cancel();
 
   int GetResponseCode() const {
@@ -138,6 +140,7 @@ class HttpRequest {
 
   std::mutex cancel_lock_;
   event* cancel_;
+  bool cancelled_;
 
   DISALLOW_COPY_AND_ASSIGN(HttpRequest);
 };


### PR DESCRIPTION
This covers the case where you're cancelling from the destructor of the object that is used in the callback. You definitely want Cancel to either let the callback complete, or never let it run, anything in between would be **Very Bad (tm)**.
