### PR TITLE
Allow other threads to pause producer.

### DIFF
--- a/python/ct/client/async_log_client_test.py
+++ b/python/ct/client/async_log_client_test.py
@@ -120,6 +120,11 @@ class AsyncLogClientTest(unittest.TestCase):
 
     def setUp(self):
         self.clock = task.Clock()
+        # Task clock doesn't have callFromThread method. But in this test
+        # everything is single threaded anyway, so we can simply run given
+        # function.
+        self.clock.callFromThread = lambda fun, *args, **kwargs: fun(*args,
+                                                                     **kwargs)
 
     def one_shot_client(self, json_content):
         """Make a one-shot client and give it a mock response."""

--- a/python/ct/client/log_client.py
+++ b/python/ct/client/log_client.py
@@ -569,7 +569,7 @@ class EntryProducer(object):
 
     @property
     def finished(self):
-        return self._current > self._end
+        return self._current > self._end and self._batches.empty()
 
     def __fail(self, failure):
         if not self._stopped:
@@ -740,7 +740,7 @@ class EntryProducer(object):
     def resumeProducing(self):
         if self._paused and not self._stopped:
             self._paused = False
-            self.produce()
+            self._reactor.callFromThread(self.produce)
 
     def stopProducing(self):
         self._paused = True


### PR DESCRIPTION
Without this change, if any thread other than reactors thread tries to resume production everything fails (produce is called is simply running in non reactor thread so it's output won't be handled etc.). 