### PR TITLE
Reporter -> TextReporter, AggregatedReporter

### DIFF
--- a/python/ct/client/aggregated_reporter.py
+++ b/python/ct/client/aggregated_reporter.py
@@ -1,0 +1,23 @@
+from ct.cert_analysis import all_checks
+from ct.client import reporter
+
+class AggregatedCertificateReport(reporter.CertificateReport):
+    """Reporter which passes the function calls to other reporters passed through
+    constructor."""
+    def __init__(self, reporters, checks=all_checks.ALL_CHECKS):
+        self._reporters = reporters
+        super(AggregatedCertificateReport, self).__init__(checks=checks)
+
+    def report(self):
+        super(AggregatedCertificateReport, self).report()
+        for report in self._reporters:
+            report.report()
+
+    def reset(self):
+        self._jobs = []
+        for report in self._reporters:
+            report.reset()
+
+    def _batch_scanned_callback(self, result):
+        for report in self._reporters:
+            report._batch_scanned_callback(result)

--- a/python/ct/client/monitor.py
+++ b/python/ct/client/monitor.py
@@ -3,9 +3,10 @@ import logging
 
 from ct.client import entry_decoder
 from ct.client import state
-from ct.client import reporter
+from ct.client import aggregated_reporter
 from ct.crypto import error
 from ct.crypto import merkle
+from ct.client import text_reporter
 from ct.proto import client_pb2
 from twisted.internet import defer
 
@@ -26,7 +27,8 @@ class Monitor(object):
         # Merkle tree info.
         # Depends on: Merkle trees implemented in Python.
         self.__state = client_pb2.MonitorState()
-        self.__report = reporter.CertificateReport()
+        self.__report = aggregated_reporter.AggregatedCertificateReport(
+                (text_reporter.TextCertificateReport(),))
         try:
             self.__state = self.__state_keeper.read(client_pb2.MonitorState)
         except state.FileNotFoundError:
@@ -95,8 +97,6 @@ class Monitor(object):
 
     def _set_verified_tree(self, new_tree):
         """Set verified_tree and maybe move pending_sth to verified_sth."""
-        self.__report.set_new_entries_count(
-                new_tree.tree_size - self.__verified_tree.tree_size)
         self.__verified_tree = new_tree
         old_state = self.__state
         new_state = client_pb2.MonitorState()

--- a/python/ct/client/monitor_test.py
+++ b/python/ct/client/monitor_test.py
@@ -169,7 +169,7 @@ class MonitorTest(unittest.TestCase):
 
     def create_monitor(self, client, skip_scan_entry=True):
         m = monitor.Monitor(client, self.verifier, self.hasher, self.db,
-                               self.temp_db, self.state_keeper)
+                            self.temp_db, self.state_keeper)
         if m:
             m._scan_entries = mock.Mock()
         return m

--- a/python/ct/client/reporter_test.py
+++ b/python/ct/client/reporter_test.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 import unittest
 
-from ct.client import reporter
+from collections import defaultdict
 from ct.cert_analysis import asn1
 from ct.cert_analysis import base_check_test
+from ct.client import reporter
+from ct.client.db import sqlite_cert_db
+from ct.client.db import sqlite_connection as sqlitecon
 from ct.crypto import cert
 
 STRICT_DER = cert.Certificate.from_der_file(
@@ -16,22 +19,40 @@ class FakeCheck(object):
     def check(certificate):
         return [asn1.Strict("Boom!")]
 
-
 class CertificateReportTest(base_check_test.BaseCheckTest):
+    class CertificateReportBase(reporter.CertificateReport):
+        def __init__(self, checks):
+            super(CertificateReportTest.CertificateReportBase, self).__init__(
+                    checks=checks)
+
+        def report(self):
+            super(CertificateReportTest.CertificateReportBase, self).report()
+            return self.observations
+
+        def reset(self):
+            self.observations = defaultdict(list)
+
+        def _batch_scanned_callback(self, result):
+            for desc, log_index, observations in result:
+                self.observations[log_index] += observations
+
     class FakeCheck(object):
         @staticmethod
         def check(certificate):
             return [asn1.Strict("Boom!")]
 
+    def setUp(self):
+        self.cert_db = sqlite_cert_db.SQLiteCertDB(
+                sqlitecon.SQLiteConnectionManager(":memory:", keepalive=True))
 
     def test_scan_der_cert_no_checks(self):
-        report = reporter.CertificateReport([])
+        report = self.CertificateReportBase([])
         report.scan_der_certs([(0, STRICT_DER)])
         result = report.report()
         self.assertEqual(len(sum(result.values(), [])), 0)
 
     def test_scan_der_cert_broken_cert(self):
-        report = reporter.CertificateReport([])
+        report = self.CertificateReportBase([])
         report.scan_der_certs([(0, "asdf")])
         result = report.report()
         self.assertObservationIn(asn1.All(),
@@ -39,15 +60,16 @@ class CertificateReportTest(base_check_test.BaseCheckTest):
         self.assertEqual(len(sum(result.values(), [])), 1)
 
     def test_scan_der_cert_check(self):
-        report = reporter.CertificateReport([FakeCheck()])
+        report = self.CertificateReportBase([FakeCheck()])
         report.scan_der_certs([(0, STRICT_DER)])
         result = report.report()
+
         self.assertObservationIn(asn1.Strict("Boom!"),
                                  sum(result.values(), []))
         self.assertEqual(len(result), 1)
 
     def test_scan_der_cert_check_non_strict(self):
-        report = reporter.CertificateReport([FakeCheck()])
+        report = self.CertificateReportBase([FakeCheck()])
         report.scan_der_certs([(0, NON_STRICT_DER)])
         result = report.report()
         # There should be FakeCheck and asn.1 strict parsing failure

--- a/python/ct/client/text_reporter.py
+++ b/python/ct/client/text_reporter.py
@@ -1,0 +1,70 @@
+import gflags
+import logging
+
+from collections import defaultdict
+from ct.cert_analysis import all_checks
+from ct.client import reporter
+
+FLAGS = gflags.FLAGS
+
+class TextCertificateReport(reporter.CertificateReport):
+    """Stores description of new entries between last verified STH and
+    current."""
+
+    def __init__(self, checks=all_checks.ALL_CHECKS):
+        super(TextCertificateReport, self).__init__(checks=checks)
+
+    def report(self):
+        """Report stored changes and reset report."""
+        super(TextCertificateReport, self).report()
+        logging.info("Report:")
+        entries_with_issues = 0
+        for obs in self._observations_by_index.values():
+            if len(obs):
+                entries_with_issues +=1
+        new_entries_count = len(self._observations_by_index)
+        logging.info("New entries since last verified STH: %s" %
+                     new_entries_count)
+        logging.info("Number of entries with observations: %d" %
+                     entries_with_issues)
+        logging.info("Observations:")
+        for index, cert_observations in sorted(
+                self._observations_by_index.iteritems()):
+            msg = "Cert %d:" % index
+            observations = []
+            for obs in cert_observations:
+                observations.append(str(obs))
+            if observations:
+                logging.info("%s %s", msg, ', '.join(observations))
+
+        stats = defaultdict(int)
+        for observations in self._observations_by_index.itervalues():
+            # here we care only about description and reason, because details
+            # will be probably different for every single observation
+            unique_observations = set((obs.description, obs.reason)
+                                      for obs in observations)
+            for obs in unique_observations:
+                stats[obs] += 1
+        # if number of new entries is unknown then we just count percentages
+        # based on number of certificates with observations
+        logging.info("Stats:")
+        for description_reason, count in stats.iteritems():
+            description, reason = description_reason
+            logging.info("%s %s: %d (%.5f%%)"
+                         % (description,
+                            "(%s)" % reason if reason else '',
+                            count,
+                            float(count) / new_entries_count * 100.))
+        ret = self._observations_by_index
+        self.reset()
+        return ret
+
+    def reset(self):
+        """Clean up report.
+
+        It's also ran at start."""
+        self._observations_by_index = defaultdict(list)
+
+    def _batch_scanned_callback(self, result):
+        for desc, log_index, observations in result:
+            self._observations_by_index[log_index] += observations


### PR DESCRIPTION
With this change it will be possible to create reporters which do various stuff with parsing results (I already have CertDBReporter ready, which stores certificate descriptions in CertDB). This change mimics previous reporter, so all AsyncResults are stored till report is called. I have follow up commit ready which fixes that, and allows reporters to work in more streaming manner (but I think it should go in separate pull request). I also added little change here - I add certificate descriptions from scan callback, so it's ready for CertDBReporter.
