### PR TITLE
Disable Travis notification emails.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,3 @@ before_install:
 script:
  - make alltests CC=clang CXX=clang++
  - go test -v ./go/...
-
-notifications:
-  email:
-   - certificate-transparency@googlegroups.com


### PR DESCRIPTION
This doesn't work as well as I hoped, and tends to have forks spamming us.
