### PR TITLE
Implement the bare minimum of EtcdConsistentStore::NextAvailableSequenceNumber()

### DIFF
--- a/cpp/log/consistent_store.h
+++ b/cpp/log/consistent_store.h
@@ -6,6 +6,7 @@
 
 #include "base/macros.h"
 #include "util/status.h"
+#include "util/statusor.h"
 
 namespace ct {
 
@@ -87,7 +88,7 @@ class ConsistentStore {
  public:
   ConsistentStore() = default;
 
-  virtual int64_t NextAvailableSequenceNumber() const = 0;
+  virtual util::StatusOr<int64_t> NextAvailableSequenceNumber() const = 0;
 
   virtual util::Status SetServingSTH(const ct::SignedTreeHead& new_sth) = 0;
 

--- a/cpp/log/etcd_consistent_store-inl.h
+++ b/cpp/log/etcd_consistent_store-inl.h
@@ -28,8 +28,21 @@ EtcdConsistentStore<Logged>::EtcdConsistentStore(EtcdClient* client,
 
 
 template <class Logged>
-int64_t EtcdConsistentStore<Logged>::NextAvailableSequenceNumber() const {
-  CHECK(false) << "Not Implemented";
+util::StatusOr<int64_t>
+EtcdConsistentStore<Logged>::NextAvailableSequenceNumber() const {
+  std::vector<EntryHandle<Logged>> sequenced_entries;
+  util::Status status(GetSequencedEntries(&sequenced_entries));
+  if (!status.ok()) {
+    return status;
+  }
+  if (!sequenced_entries.empty()) {
+    CHECK(sequenced_entries.back().Entry().has_sequence_number());
+    return sequenced_entries.back().Entry().sequence_number() + 1;
+  }
+
+  // TODO(alcutter): Implement the rest of the logic around /serving_sth too
+  // once there are methods to inspect that.
+  LOG(WARNING) << "NextAvailableSequenceNumber() not checking /serving_sth.";
   return 0;
 }
 

--- a/cpp/log/etcd_consistent_store.h
+++ b/cpp/log/etcd_consistent_store.h
@@ -22,7 +22,7 @@ class EtcdConsistentStore : public ConsistentStore<Logged> {
   EtcdConsistentStore(EtcdClient* client, const std::string& root,
                       const std::string& node_id);
 
-  int64_t NextAvailableSequenceNumber() const override;
+  util::StatusOr<int64_t> NextAvailableSequenceNumber() const override;
 
   util::Status SetServingSTH(const ct::SignedTreeHead& new_sth) override;
 

--- a/cpp/log/etcd_consistent_store_test.cc
+++ b/cpp/log/etcd_consistent_store_test.cc
@@ -129,8 +129,20 @@ class EtcdConsistentStoreTest : public ::testing::Test {
 
 typedef class EtcdConsistentStoreTest EtcdConsistentStoreDeathTest;
 
+
 TEST_F(EtcdConsistentStoreDeathTest, TestNextAvailableSequenceNumber) {
-  EXPECT_DEATH(store_->NextAvailableSequenceNumber(), "Not Implemented");
+  EXPECT_EQ(0, store_->NextAvailableSequenceNumber().ValueOrDie());
+}
+
+
+TEST_F(EtcdConsistentStoreTest,
+       TestNextAvailableSequenceNumberWhenSequencedEntriesExist) {
+  const LoggedCertificate one(MakeSequencedCert(0, "one", 1));
+  const LoggedCertificate two(MakeSequencedCert(1, "two", 1));
+  InsertEntry(string(kRoot) + "/sequenced/0", one);
+  InsertEntry(string(kRoot) + "/sequenced/1", two);
+
+  EXPECT_EQ(2, store_->NextAvailableSequenceNumber().ValueOrDie());
 }
 
 

--- a/cpp/log/fake_consistent_store-inl.h
+++ b/cpp/log/fake_consistent_store-inl.h
@@ -21,7 +21,8 @@ FakeConsistentStore<Logged>::FakeConsistentStore(
 
 
 template <class Logged>
-int64_t FakeConsistentStore<Logged>::NextAvailableSequenceNumber() const {
+util::StatusOr<int64_t>
+FakeConsistentStore<Logged>::NextAvailableSequenceNumber() const {
   std::unique_lock<std::mutex> lock(mutex_);
   return next_available_sequence_number_;
 }

--- a/cpp/log/fake_consistent_store.h
+++ b/cpp/log/fake_consistent_store.h
@@ -28,7 +28,7 @@ class FakeConsistentStore : public ConsistentStore<Logged> {
 
   virtual ~FakeConsistentStore() = default;
 
-  int64_t NextAvailableSequenceNumber() const override;
+  util::StatusOr<int64_t> NextAvailableSequenceNumber() const override;
 
   util::Status SetServingSTH(const ct::SignedTreeHead& new_sth) override;
 

--- a/cpp/log/fake_consistent_store_test.cc
+++ b/cpp/log/fake_consistent_store_test.cc
@@ -90,7 +90,7 @@ class FakeConsistentStoreTest : public ::testing::Test {
 
 
 TEST_F(FakeConsistentStoreTest, TestNextAvailableSequenceNumber) {
-  EXPECT_EQ(0, store_->NextAvailableSequenceNumber());
+  EXPECT_EQ(0, store_->NextAvailableSequenceNumber().ValueOrDie());
 }
 
 
@@ -194,10 +194,10 @@ TEST_F(FakeConsistentStoreTest, TestAssignSequenceNumber) {
 
   int i(0);
   for (auto& e : entries) {
-    EXPECT_EQ(i, store_->NextAvailableSequenceNumber());
+    EXPECT_EQ(i, store_->NextAvailableSequenceNumber().ValueOrDie());
     status = store_->AssignSequenceNumber(i++, &e);
     EXPECT_TRUE(status.ok()) << status;
-    EXPECT_EQ(i, store_->NextAvailableSequenceNumber());
+    EXPECT_EQ(i, store_->NextAvailableSequenceNumber().ValueOrDie());
   }
 
   EXPECT_EQ(entries[0].Entry(), GetSequencedEntry(0).Entry());


### PR DESCRIPTION
Temporary stepping stone.

This will break the restart-with-previous-data functionality of the logserver for a bit.
