### PR TITLE
Improve the interface of ReadPrivateKey.

### DIFF
--- a/cpp/server/ct-server.cc
+++ b/cpp/server/ct-server.cc
@@ -68,7 +68,7 @@ using cert_trans::LoggedCertificate;
 using cert_trans::PeriodicClosure;
 using cert_trans::ThreadPool;
 using cert_trans::TreeSigner;
-using cert_trans::util::ReadPrivateKey;
+using cert_trans::ReadPrivateKey;
 using google::RegisterFlagValidator;
 using std::bind;
 using std::chrono::duration;
@@ -158,9 +158,9 @@ int main(int argc, char* argv[]) {
   ERR_load_crypto_strings();
   cert_trans::LoadCtExtensions();
 
-  EVP_PKEY* pkey = NULL;
-  CHECK_EQ(ReadPrivateKey(&pkey, FLAGS_key), cert_trans::util::KEY_OK);
-  LogSigner log_signer(pkey);
+  util::StatusOr<EVP_PKEY*> pkey(ReadPrivateKey(FLAGS_key));
+  CHECK_EQ(pkey.status(), util::Status::OK);
+  LogSigner log_signer(pkey.ValueOrDie());
 
   CertChecker checker;
   CHECK(checker.LoadTrustedCertificates(FLAGS_trusted_cert_file))

--- a/cpp/util/read_private_key.cc
+++ b/cpp/util/read_private_key.cc
@@ -1,28 +1,41 @@
 #include "util/read_private_key.h"
 
+#include <memory>
 #include <openssl/pem.h>
 
+using std::unique_ptr;
+
 namespace cert_trans {
-namespace util {
+
+namespace {
 
 
-KeyError ReadPrivateKey(EVP_PKEY** pkey, const std::string& file) {
-  FILE* fp = fopen(file.c_str(), "r");
+void FileCloser(FILE* fp) {
+  if (fp) {
+    fclose(fp);
+  }
+}
 
-  if (!fp)
-    return NO_SUCH_FILE;
+
+}  // namespace
+
+
+util::StatusOr<EVP_PKEY*> ReadPrivateKey(const std::string& file) {
+  unique_ptr<FILE, void (*)(FILE*)> fp(fopen(file.c_str(), "r"), FileCloser);
+
+  if (!fp) {
+    return util::Status(util::error::NOT_FOUND, "key file not found: " + file);
+  }
 
   // No password.
-  PEM_read_PrivateKey(fp, pkey, NULL, NULL);
-  KeyError retval(KEY_OK);
-  if (!*pkey)
-    retval = INVALID_KEY;
-
-  fclose(fp);
+  EVP_PKEY* retval(nullptr);
+  PEM_read_PrivateKey(fp.get(), &retval, nullptr, nullptr);
+  if (!retval)
+    return util::Status(util::error::FAILED_PRECONDITION,
+                        "invalid key: " + file);
 
   return retval;
 }
 
 
-}  // namespace util
 }  // namespace cert_trans

--- a/cpp/util/read_private_key.h
+++ b/cpp/util/read_private_key.h
@@ -4,20 +4,14 @@
 #include <openssl/evp.h>
 #include <string>
 
+#include "util/statusor.h"
+
 namespace cert_trans {
-namespace util {
 
 
-enum KeyError {
-  KEY_OK,
-  NO_SUCH_FILE,
-  INVALID_KEY,
-};
-
-KeyError ReadPrivateKey(EVP_PKEY** pkey, const std::string& file);
+util::StatusOr<EVP_PKEY*> ReadPrivateKey(const std::string& file);
 
 
-}  // namespace util
 }  // namespace cert_trans
 
 #endif  // CERT_TRANS_UTIL_READ_PRIVATE_KEY_H_


### PR DESCRIPTION
What I was _really_ after was getting rid of the `util` sub-namespace, as it was hindering another change (well, making slightly ugly), then there was the enum values just "floating" about in the `cert_trans` namespace, which I didn't like much, and I remember wishing for `unique_ptr`, so I just went for it. :stuck_out_tongue: 
