### PR TITLE
Add a method to get the tree size of the local database.

### DIFF
--- a/cpp/log/database.h
+++ b/cpp/log/database.h
@@ -76,6 +76,11 @@ class ReadOnlyDatabase {
   // Return the tree head with the freshest timestamp.
   virtual LookupResult LatestTreeHead(ct::SignedTreeHead* result) const = 0;
 
+  // Return the number of entries of contiguous entries (what could be
+  // put in a signed tree head). This can be greater than the tree
+  // size returned by LatestTreeHead.
+  virtual int TreeSize() const = 0;
+
   // Add/remove a callback to be called when a new tree head is
   // available. The pointer is used as a key, so it should be the same
   // in matching add/remove calls.

--- a/cpp/log/file_db-inl.h
+++ b/cpp/log/file_db-inl.h
@@ -185,6 +185,12 @@ typename Database<Logged>::LookupResult FileDB<Logged>::LatestTreeHead(
 }
 
 template <class Logged>
+int FileDB<Logged>::TreeSize() const {
+  CHECK_EQ(sequence_map_.size(), sequence_map_.rbegin()->first + 1);
+  return sequence_map_.size();
+}
+
+template <class Logged>
 void FileDB<Logged>::AddNotifySTHCallback(
     const typename Database<Logged>::NotifySTHCallback* callback) {
   callbacks_.Add(callback);

--- a/cpp/log/file_db.h
+++ b/cpp/log/file_db.h
@@ -55,6 +55,8 @@ class FileDB : public Database<Logged> {
   virtual typename Database<Logged>::LookupResult LatestTreeHead(
       ct::SignedTreeHead* result) const;
 
+  virtual int TreeSize() const;
+
   virtual void AddNotifySTHCallback(
       const typename Database<Logged>::NotifySTHCallback* callback);
   virtual void RemoveNotifySTHCallback(

--- a/cpp/log/sqlite_db-inl.h
+++ b/cpp/log/sqlite_db-inl.h
@@ -222,6 +222,20 @@ typename Database<Logged>::LookupResult SQLiteDB<Logged>::LatestTreeHead(
 }
 
 template <class Logged>
+int SQLiteDB<Logged>::TreeSize() const {
+  sqlite::Statement statement(
+      db_, "SELECT sequence FROM leaves ORDER BY sequence DESC LIMIT 1");
+
+  const int ret(statement.Step());
+  if (ret == SQLITE_DONE) {
+    return 0;
+  }
+  CHECK_EQ(SQLITE_ROW, ret);
+
+  return statement.GetUInt64(0) + 1;
+}
+
+template <class Logged>
 void SQLiteDB<Logged>::AddNotifySTHCallback(
     const typename Database<Logged>::NotifySTHCallback* callback) {
   callbacks_.Add(callback);

--- a/cpp/log/sqlite_db.h
+++ b/cpp/log/sqlite_db.h
@@ -36,6 +36,8 @@ class SQLiteDB : public Database<Logged> {
 
   virtual LookupResult LatestTreeHead(ct::SignedTreeHead* result) const;
 
+  virtual int TreeSize() const;
+
   virtual void AddNotifySTHCallback(
       const typename Database<Logged>::NotifySTHCallback* callback);
   virtual void RemoveNotifySTHCallback(


### PR DESCRIPTION
This is to be able to resume from a partially replicated database after a restart.
