### PR TITLE
Add some TTL aware methods to etcd.

### DIFF
--- a/cpp/util/etcd.cc
+++ b/cpp/util/etcd.cc
@@ -661,6 +661,18 @@ void EtcdClient::Create(const string& key, const string& value,
 }
 
 
+void EtcdClient::CreateWithTTL(const std::string& key,
+                               const std::string& value,
+                               const std::chrono::duration<int>& ttl,
+                               const CreateCallback& cb) {
+  map<string, string> params;
+  params["value"] = value;
+  params["prevExist"] = "false";
+  params["ttl"] = std::to_string(ttl.count());
+  Generic(key, params, EVHTTP_REQ_PUT, bind(&CreateRequestDone, _1, _2, cb));
+}
+
+
 void EtcdClient::CreateInQueue(const string& dir, const string& value,
                                const CreateInQueueCallback& cb) {
   map<string, string> params;
@@ -680,10 +692,32 @@ void EtcdClient::Update(const string& key, const string& value,
 }
 
 
+void EtcdClient::UpdateWithTTL(const string& key, const string& value,
+                               const std::chrono::duration<int>& ttl,
+                               const int previous_index,
+                               const UpdateCallback& cb) {
+  map<string, string> params;
+  params["value"] = value;
+  params["prevIndex"] = to_string(previous_index);
+  params["ttl"] = std::to_string(ttl.count());
+  Generic(key, params, EVHTTP_REQ_PUT, bind(&UpdateRequestDone, _1, _2, cb));
+}
+
+
 void EtcdClient::ForceSet(const string& key, const string& value,
                           const ForceSetCallback& cb) {
   map<string, string> params;
   params["value"] = value;
+  Generic(key, params, EVHTTP_REQ_PUT, bind(&ForceSetRequestDone, _1, _2, cb));
+}
+
+
+void EtcdClient::ForceSetWithTTL(const string& key, const string& value,
+                                 const std::chrono::duration<int>& ttl,
+                                 const ForceSetCallback& cb) {
+  map<string, string> params;
+  params["value"] = value;
+  params["ttl"] = std::to_string(ttl.count());
   Generic(key, params, EVHTTP_REQ_PUT, bind(&ForceSetRequestDone, _1, _2, cb));
 }
 

--- a/cpp/util/etcd.h
+++ b/cpp/util/etcd.h
@@ -1,6 +1,7 @@
 #ifndef CERT_TRANS_UTIL_ETCD_H_
 #define CERT_TRANS_UTIL_ETCD_H_
 
+#include <chrono>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -71,14 +72,26 @@ class EtcdClient {
   void Create(const std::string& key, const std::string& value,
               const CreateCallback& cb);
 
+  void CreateWithTTL(const std::string& key, const std::string& value,
+                     const std::chrono::duration<int>& ttl,
+                     const CreateCallback& cb);
+
   void CreateInQueue(const std::string& dir, const std::string& value,
                      const CreateInQueueCallback& cb);
 
   void Update(const std::string& key, const std::string& value,
               const int previous_index, const UpdateCallback& cb);
 
+  void UpdateWithTTL(const std::string& key, const std::string& value,
+                     const std::chrono::duration<int>& ttl,
+                     const int previous_index, const UpdateCallback& cb);
+
   void ForceSet(const std::string& key, const std::string& value,
                 const ForceSetCallback& cb);
+
+  void ForceSetWithTTL(const std::string& key, const std::string& value,
+                       const std::chrono::duration<int>& ttl,
+                       const ForceSetCallback& cb);
 
   void Delete(const std::string& key, const int current_index,
               const DeleteCallback& cb);

--- a/cpp/util/sync_etcd.cc
+++ b/cpp/util/sync_etcd.cc
@@ -130,6 +130,15 @@ Status SyncEtcdClient::Create(const string& key, const string& value,
 }
 
 
+util::Status SyncEtcdClient::CreateWithTTL(
+    const std::string& key, const std::string& value,
+    const std::chrono::duration<int>& ttl, int* index) {
+  return BlockingCall(base_, bind(&EtcdClient::CreateWithTTL, client_.get(),
+                                  key, value, ttl, _1),
+                      index);
+}
+
+
 Status SyncEtcdClient::CreateInQueue(const string& dir, const string& value,
                                      string* key, int* index) {
   return BlockingCall(base_, bind(&EtcdClient::CreateInQueue, client_.get(),
@@ -146,10 +155,29 @@ Status SyncEtcdClient::Update(const string& key, const string& value,
 }
 
 
+Status SyncEtcdClient::UpdateWithTTL(const string& key, const string& value,
+                                     const std::chrono::duration<int>& ttl,
+                                     const int previous_index,
+                                     int* new_index) {
+  return BlockingCall(base_, bind(&EtcdClient::UpdateWithTTL, client_.get(),
+                                  key, value, ttl, previous_index, _1),
+                      new_index);
+}
+
+
 Status SyncEtcdClient::ForceSet(const string& key, const string& value,
                                 int* new_index) {
   return BlockingCall(base_, bind(&EtcdClient::ForceSet, client_.get(), key,
                                   value, _1),
+                      new_index);
+}
+
+
+Status SyncEtcdClient::ForceSetWithTTL(const string& key, const string& value,
+                                       const std::chrono::duration<int>& ttl,
+                                       int* new_index) {
+  return BlockingCall(base_, bind(&EtcdClient::ForceSetWithTTL, client_.get(),
+                                  key, value, ttl, _1),
                       new_index);
 }
 

--- a/cpp/util/sync_etcd.h
+++ b/cpp/util/sync_etcd.h
@@ -1,10 +1,11 @@
 #ifndef CERT_TRANS_UTIL_SYNC_ETCD_H_
 #define CERT_TRANS_UTIL_SYNC_ETCD_H_
 
-#include <vector>
+#include <chrono>
 #include <memory>
 #include <stdint.h>
 #include <string>
+#include <vector>
 
 #include "base/macros.h"
 #include "util/etcd.h"
@@ -37,6 +38,11 @@ class SyncEtcdClient {
   virtual util::Status Create(const std::string& key, const std::string& value,
                               int* index);
 
+  virtual util::Status CreateWithTTL(const std::string& key,
+                                     const std::string& value,
+                                     const std::chrono::duration<int>& ttl,
+                                     int* index);
+
   virtual util::Status CreateInQueue(const std::string& dir,
                                      const std::string& value,
                                      std::string* key, int* index);
@@ -44,8 +50,18 @@ class SyncEtcdClient {
   virtual util::Status Update(const std::string& key, const std::string& value,
                               const int previous_index, int* new_index);
 
+  virtual util::Status UpdateWithTTL(const std::string& key,
+                                     const std::string& value,
+                                     const std::chrono::duration<int>& ttl,
+                                     const int previous_index, int* new_index);
+
   virtual util::Status ForceSet(const std::string& key,
                                 const std::string& value, int* new_index);
+
+  virtual util::Status ForceSetWithTTL(const std::string& key,
+                                       const std::string& value,
+                                       const std::chrono::duration<int>& ttl,
+                                       int* new_index);
 
   virtual util::Status Delete(const std::string& key, const int current_index);
 


### PR DESCRIPTION
We'll need to have some calls which support setting TTL on certain entries in etcd.
They're broken out from the other non-TTL calls (i.e. rather than adding a [defaulted] parameter) because accidentally setting an entry to have a TTL would be potentially Rather Bad™.
