### PR TITLE
TLD checks for common names and dnsnames.

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -29,6 +29,7 @@ test: all
 	PYTHONPATH=$(PYTHONPATH):. ./ct/cert_analysis/algorithm_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/cert_analysis/ca_field_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/cert_analysis/dnsnames_test.py
+	PYTHONPATH=$(PYTHONPATH):. ./ct/cert_analysis/common_name_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/cert_analysis/ip_addresses_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/cert_analysis/serial_number_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/cert_analysis/validity_test.py

--- a/python/ct/cert_analysis/all_checks.py
+++ b/python/ct/cert_analysis/all_checks.py
@@ -1,11 +1,12 @@
-from ct.cert_analysis import serial_number
-from ct.cert_analysis import validity
-from ct.cert_analysis import dnsnames
-from ct.cert_analysis import ip_addresses
 from ct.cert_analysis import algorithm
 from ct.cert_analysis import ca_field
-from ct.cert_analysis import ocsp_pointers
+from ct.cert_analysis import common_name
 from ct.cert_analysis import crl_pointers
+from ct.cert_analysis import dnsnames
+from ct.cert_analysis import ip_addresses
+from ct.cert_analysis import ocsp_pointers
+from ct.cert_analysis import serial_number
+from ct.cert_analysis import validity
 
 ALL_CHECKS = [serial_number.CheckNegativeSerialNumber(),
               validity.CheckValidityNotBeforeFuture(),
@@ -13,6 +14,10 @@ ALL_CHECKS = [serial_number.CheckNegativeSerialNumber(),
               validity.CheckIsExpirationDateWellDefined(),
               dnsnames.CheckValidityOfDnsnames(),
               dnsnames.CheckCorruptSANExtension(),
+              dnsnames.CheckTldMatches(),
+              common_name.CheckSCNTldMatches(),
+              common_name.CheckLackOfSubjectCommonName(),
+              common_name.CheckCorruptSubjectCommonName(),
               ip_addresses.CheckPrivateIpAddresses(),
               ip_addresses.CheckCorruptIpAddresses(),
               algorithm.CheckSignatureAlgorithmsMismatch(),

--- a/python/ct/cert_analysis/common_name.py
+++ b/python/ct/cert_analysis/common_name.py
@@ -1,0 +1,92 @@
+from ct.cert_analysis.observation import Observation
+from ct.cert_analysis import tld_check
+from ct.crypto import cert
+
+
+class CommonNameObservation(Observation):
+    def __init__(self, description, *args, **kwargs):
+        super(CommonNameObservation, self).__init__("Subject common name: " +
+                                                    description, *args, **kwargs)
+
+class NoSubjectCommonName(CommonNameObservation):
+    def __init__(self):
+        super(NoSubjectCommonName, self).__init__("no subject common name")
+
+
+class TldMatchesBothUnicodeAndIdna(CommonNameObservation):
+    def __init__(self, *args, **kwargs):
+        super(TldMatchesBothUnicodeAndIdna, self).__init__("unicode and idna"
+                "encoding of address matches different top level domain names",
+                                                           *args, **kwargs)
+
+
+class NoTldMatch(CommonNameObservation):
+    def __init__(self, *args, **kwargs):
+        super(NoTldMatch, self).__init__(
+                "no top level domain matches", *args, **kwargs)
+
+
+class NotAnAddress(CommonNameObservation):
+    def __init__(self, *args, **kwargs):
+        super(NotAnAddress, self).__init__("not an address", *args, **kwargs)
+
+
+class NonUnicodeAddress(CommonNameObservation):
+    def __init__(self, *args, **kwargs):
+        super(NonUnicodeAddress, self).__init__("non unicode address", *args,
+                                                **kwargs)
+
+
+class GenericWildcard(CommonNameObservation):
+    def __init__(self, *args, **kwargs):
+        super(GenericWildcard, self).__init__("name wildcard matches top level "
+                                              "domain name", *args, **kwargs)
+
+
+class CorruptSubjectCommonNames(CommonNameObservation):
+    def __init__(self):
+        super(CorruptSubjectCommonNames, self).__init__("corrupt")
+
+
+class CheckCorruptSubjectCommonName(object):
+    """Check if CN attribute is corrupt.
+
+    Returns:
+        array containing CorruptSubjectCommonNames or None"""
+    @staticmethod
+    def check(certificate):
+        try:
+            certificate.subject_common_names()
+        except cert.CertificateError:
+            return [CorruptSubjectCommonNames()]
+
+
+class CheckLackOfSubjectCommonName(object):
+    """Checks existence of subject common names.
+
+    Returns:
+        array containing NoSubjectCommonName"""
+    @staticmethod
+    def check(certificate):
+        try:
+            if len(certificate.subject_common_names()) == 0:
+               return [NoSubjectCommonName()]
+        except cert.CertificateError:
+            pass
+
+
+class CheckSCNTldMatches(object):
+    """"Check whether common names matches some top level domain name.
+
+    This will also return NoTldMatch if common name is not an address.
+    Returns:
+        array containing TldMatchesBothUnicodeAndIdna, NoTldMatch,
+        GenericWildcard or None"""
+    @classmethod
+    def check(cls, certificate):
+        try:
+            return tld_check.CheckTldMatches.check(
+                    certificate.subject_common_names(), "Subject common name: ")
+        except cert.CertificateError:
+            pass
+

--- a/python/ct/cert_analysis/common_name_test.py
+++ b/python/ct/cert_analysis/common_name_test.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+# coding=utf-8
+import unittest
+import mock
+from ct.cert_analysis import base_check_test
+from ct.cert_analysis import common_name
+from ct.cert_analysis import tld_check
+from ct.cert_analysis import tld_list
+from ct.crypto import cert
+
+def gen_common_name(name):
+    common_name = mock.Mock()
+    common_name.value = name
+    return common_name
+
+def cert_with_urls(*args):
+    certificate = mock.MagicMock()
+    certificate.subject_common_names = mock.Mock(return_value=list(args))
+    return certificate
+
+tlds = tld_list.TLDList(tld_dir="ct/cert_analysis/test_data/",
+                        tld_file_name="test_tld_list")
+
+EXAMPLE = gen_common_name("example.com")
+NOT_TLD = gen_common_name("asdf.asdf")
+CA_NAME = gen_common_name("Trusty CA Ltd.")
+WILDCARD_TLD = gen_common_name("*.com")
+NON_UNICODE_TLD = gen_common_name("\xff\x00.com")
+
+class CommonNameTest(base_check_test.BaseCheckTest):
+    def setUp(self):
+        tld_check.CheckTldMatches.TLD_LIST = tld_list.TLDList(
+                tld_dir="ct/cert_analysis/test_data/",
+                tld_file_name="test_tld_list")
+
+    def test_common_name_tld_match(self):
+        certificate = cert_with_urls(EXAMPLE)
+        check = common_name.CheckSCNTldMatches()
+        result = check.check(certificate)
+        self.assertEqual(len(result), 0)
+
+    def test_common_name_no_tld_match(self):
+        certificate = cert_with_urls(NOT_TLD)
+        check = common_name.CheckSCNTldMatches()
+        result = check.check(certificate)
+        self.assertIn(common_name.NoTldMatch().description, ''.join([
+                obs.description for obs in result]))
+
+    def test_common_name_actual_ca_name(self):
+        certificate = cert_with_urls(CA_NAME)
+        check = common_name.CheckSCNTldMatches()
+        result = check.check(certificate)
+        self.assertIn(common_name.NotAnAddress().description,
+                      ''.join([obs.description for obs in result]))
+
+    def test_common_name_wildcard_tld_match(self):
+        certificate = cert_with_urls(WILDCARD_TLD)
+        check = common_name.CheckSCNTldMatches()
+        result = check.check(certificate)
+        self.assertIn(common_name.GenericWildcard().description, ''.join([
+                obs.description for obs in result]))
+
+    def test_common_name_corrupt(self):
+        certificate = mock.MagicMock()
+        certificate.subject_common_names = mock.Mock(
+                side_effect=cert.CertificateError("Boom!"))
+        check = common_name.CheckCorruptSubjectCommonName()
+        result = check.check(certificate)
+        self.assertObservationIn(common_name.CorruptSubjectCommonNames(),
+                                 result)
+
+    def test_lack_of_subject_common_name(self):
+        certificate = mock.MagicMock()
+        certificate.subject_common_names = mock.Mock(return_value=[])
+        check = common_name.CheckLackOfSubjectCommonName()
+        result = check.check(certificate)
+        self.assertObservationIn(common_name.NoSubjectCommonName(),
+                                 result)
+
+    def test_common_name_non_unicode_tld_match(self):
+        certificate = cert_with_urls(NON_UNICODE_TLD)
+        check = common_name.CheckSCNTldMatches()
+        result = check.check(certificate)
+        self.assertIn(common_name.NonUnicodeAddress().description,
+                      ''.join([obs.description for obs in result]))
+        self.assertEqual(len(result), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/ct/cert_analysis/dnsnames.py
+++ b/python/ct/cert_analysis/dnsnames.py
@@ -1,6 +1,7 @@
 from ct.crypto import cert
 import re
 from ct.cert_analysis.observation import Observation
+from ct.cert_analysis import tld_check
 
 class DNSNamesObservation(Observation):
     def __init__(self, description, *args, **kwargs):
@@ -17,6 +18,39 @@ class InvalidCharacter(DNSNamesObservation):
 class CorruptSANExtension(DNSNamesObservation):
     def __init__(self):
         super(CorruptSANExtension, self).__init__("corrupt extension")
+
+
+
+class TldMatchesBothUnicodeAndIdna(DNSNamesObservation):
+    def __init__(self, *args, **kwargs):
+        super(DNSNamesObservation, self).__init__("unicode and idna encoding"
+              "of address matches different top level domain names", *args,
+                                                  **kwargs)
+
+
+class NoTldMatch(DNSNamesObservation):
+    def __init__(self, *args, **kwargs):
+        super(NoTldMatch, self).__init__("no top level domain matches", *args,
+                                         **kwargs)
+
+
+class NonUnicodeAddress(DNSNamesObservation):
+    def __init__(self, *args, **kwargs):
+        super(NonUnicodeAddress, self).__init__("non unicode address", *args,
+                                                **kwargs)
+
+
+class NotAnAddress(DNSNamesObservation):
+    def __init__(self, *args, **kwargs):
+        super(NotAnAddress, self).__init__("not an address", *args,
+                                           **kwargs)
+
+
+class GenericWildcard(DNSNamesObservation):
+    def __init__(self, *args, **kwargs):
+        super(GenericWildcard, self).__init__(
+                "name wildcard matches top level domain name", *args,
+                **kwargs)
 
 
 class CheckValidityOfDnsnames(object):
@@ -60,6 +94,22 @@ class CheckValidityOfDnsnames(object):
         except cert.CertificateError:
             pass
         return observations
+
+
+class CheckTldMatches(object):
+    """Checks whether dNSNames matches some top level domain name.
+
+    Returns:
+        array containing TldMatchesBothUnicodeAndIdna, NoTldMatch,
+        GenericWildcard or None"""
+    @classmethod
+    def check(cls, certificate):
+        try:
+            return tld_check.CheckTldMatches.check(
+                    certificate.subject_dns_names(),
+                    "dNSNames: ")
+        except cert.CertificateError:
+            pass
 
 class CheckCorruptSANExtension(object):
     """Checks whether SAN extension is corrupt.

--- a/python/ct/cert_analysis/tld_check.py
+++ b/python/ct/cert_analysis/tld_check.py
@@ -1,0 +1,78 @@
+from ct.cert_analysis.observation import Observation
+from ct.cert_analysis import tld_list
+
+class TldCheckObservation(Observation):
+    def __init__(self, description, prefix=None, *args, **kwargs):
+        super(TldCheckObservation, self).__init__(
+                ("Top level domain: " if not prefix else prefix) + description,
+                *args, **kwargs)
+
+class TldMatchesBothUnicodeAndIdna(TldCheckObservation):
+    def __init__(self, *args, **kwargs):
+        super(TldMatchesBothUnicodeAndIdna, self).__init__("unicode and idna"
+                "encoding of address matches different top level domain names",
+                                                           *args, **kwargs)
+
+
+class NoTldMatch(TldCheckObservation):
+    def __init__(self, *args, **kwargs):
+        super(NoTldMatch, self).__init__(
+                "no top level domain matches", *args, **kwargs)
+
+
+class NotAnAddress(TldCheckObservation):
+    def __init__(self, *args, **kwargs):
+        super(NotAnAddress, self).__init__("not an address", *args, **kwargs)
+
+
+class NonUnicodeAddress(TldCheckObservation):
+    def __init__(self, *args, **kwargs):
+        super(NonUnicodeAddress, self).__init__("non unicode address", *args,
+                                                **kwargs)
+
+
+class GenericWildcard(TldCheckObservation):
+    def __init__(self, *args, **kwargs):
+        super(GenericWildcard, self).__init__("name wildcard matches top level "
+                                              "domain name", *args, **kwargs)
+
+
+class CheckTldMatches(object):
+    TLD_LIST = tld_list.TLDList()
+    @classmethod
+    def check(cls, names, prefix=None):
+        # This check is different from others, because it's supposed to be used
+        # by other checks (common_name and dnsnames). The code for this check
+        # would be the same in common_name and dnsnames, but resulting
+        # observations should have different descriptions. This check still can
+        # live on it's own if list of addresses is passed instead of
+        # certificate. If prefix is provided, it's attached to descriptions of
+        # observations.
+        observations = []
+        for name in names:
+            name = name.value
+            try:
+                tld_match, idna_match, unicode_fail = (
+                        cls.TLD_LIST.match_certificate_name(name))
+            except ValueError:
+                observations += [NotAnAddress(details=name, prefix=prefix)]
+                continue
+            if unicode_fail:
+                observations += [NonUnicodeAddress(details=name, prefix=prefix)]
+            if tld_match and idna_match and tld_match != idna_match:
+                observations += [TldMatchesBothUnicodeAndIdna(
+                                    details=(name, tld_match, idna_match),
+                                    prefix=prefix)]
+            if not (tld_match or idna_match):
+                observations += [NoTldMatch(details=(name), prefix=prefix)]
+            # Check for generic wildcard
+            if name.startswith('*.'):
+                name_without_wildcard = name[2:]
+                tld_match, idna_match, _ = cls.TLD_LIST.match_certificate_name(
+                        name_without_wildcard)
+                if (tld_match == name_without_wildcard or
+                    idna_match == name_without_wildcard):
+                    observations += [GenericWildcard(details=(name,
+                                    tld_match if tld_match else idna_match),
+                                                     prefix=prefix)]
+        return observations

--- a/python/ct/cert_analysis/tld_list.py
+++ b/python/ct/cert_analysis/tld_list.py
@@ -1,5 +1,6 @@
 import gflags
 import logging
+import re
 
 FLAGS = gflags.FLAGS
 
@@ -8,34 +9,39 @@ gflags.DEFINE_string("tld_list_dir", "/tmp", "Stores top level domains list,"
 
 TLD_LIST_ADDR = "https://publicsuffix.org/list/effective_tld_names.dat"
 
+
 class TLDList(object):
     """Contains list of top-level domains"""
+    NOT_ADDRESS_REGEX = re.compile('[^a-z0-9\-.*]')
     def __init__(self, tld_dir=FLAGS.tld_list_dir, tld_file_name="tld_list"):
         tld_file = '/'.join((tld_dir, tld_file_name))
         try:
             with open(tld_file, 'r') as f:
                 raw_list = f.read()
         except IOError:
-            logging.warning("Couldn't open file with top level domains")
-        lines = unicode(raw_list, 'utf-8').splitlines()
-        lines = lines[0:lines.index('// ===END ICANN DOMAINS===')]
-        lines = filter(
-            lambda line: not line.startswith('//') and not len(line) == 0,
-            lines)
-        lines = [line.split('.') for line in lines]
-        self.tld_tree = {}
-        for tld in lines:
-            sub_tree = self.tld_tree
-            for part in reversed(tld):
-                if part.startswith('*'):
-                   sub_tree['*'] = []
-                elif part.startswith('!'):
-                    sub_tree['*'].append(part[1:])
-                elif part not in sub_tree:
-                    sub_tree[part] = {}
-                    sub_tree = sub_tree[part]
-                else:
-                    sub_tree = sub_tree[part]
+            logging.warning("Couldn't open file with top level domains, "
+                            "all matches will fail.")
+            self.tld_tree = {}
+        else:
+            lines = unicode(raw_list, 'utf-8').splitlines()
+            lines = lines[0:lines.index('// ===END ICANN DOMAINS===')]
+            lines = filter(
+                lambda line: not line.startswith('//') and not len(line) == 0,
+                lines)
+            lines = [line.split('.') for line in lines]
+            self.tld_tree = {}
+            for tld in lines:
+                sub_tree = self.tld_tree
+                for part in reversed(tld):
+                    if part.startswith('*'):
+                       sub_tree['*'] = []
+                    elif part.startswith('!'):
+                        sub_tree['*'].append(part[1:])
+                    elif part not in sub_tree:
+                        sub_tree[part] = {}
+                        sub_tree = sub_tree[part]
+                    else:
+                        sub_tree = sub_tree[part]
 
     def match(self, address):
         """Matches address to the list.
@@ -73,3 +79,38 @@ class TLDList(object):
             return self.match(idna)
         except:
             return None
+
+    def match_certificate_name(self, name):
+        """Returns both match and match_idna result for given address from cert.
+        Also if name fails to be encoded as utf-8 third value in tuple will
+        indicate that.
+        Returns:
+            tuple containing result from match and match_idna and boolean which
+            indicates whether name successfully encoded in unicode.
+
+        Raises:
+            ValueError if name is not an address"""
+        uni_fail = False
+        try:
+            uni_name = unicode(name, 'utf-8')
+        except UnicodeError:
+            # There could be some non-utf encoding with some characters
+            # still matching a TLD so we move on, and try to match it.
+            # RFC5280 says that dNSNames should be IA5String, but somebody still
+            # could put utf-8 inside so it's reasonable to go through anyway.
+            uni_fail = True
+        else:
+            # If an address fails this matching then it shouldn't work in any
+            # browser, and trying to match it to TLDs will mess the output.
+            uni_name = uni_name.lower()
+            idna_name = uni_name.encode('idna')
+            if self.NOT_ADDRESS_REGEX.search(idna_name):
+                raise ValueError("%s (idna: %s) is not an address" % (uni_name,
+                                                                      idna_name))
+            name = uni_name
+        name = name.lower()
+        tld_match = self.match(name)
+        # url could be decoded as idna
+        idna_match = self.match_idna(name)
+        return (tld_match, idna_match, uni_fail)
+


### PR DESCRIPTION
As in title. There is small ugly part that TLD check for common name and dnsname looks pretty much the same, but I wasn't sure where I could extract it. I'm also not sure if my approach to checking whether a name is probably an address or not is correct (I'm converting name to idna and checking whether it contains [a-z0-9-.*] characters). I could add this python package: https://pypi.python.org/pypi/rfc3987, so it will be more advanced.   
