### PR TITLE
Create an PeriodicClosure class.

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -121,7 +121,8 @@ util_tests: util/json_wrapper_test util/etcd_test util/sync_etcd_test util/fake_
 ### util/ targets
 util/libutil.a: util/util.o util/openssl_util.o util/testing.o \
                 util/json_wrapper.o util/thread_pool.o util/libevent_wrapper.o \
-                util/etcd.o util/status.o util/sync_etcd.o util/fake_etcd.o
+                util/etcd.o util/status.o util/sync_etcd.o util/fake_etcd.o \
+                util/periodic_closure.o
 	rm -f $@
 	ar -rcs $@ $^
 

--- a/cpp/util/periodic_closure.cc
+++ b/cpp/util/periodic_closure.cc
@@ -1,0 +1,41 @@
+#include "util/periodic_closure.h"
+
+#include <functional>
+#include <glog/logging.h>
+
+using std::bind;
+using std::chrono::duration_cast;
+using std::function;
+using std::shared_ptr;
+
+namespace cert_trans {
+
+
+PeriodicClosure::PeriodicClosure(const shared_ptr<libevent::Base>& base,
+                                 const std::chrono::duration<double>& period,
+                                 const function<void()>& closure)
+    : base_(base),
+      period_(duration_cast<clock::duration>(period)),
+      closure_(closure),
+      event_(*base_, -1, 0, bind(&PeriodicClosure::Run, this)),
+      target_run_time_(clock::now() + period_) {
+  LOG_IF(WARNING, !clock::is_steady)
+      << "clock used for PeriodicClosure is not steady";
+
+  event_.Add(target_run_time_ - clock::now());
+}
+
+
+void PeriodicClosure::Run() {
+  closure_();
+
+  const clock::time_point now(clock::now());
+  while (target_run_time_ <= now) {
+    target_run_time_ += period_;
+  }
+
+  event_.Add(target_run_time_ - now);
+}
+
+
+}  // namespace cert_trans

--- a/cpp/util/periodic_closure.h
+++ b/cpp/util/periodic_closure.h
@@ -1,0 +1,45 @@
+#ifndef CERT_TRANS_UTIL_PERIODIC_CLOSURE_H_
+#define CERT_TRANS_UTIL_PERIODIC_CLOSURE_H_
+
+#include <chrono>
+#include <functional>
+#include <memory>
+
+#include "base/macros.h"
+#include "util/libevent_wrapper.h"
+
+namespace cert_trans {
+
+
+// Arranges for "closure" to be called every "period". If "closure"
+// runs for too long, it will skip to the next period that is in the
+// future.
+//
+// This object should always be destroyed either from a libevent
+// callback, or while the libevent dispatcher is not running. It
+// should also NOT be destroyed from within "closure".
+class PeriodicClosure {
+ public:
+  PeriodicClosure(const std::shared_ptr<libevent::Base>& base,
+                  const std::chrono::duration<double>& period,
+                  const std::function<void()>& closure);
+
+ private:
+  typedef std::chrono::steady_clock clock;
+
+  void Run();
+
+  const std::shared_ptr<libevent::Base> base_;
+  const clock::duration period_;
+  const std::function<void()> closure_;
+
+  libevent::Event event_;
+  clock::time_point target_run_time_;
+
+  DISALLOW_COPY_AND_ASSIGN(PeriodicClosure);
+};
+
+
+}  // namespace cert_trans
+
+#endif  // CERT_TRANS_UTIL_PERIODIC_CLOSURE_H_


### PR DESCRIPTION
Some improvements over the existing class, but at the same time, some of its issues (at destruction time) have not been fixed, only better documented.

One important thing you usually want to know when destroying this object is whether the closure will be called again. To support destruction from arbitrary threads, it would be easy to make the destructor block until the closure returns, but it would still not allow destroying the object from within the closure.

Since supporting destruction from arbitrary threads would be kind of complicated, and I'm not sure if @AlCutter even needs it, I figured I'd [YAGNI](http://en.wikipedia.org/wiki/You_aren%27t_gonna_need_it) it. I have a much better idea that will support stopping it from other threads **and** from the closure, but it requires some more support code, so I figured I'd put this out first, since it was easy (and might be enough to unblock @AlCutter!).
