### PR TITLE
Added get_extensions method.

### DIFF
--- a/python/ct/crypto/cert.py
+++ b/python/ct/crypto/cert.py
@@ -189,6 +189,14 @@ class Certificate(object):
     def is_identical_to(self, other_cert):
         return self.to_der() == other_cert.to_der()
 
+    def get_extensions(self):
+        """Get all extensions.
+
+        Returns:
+            a list of extensions.
+        """
+        return self._asn1_cert["tbsCertificate"]["extensions"] or []
+
     def version(self):
         """Get the version.
 

--- a/python/ct/crypto/cert_test.py
+++ b/python/ct/crypto/cert_test.py
@@ -695,6 +695,20 @@ class CertificateTest(unittest.TestCase):
         c = self.cert_from_pem_file(self._PEM_FILE)
         self.assertItemsEqual([], c.ocsp_responders())
 
+    def test_get_extensions(self):
+        c = self.cert_from_pem_file(self._PEM_AIA)
+        extensions = c.get_extensions()
+        extensions_oids = [extension['extnID'] for extension in extensions]
+        self.assertItemsEqual((oid.ID_CE_EXT_KEY_USAGE,
+                               oid.ID_CE_SUBJECT_ALT_NAME,
+                               oid.ID_PE_AUTHORITY_INFO_ACCESS,
+                               oid.ID_CE_SUBJECT_KEY_IDENTIFIER,
+                               oid.ID_CE_BASIC_CONSTRAINTS,
+                               oid.ID_CE_AUTHORITY_KEY_IDENTIFIER,
+                               oid.ID_CE_CERTIFICATE_POLICIES,
+                               oid.ID_CE_CRL_DISTRIBUTION_POINTS),
+                              extensions_oids)
+
     def test_indefinite_encoding(self):
         self.assertRaises(error.ASN1Error, self.cert_from_pem_file,
                           self._PEM_INDEFINITE_LENGTH)


### PR DESCRIPTION
We need a way to check if extension is critical or not, which is not currently possible. I'm not sure whether I should just simply create get_extensions (so it might be useful later, and I feel like there should be a way to get extension itself), or create more specific method for criticality.
