### PR TITLE
Add Certly log (pending inclusion)

### DIFF
--- a/python/utilities/ev_whitelist/create_ev_whitelist_zip.py
+++ b/python/utilities/ev_whitelist/create_ev_whitelist_zip.py
@@ -25,6 +25,7 @@ LOGS_LIST = [
     "https://ct.googleapis.com/pilot",
     "https://ct.googleapis.com/aviator",
     "https://ct1.digicert-ct.com/log",
+    "https://log.certly.io",
 ]
 
 FLAGS = gflags.FLAGS


### PR DESCRIPTION
Adds the Certly log (`log.certly.io`) to the EV whitelist extension.
