### PR TITLE
Store cert fields in CertDB

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -22,6 +22,7 @@ test: all
 	PYTHONPATH=$(PYTHONPATH):. ./ct/client/db/sqlite_cert_db_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/client/db/sqlite_temp_db_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/client/db/sqlite_connection_test.py
+	PYTHONPATH=$(PYTHONPATH):. ./ct/client/db/cert_desc_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/client/log_client_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/client/db_reporter_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/client/reporter_test.py

--- a/python/ct/client/db/cert_db_test.py
+++ b/python/ct/client/db/cert_db_test.py
@@ -3,9 +3,19 @@ import hashlib
 from ct.client.db import cert_desc
 
 SAMPLE_CERT = cert_desc.CertificateDescription.from_values("hello\x00",
-                                                          ["example.com"])
+                                                          ["example.com"],
+                                                           ["alt.com"],
+                                                           "2",
+                                                           "123",
+                                                           ["8.7.6.4"])
 FOUR_CERTS = [(cert_desc.CertificateDescription.from_values("hello-%d" % i,
-                                                        ["domain-%d.com" % i]), i)
+                                                        ["domain-%d.com" % i],
+                                                        ["alt-%d.com" % i],
+                                                        str(i),
+                                                        str(i+i*i),
+                                                        ["%d.%d.%d.%d" % (i, i,
+                                                                          i, i)],
+                                                            ),i)
               for i in range(4)]
 # This class provides common tests for all cert database implementations.
 # It only inherits from object so that unittest won't attempt to run the test_*

--- a/python/ct/client/db/cert_desc_test.py
+++ b/python/ct/client/db/cert_desc_test.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+import unittest
+from ct.client.db import cert_desc
+from ct.crypto import cert
+CERT = cert.Certificate.from_der_file("ct/crypto/testdata/google_cert.der")
+class CertificateDescriptionTest(unittest.TestCase):
+    def test_from_cert(self):
+        desc = cert_desc.CertificateDescription.from_cert(CERT)
+        self.assertEqual(desc.der, CERT.to_der())
+        self.assertEqual(desc.subject_names,
+                         ['.'.join(cert_desc.process_name(sub.value))
+                          for sub in CERT.subject_common_names()])
+        self.assertEqual(desc.alt_subject_names,
+                         ['.'.join(cert_desc.process_name(sub.value))
+                          for sub in CERT.subject_dns_names()])
+        self.assertEqual(desc.version, str(CERT.version().value))
+        self.assertEqual(desc.serial_number, str(CERT.serial_number().value))
+        self.assertEqual(desc.ip_addresses,
+                         [str(ip) for ip in CERT.subject_ip_addresses()])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I'm not 100% sure if this is the correct approach, so I didn't pull out all fields which are in CertificateDescription constructor. If everything is OK, then I'll add that (here or in follow up pull request). Also which fields other than those should we store? It should be easy to write a script which repopulates database with added fields, so we can add them as we need them.
Also test feels slightly pointless, because it almost copies the code in from_values, but at least we know that there are no obvious errors in description.
