### PR TITLE
Store entry responses.

### DIFF
--- a/python/ct/client/log_client.py
+++ b/python/ct/client/log_client.py
@@ -2,6 +2,7 @@
 import base64
 import json
 
+from ct.client import database
 from ct.proto import client_pb2
 import gflags
 import logging
@@ -47,6 +48,7 @@ gflags.DEFINE_integer("response_buffer_size_bytes", 50 * 1000 * 1000, "Maximum "
                       "the buffer. A typical log entry is expected to be < "
                       "10kB.")
 
+gflags.DEFINE_bool("persist_entries", True, "Cache entries on disk.")
 
 class Error(Exception):
     pass
@@ -542,10 +544,12 @@ class EntryProducer(object):
     """A push producer for log entries."""
     implements(iweb.IBodyProducer)
 
-    def __init__(self, handler, reactor, uri, start, end, batch_size):
+    def __init__(self, handler, reactor, uri, start, end,
+                 batch_size, entries_db=None):
         self._handler = handler
         self._reactor = reactor
         self._uri = uri
+        self._entries_db = entries_db
         self._consumer = None
 
         assert 0 <= start <= end
@@ -615,17 +619,34 @@ class EntryProducer(object):
         self._currently_stored += len(result)
         return result
 
+    def _store_batch(self, entry_batch, start_index):
+        assert self._entries_db
+        self._entries_db.store_entries(enumerate(entry_batch, start_index))
+        return entry_batch
+
+    def _get_entries_from_db(self, first, last):
+        if FLAGS.persist_entries and self._entries_db:
+            try:
+                return list(self._entries_db.scan_entries(first, last))
+            except database.KeyError:
+                pass
+
     def _fetch_parsed_entries(self, first, last):
+        entries = self._get_entries_from_db(first, last)
         # it's not the best idea to attack server with many requests exactly at
         # the same time, so requests are sent after slight delay.
-        request = task.deferLater(self._reactor,
-                                  self._calculate_retry_delay(0),
-                                  self._handler.get,
-                                  self._uri + "/" + _GET_ENTRIES_PATH,
-                                  params={"start": str(first),
-                                          "end": str(last)})
-        request.addCallback(_parse_entries, last - first + 1)
-        return request
+        if not entries:
+            request = task.deferLater(self._reactor,
+                                      self._calculate_retry_delay(0),
+                                      self._handler.get,
+                                      self._uri + "/" + _GET_ENTRIES_PATH,
+                                      params={"start": str(first),
+                                              "end": str(last)})
+            request.addCallback(_parse_entries, last - first + 1)
+            if self._entries_db and FLAGS.persist_entries:
+                request.addCallback(self._store_batch, first)
+            entries = request
+        return entries
 
     def _create_next_request(self, first, last, entries, retries):
         d = self._fetch_parsed_entries(first, last)
@@ -732,19 +753,24 @@ class EntryProducer(object):
 class AsyncLogClient(object):
     """A twisted log client."""
 
-    def __init__(self, agent, uri, reactor=ireactor):
+    def __init__(self, agent, uri, entries_db=None, reactor=ireactor):
 
         """Initialize the client.
+
+        If entries_db is specified and flag persist_entries is true, get_entries
+        will return stored entries.
 
         Args:
             agent: the agent to use.
             uri: the uri of the log.
+            entries_db: object that conforms TempDB API
             reactor: the reactor to use. Default is twisted.internet.reactor.
         """
         self._handler = AsyncRequestHandler(agent)
         #twisted expects bytes, so if uri is unicode we have to change encoding
         self._uri = uri.encode('ascii')
         self._reactor = reactor
+        self._entries_db = entries_db
 
     @property
     def servername(self):
@@ -790,8 +816,8 @@ class AsyncLogClient(object):
         if start < 0 or end < 0 or start > end:
             raise InvalidRequestError("Invalid range [%d, %d]" % (start, end))
         batch_size = batch_size or FLAGS.entry_fetch_batch_size
-        return EntryProducer(self._handler, self._reactor, self._uri, start,
-                             end, batch_size)
+        return EntryProducer(self._handler, self._reactor, self._uri,
+                             start, end, batch_size, self._entries_db)
 
     def get_sth_consistency(self, old_size, new_size):
         """Retrieve a consistency proof.

--- a/python/ct/client/sqlite_temp_db.py
+++ b/python/ct/client/sqlite_temp_db.py
@@ -102,15 +102,13 @@ class SQLiteTempDB(temp_db.TempDB):
         Args:
             entries: an iterable of (entry_number, client_pb2.EntryResponse)
                      tuples
-        Raises:
-            KeyError: an entry with this sequence number already exists.
         """
         with self.__mgr.get_connection() as conn:
             cursor = conn.cursor()
             serialized_entries = map(lambda x: (
                     x[0], sqlite3.Binary(x[1].SerializeToString())), entries)
             try:
-                cursor.executemany("INSERT INTO entries(id, entry) VALUES "
+                cursor.executemany("INSERT OR REPLACE INTO entries(id, entry) VALUES "
                                    "(?, ?)", serialized_entries)
             except sqlite3.IntegrityError as e:
                 raise database.KeyError("Failed to insert entries: an entry "

--- a/python/ct/client/temp_db.py
+++ b/python/ct/client/temp_db.py
@@ -12,8 +12,6 @@ class TempDB(object):
         Args:
             entries: an iterable of (entry_number, client_pb2.EntryResponse)
                      tuples
-        Raises:
-            KeyError: an entry with this sequence number already exists.
        """
 
     @abc.abstractmethod

--- a/python/ct/client/temp_db_test.py
+++ b/python/ct/client/temp_db_test.py
@@ -39,11 +39,12 @@ class TempDBTest(object):
         returned_entries = list(self.db().scan_entries(0, 9))
         self.verify_entries(returned_entries, 0, 9)
 
-    def test_store_twice_fails(self):
+    def test_store_twice_doesnt_raise(self):
         entries = self.make_entries(0, 9)
         self.db().store_entries(entries)
-        self.assertRaises(database.KeyError, self.db().store_entries,
-                          entries)
+        entries = self.make_entries(1, 10)
+        self.db().store_entries(entries)
+        self.verify_entries(list(self.db().scan_entries(0, 10)), 0, 10)
 
     def test_scan_out_of_range_fails(self):
         entries = self.make_entries(0, 9)

--- a/python/utilities/logobserver/logobserver.py
+++ b/python/utilities/logobserver/logobserver.py
@@ -4,7 +4,6 @@ from google.protobuf import text_format
 import logging
 import os
 import sys
-import time
 
 from ct.client import sqlite_connection as sqlitecon
 from ct.client import prober
@@ -33,11 +32,11 @@ if __name__ == '__main__':
     sys.argv = FLAGS(sys.argv)
     logging.basicConfig(level=FLAGS.log_level)
 
-    sqlite_log_db = sqlite_log_db.SQLiteLogDB(
-        sqlitecon.SQLiteConnectionManager(FLAGS.ct_sqlite_db))
-
     create_directory(FLAGS.ct_sqlite_temp_dir)
     create_directory(FLAGS.monitor_state_dir)
+
+    sqlite_log_db = sqlite_log_db.SQLiteLogDB(
+        sqlitecon.SQLiteConnectionManager(FLAGS.ct_sqlite_db))
 
     sqlite_temp_db_factory = sqlite_temp_db.SQLiteTempDBFactory(
         sqlitecon.SQLiteConnectionManager(FLAGS.ct_sqlite_temp_dir + "/meta"),
@@ -53,6 +52,6 @@ if __name__ == '__main__':
         ct_server_list.append(log.log_server)
 
     prober_thread = prober.ProberThread(ctlogs, sqlite_log_db,
-                                      sqlite_temp_db_factory,
-                                      FLAGS.monitor_state_dir)
+                                        sqlite_temp_db_factory,
+                                        FLAGS.monitor_state_dir)
     prober_thread.start()


### PR DESCRIPTION
Store responses fetched by async log client, and use them when available. Since we aren't using unsafe pickle I've set use_stored_entries flag to true by default. 
However, storing one file per EntryResponse might not be the best aproach.
