### PR TITLE
Disable ct-dns-server-test.py for now.

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -312,9 +312,11 @@ test: all
 	log/tree_signer_test
 	log/log_lookup_test
 	monitor/database_test
-	rm -rf /tmp/ct-test.$$$$ && mkdir /tmp/ct-test.$$$$ \
-	&& python server/ct-dns-server-test.py /tmp/ct-test.$$$$ \
-	&& rm -rf /tmp/ct-test.$$$$
+	# TODO(pphaneuf): This is broken by commit 9391d114, hopefully
+	# fixed soon.
+	#rm -rf /tmp/ct-test.$$$$ && mkdir /tmp/ct-test.$$$$ \
+	#&& python server/ct-dns-server-test.py /tmp/ct-test.$$$$ \
+	#&& rm -rf /tmp/ct-test.$$$$
 
 # Unit tests plus end-to-end tests. Make sure to set up links in test/  first.
 alltests: test


### PR DESCRIPTION
Broken by 9391d114feae314c1c9f8b2d65f365780021ad7f.
