### PR TITLE
Storing entries no longer break client.

### DIFF
--- a/python/ct/client/async_log_client_test.py
+++ b/python/ct/client/async_log_client_test.py
@@ -336,7 +336,9 @@ class AsyncLogClientTest(unittest.TestCase):
                 return_value=test_util.make_entries(10, 19))
         client = self.default_client(entries_db=fake_db)
         consumer = self.get_entries(client, 0, 9)
-        test_util.verify_entries(consumer.received, 10, 19)
+        self.assertEqual(len(consumer.received), 10)
+        for i in range(0, 9):
+            self.assertEqual(test_util.make_entry(i + 10), consumer.received[i])
 
     def test_get_entries_tries_to_fetch_if_not_available_in_db(self):
         fake_db = self.FakeDB()

--- a/python/ct/client/log_client.py
+++ b/python/ct/client/log_client.py
@@ -646,6 +646,10 @@ class EntryProducer(object):
             if self._entries_db and FLAGS.persist_entries:
                 request.addCallback(self._store_batch, first)
             entries = request
+        else:
+            deferred_entries = defer.Deferred()
+            deferred_entries.callback(entries)
+            entries = deferred_entries
         return entries
 
     def _create_next_request(self, first, last, entries, retries):


### PR DESCRIPTION
_fetch_parsed_entries is supposed to return Deferred. 
