### PR TITLE
Convert etcd watchers to use util::Task.

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -330,10 +330,12 @@ tools/dump_sth: tools/dump_sth.o proto/libproto.a
 
 util/bench_etcd: util/bench_etcd.o util/libutil.a
 
-util/etcd_masterelection: util/etcd_masterelection.o util/libutil.a
+util/etcd_masterelection: util/etcd_masterelection.o base/notification.o \
+                          util/libutil.a
 
 util/etcd_watch: util/etcd_watch.o util/etcd.o util/libevent_wrapper.o \
-	util/json_wrapper.o util/status.o util/task.o
+	util/json_wrapper.o util/status.o util/task.o util/sync_task.o \
+	base/notification.o
 
 test: tests
 	@set -e; for TEST in $(TESTS); do \

--- a/cpp/util/fake_etcd.h
+++ b/cpp/util/fake_etcd.h
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "util/etcd.h"
+#include "util/task.h"
 #include "util/thread_pool.h"
 
 
@@ -19,8 +20,8 @@ class FakeEtcdClient : public EtcdClient {
 
   void DumpEntries();
 
-  Watcher* CreateWatcher(const std::string& key,
-                         const Watcher::WatchCallback& cb) override;
+  void Watch(const std::string& key, const WatchCallback& cb,
+             util::Task* task) override;
 
  protected:
   void Generic(const std::string& key,
@@ -28,8 +29,6 @@ class FakeEtcdClient : public EtcdClient {
                evhttp_cmd_type verb, const GenericCallback& cb) override;
 
  private:
-  class FakeWatcher;
-
   void PurgeExpiredEntries();
 
   void NotifyForPath(const std::string& path);
@@ -57,7 +56,7 @@ class FakeEtcdClient : public EtcdClient {
                     const std::map<std::string, std::string>& params,
                     const GenericCallback& cb);
 
-  void RemoveWatcher(const void* cookie);
+  void CancelWatch(util::Task* task);
 
   // Schedules a callback to be run.
   // Callbacks should not block.
@@ -67,7 +66,7 @@ class FakeEtcdClient : public EtcdClient {
   std::mutex mutex_;
   int64_t index_;
   std::map<std::string, Node> entries_;
-  std::map<std::string, std::vector<std::pair<Watcher::WatchCallback, void*>>>
+  std::map<std::string, std::vector<std::pair<WatchCallback, util::Task*>>>
       watches_;
 
   friend class ElectionTest;


### PR DESCRIPTION
Minor downside: cancellations aren't as expedited as before. There's a plan to fix that, but I think it's actually sort of nice to have a bit of odd behaviour there to shake more bugs out...
