### PR TITLE
Consumer won't overflow reporters now.

### DIFF
--- a/python/ct/client/aggregated_reporter.py
+++ b/python/ct/client/aggregated_reporter.py
@@ -14,7 +14,6 @@ class AggregatedCertificateReport(reporter.CertificateReport):
             report.report()
 
     def reset(self):
-        self._jobs = []
         for report in self._reporters:
             report.reset()
 

--- a/python/ct/client/async_log_client_test.py
+++ b/python/ct/client/async_log_client_test.py
@@ -169,6 +169,9 @@ class AsyncLogClientTest(unittest.TestCase):
 
         def consume(self, entries):
             self.received += entries
+            d = defer.Deferred()
+            d.callback(None)
+            return d
 
     # Helper method.
     def get_entries(self, client, start, end, batch_size=0):
@@ -309,6 +312,9 @@ class AsyncLogClientTest(unittest.TestCase):
                 len(self.received) >= self.pause_at):
                 self.producer.pauseProducing()
                 self.already_paused = True
+            d = defer.Deferred()
+            d.callback(None)
+            return d
 
     def test_get_entries_pause_resume(self):
         client = self.default_client()

--- a/python/ct/client/log_client.py
+++ b/python/ct/client/log_client.py
@@ -608,11 +608,14 @@ class EntryProducer(object):
         self.__fail(failure)
 
     def _write_pending(self):
+        d = defer.Deferred()
+        d.callback(None)
         if self._pending:
             self._current += len(self._pending)
             self._currently_stored -= len(self._pending)
-            self._consumer.consume(self._pending)
+            d = self._consumer.consume(self._pending)
             self._pending = None
+        return d
 
     def _batch_completed(self, result):
         self._currently_fetching -= len(result)
@@ -679,7 +682,9 @@ class EntryProducer(object):
     def produce(self):
         """Produce entries."""
         while not self._paused:
-            self._write_pending()
+            wfd = defer.waitForDeferred(self._write_pending())
+            yield wfd
+            wfd.getResult()
 
             if self.finished:
                 self.finishProducing()

--- a/python/ct/client/monitor_test.py
+++ b/python/ct/client/monitor_test.py
@@ -92,6 +92,7 @@ class FakeEntryProducer(object):
     def stopProducing(self):
         self.stop = True
 
+
 class FakeLogClient(object):
     def __init__(self, sth, servername="log_server", batch_size=None,
                  get_entries_throw=None):


### PR DESCRIPTION
And also AsyncResults will be processed asap, instead of waiting for report call.
