### PR TITLE
Send params on the URL for DELETEs

### DIFF
--- a/cpp/util/etcd.cc
+++ b/cpp/util/etcd.cc
@@ -410,14 +410,14 @@ struct EtcdClient::Request {
             bind(&EtcdClient::RequestDone, client_, _1, this)));
 
     string uri(path_);
-    if (verb_ == EVHTTP_REQ_GET) {
-      uri += "?" + params_;
-    } else {
+    if (verb_ == EVHTTP_REQ_PUT || verb_ == EVHTTP_REQ_POST) {
       evhttp_add_header(req->GetOutputHeaders(), "Content-Type",
                         "application/x-www-form-urlencoded");
       CHECK_EQ(evbuffer_add(req->GetOutputBuffer(), params_.data(),
                             params_.size()),
                0);
+    } else {
+      uri += "?" + params_;
     }
 
     {


### PR DESCRIPTION
This is the root of all\* the weird issues with etcd today - DELETE was trying to send params in the body of the request, and since etcd wasn't expecting to have to read a body they were being munged into the method of the following request which the Gorilla MUX, used by etcd internally, helpfully hid by returning a 404 rather than logging the fact that garbage was coming in.
