### PR TITLE
EV whitelist generator: Remove Alpha log.

### DIFF
--- a/python/utilities/ev_whitelist/create_ev_whitelist_zip.py
+++ b/python/utilities/ev_whitelist/create_ev_whitelist_zip.py
@@ -24,7 +24,6 @@ NUM_FETCHING_PROCESSES = 40
 LOGS_LIST = [
     "https://ct.googleapis.com/pilot",
     "https://ct.googleapis.com/aviator",
-    "https://alpha.ctlogs.org"
 ]
 
 FLAGS = gflags.FLAGS


### PR DESCRIPTION
It's offline anyway, we can't scan it.
