### PR TITLE
Etcd consistent store creates sync wrapper

### DIFF
--- a/cpp/log/etcd_consistent_store.h
+++ b/cpp/log/etcd_consistent_store.h
@@ -8,6 +8,7 @@
 #include "base/macros.h"
 #include "log/consistent_store.h"
 #include "proto/ct.pb.h"
+#include "util/etcd.h"
 #include "util/status.h"
 #include "util/sync_etcd.h"
 
@@ -17,7 +18,8 @@ namespace cert_trans {
 template <class Logged>
 class EtcdConsistentStore : public ConsistentStore<Logged> {
  public:
-  EtcdConsistentStore(SyncEtcdClient* client, const std::string& root,
+  // No change of ownership for |client|
+  EtcdConsistentStore(EtcdClient* client, const std::string& root,
                       const std::string& node_id);
 
   int64_t NextAvailableSequenceNumber() const override;
@@ -70,7 +72,8 @@ class EtcdConsistentStore : public ConsistentStore<Logged> {
 
   std::string GetFullPath(const std::string& key) const;
 
-  SyncEtcdClient* const client_;
+  EtcdClient* const client_;  // We don't own this.
+  SyncEtcdClient sync_client_;
   const std::string root_;
   const std::string node_id_;
 

--- a/cpp/util/json_wrapper.h
+++ b/cpp/util/json_wrapper.h
@@ -75,7 +75,7 @@ class JsonObject {
   }
 
   void Add(const char* name, const JsonObject& addand) {
-    Add(name, addand.obj_);
+    Add(name, json_object_get(addand.obj_));
   }
 
   void Add(const char* name, int64_t value) {

--- a/cpp/util/sync_etcd.cc
+++ b/cpp/util/sync_etcd.cc
@@ -96,13 +96,13 @@ SyncEtcdClient::SyncEtcdClient(EtcdClient* client) : client_(client) {
 }
 
 
-Status SyncEtcdClient::Get(const string& key, EtcdClient::Node* node) {
+Status SyncEtcdClient::Get(const string& key, EtcdClient::Node* node) const {
   return BlockingCall(bind(&EtcdClient::Get, client_, key, _1), node);
 }
 
 
 Status SyncEtcdClient::GetAll(const string& dir,
-                              vector<EtcdClient::Node>* values) {
+                              vector<EtcdClient::Node>* values) const {
   return BlockingCall(bind(&EtcdClient::GetAll, client_, dir, _1), values);
 }
 

--- a/cpp/util/sync_etcd.h
+++ b/cpp/util/sync_etcd.h
@@ -31,10 +31,11 @@ class SyncEtcdClient {
 
   // Synchronous analogues to the etcd API below:
 
-  virtual util::Status Get(const std::string& key, EtcdClient::Node* node);
+  virtual util::Status Get(const std::string& key,
+                           EtcdClient::Node* node) const;
 
   virtual util::Status GetAll(const std::string& dir,
-                              std::vector<EtcdClient::Node>* values);
+                              std::vector<EtcdClient::Node>* values) const;
 
   virtual util::Status Create(const std::string& key, const std::string& value,
                               int64_t* index);


### PR DESCRIPTION
Let EtcdConsistentStore use an EtcdClient rather than forcing the caller to faff about with SyncEtcdClient.

Also rolls in a couple of other fixes:
- a TODO to create JsonObjects directly in fakeetcd
- a json wrapper double free issue.
