### PR TITLE
Add an etcd watcher class.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@
 /cpp/server/ct-server
 /cpp/util/bench_etcd
 /cpp/util/etcd_test
+/cpp/util/etcd_watch
 /cpp/util/json_wrapper_test
 /cpp/util/sync_etcd_test
 /java/build

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -77,7 +77,7 @@ ALL_TESTS = $(PROTO_TESTS) $(MERKLETREE_TESTS) $(LOG_TESTS) $(UTIL_TESTS) \
 	$(MONITOR_TESTS) dns_tests
 
 all: unit_tests client/ct server/ct-server server/ct-dns-server \
-     util/bench_etcd
+     util/bench_etcd util/etcd_watch
 
 .DELETE_ON_ERROR:
 
@@ -284,6 +284,9 @@ server/ct-server: server/ct-server.o util/read_private_key.o \
 	server/handler.o $(LOCAL_LIBS)
 
 util/bench_etcd: util/bench_etcd.o util/libutil.a
+
+util/etcd_watch: util/etcd_watch.o util/etcd.o util/libevent_wrapper.o \
+	util/json_wrapper.o util/status.o
 
 dns_tests: server/ct-dns-server
 

--- a/cpp/util/etcd_watch.cc
+++ b/cpp/util/etcd_watch.cc
@@ -1,0 +1,44 @@
+#include <event2/thread.h>
+#include <functional>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <iostream>
+#include <memory>
+
+#include "util/etcd.h"
+#include "util/libevent_wrapper.h"
+
+namespace libevent = cert_trans::libevent;
+
+using cert_trans::EtcdClient;
+using std::bind;
+using std::cout;
+using std::endl;
+using std::make_shared;
+using std::placeholders::_1;
+using std::placeholders::_2;
+using std::shared_ptr;
+using std::string;
+
+DEFINE_string(etcd, "127.0.0.1", "etcd server address");
+DEFINE_int32(etcd_port, 4001, "etcd server port");
+
+
+void Notify(const string& key, int index, const string& value) {
+  cout << "key changed: " << key << " (" << index << ") = " << value << endl;
+}
+
+
+int main(int argc, char* argv[]) {
+  google::ParseCommandLineFlags(&argc, &argv, true);
+  google::InitGoogleLogging(argv[0]);
+  evthread_use_pthreads();
+
+  const shared_ptr<libevent::Base> event_base(make_shared<libevent::Base>());
+  EtcdClient etcd(event_base, FLAGS_etcd, FLAGS_etcd_port);
+  EtcdClient::Watcher watcher(&etcd, "/foo", bind(&Notify, "/foo", _1, _2));
+
+  event_base->Dispatch();
+
+  return 0;
+}


### PR DESCRIPTION
Also a few cleanups I forgot in previous commits, like not using a temporary object when using `UpdateLeader`, and using an `unique_ptr` in `RequestDone`.
