### PR TITLE
Changed cert_db to use Certificates and log_ids.

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -9,7 +9,6 @@ ct/proto/ct_pb2.py: ../proto/ct.proto
 
 # TODO(laiqu) use unittest ability to detect tests
 test: all
-	PYTHONPATH=$(PYTHONPATH):. ./ct/client/sqlite_log_db_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/crypto/verify_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/crypto/merkle_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/crypto/pem_test.py
@@ -19,10 +18,11 @@ test: all
 	PYTHONPATH=$(PYTHONPATH):. ./ct/crypto/asn1/oid_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/crypto/asn1/x509_time_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/crypto/cert_test.py
+	PYTHONPATH=$(PYTHONPATH):. ./ct/client/sqlite_log_db_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/client/sqlite_cert_db_test.py
+	PYTHONPATH=$(PYTHONPATH):. ./ct/client/sqlite_temp_db_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/client/sqlite_connection_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/client/log_client_test.py
-	PYTHONPATH=$(PYTHONPATH):. ./ct/client/sqlite_temp_db_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/client/reporter_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/client/state_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/client/tls_message_test.py

--- a/python/ct/client/cert_db.py
+++ b/python/ct/client/cert_db.py
@@ -1,6 +1,7 @@
 import abc
 import hashlib
 
+
 class CertDB(object):
     """Database interface for storing X509 certificate information."""
     __metaclass__ = abc.ABCMeta
@@ -10,18 +11,23 @@ class CertDB(object):
         return hashlib.sha256(der_cert).digest()
 
     @abc.abstractmethod
-    def store_cert(self, der_cert, subject_names):
-        """Store a certificate.
+    def store_cert_desc(self, cert_desc, index, log_key):
+        """Stores a certificate using its description.
+
         Args:
-            der_cert:      the DER-encoded certificate
-            subject_names: an iterable of subject names, used to create a search
-                           index."""
+            cert:          CertificateDescription
+            index:         position in log
+            log_key:       log id in LogDB"""
 
     @abc.abstractmethod
-    def store_certs(self, certs):
-        """Batch store certificates.
+    def store_certs_desc(self, certs, log_key):
+        """Store certificates using its descriptions.
+
+        Batched version of store_cert_desc.
+
         Args:
-            certs:         an iterable of (der_cert, subject_names) tuples."""
+            certs:         iterable of (CertificateDescription, index) tuples
+            log_key:       log id in LogDB"""
 
     @abc.abstractmethod
     def get_cert_by_sha256_hash(self, cert_sha256_hash):

--- a/python/ct/client/cert_desc.py
+++ b/python/ct/client/cert_desc.py
@@ -1,0 +1,66 @@
+import re
+from ct.crypto import cert
+
+class CertificateDescription(object):
+    """Container for fields in certificate that CertDB is supposed to store."""
+    def __init__(self):
+        """Returns empty object with all fields set to None"""
+        self.der = None
+        self.subject_common_names = None
+
+    @classmethod
+    def from_cert(cls, certificate):
+        """Pulls out interesting fields from certificate, so format of data will
+        be similar in every database implementation."""
+        der = certificate.to_der()
+        try:
+            subject_common_names = [sub.value
+                                    for sub in
+                                    certificate.subject_common_names()]
+        except cert.CertificateError:
+            subject_common_names = []
+
+        return cls.from_values(der,
+                               subject_common_names)
+
+    @staticmethod
+    def from_values(der=None, subject_common_names=None):
+        """Creates CertificateDescription from provided fields.
+
+        Without this method there is no easy way of creating description for
+        unparsable certificate. Values provided are still processed like they
+        would be if pulled from certificate."""
+        desc = CertificateDescription()
+        if der:
+            desc.der = der
+        if subject_common_names:
+            desc.subject_common_names = [u".".join(process_name(
+                                            unicode(sub, 'utf-8', 'replace')))
+                                         for sub in subject_common_names]
+        return desc
+
+def process_name(subject, reverse=True):
+    # RFCs for DNS names: RFC 1034 (sect. 3.5), RFC 1123 (sect. 2.1);
+    # for common names: RFC 5280.
+    # However we probably do not care about full RFC compliance here
+    # (e.g. we ignore that a compliant label cannot begin with a hyphen,
+    # we accept multi-wildcard names, etc.).
+    #
+    # For now, make indexing work for the common case:
+    # allow letter-digit-hyphen, as well as wildcards (RFC 2818).
+    forbidden = re.compile(r"[^a-z\d\-\*]")
+    subject = subject.lower()
+    labels = subject.split(".")
+    valid = all(map(lambda x: len(x) and not forbidden.search(x), labels))
+
+    if valid:
+        # ["com", "example", "*"], ["com", "example", "mail"],
+        # ["localhost"], etc.
+        return list(reversed(labels)) if reverse else labels
+
+    else:
+        # ["john smith"], ["trustworthy certificate authority"],
+        # ["google.com\x00"], etc.
+        # TODO(ekasper): figure out what to do (use stringprep as specified
+        # by RFC 5280?) to properly handle non-letter-digit-hyphen names.
+        return [subject]

--- a/python/ct/client/sqlite_connection_test.py
+++ b/python/ct/client/sqlite_connection_test.py
@@ -3,8 +3,7 @@
 import sqlite3
 import unittest
 
-from ct.client import database
-from  ct.client import sqlite_connection as sqlitecon
+from ct.client import sqlite_connection as sqlitecon
 
 class SQLiteConnectionTest(unittest.TestCase):
     def test_connection_works(self):

--- a/python/ct/dashboard/dashboard.py
+++ b/python/ct/dashboard/dashboard.py
@@ -8,10 +8,10 @@ import time
 from wsgiref import simple_server
 
 from ct.dashboard import grapher
-from ct.client import sqlite_connection as sqlitecon
+from ct.client.db import sqlite_connection as sqlitecon
 from ct.client import prober
-from ct.client import sqlite_log_db
-from ct.client import sqlite_temp_db
+from ct.client.db import sqlite_log_db
+from ct.client.db import sqlite_temp_db
 from ct.proto import client_pb2
 
 

--- a/python/utilities/logobserver/logobserver.py
+++ b/python/utilities/logobserver/logobserver.py
@@ -7,10 +7,10 @@ import sys
 import requests
 
 from ct.cert_analysis import tld_list
-from ct.client import sqlite_connection as sqlitecon
+from ct.client.db import sqlite_connection as sqlitecon
 from ct.client import prober
-from ct.client import sqlite_log_db
-from ct.client import sqlite_temp_db
+from ct.client.db import sqlite_log_db
+from ct.client.db import sqlite_temp_db
 from ct.proto import client_pb2
 
 FLAGS = gflags.FLAGS


### PR DESCRIPTION
I think it's nicer if cert_db itself pulls subject names etc. from the certificate, so I changed it to use cert.Certificate. Also it should be more convenient if id in database were the same as certificate index in log.
