### PR TITLE
EV whitelist: Gather certs from all pending EV certs

### DIFF
--- a/python/utilities/ev_whitelist/create_ev_whitelist_zip.py
+++ b/python/utilities/ev_whitelist/create_ev_whitelist_zip.py
@@ -25,6 +25,8 @@ LOGS_LIST = [
     "https://ct.googleapis.com/pilot",
     "https://ct.googleapis.com/aviator",
     "https://ct1.digicert-ct.com/log",
+    "https://log.certly.io",
+    "https://ct.izenpe.com",
 ]
 
 FLAGS = gflags.FLAGS


### PR DESCRIPTION
This includes both Certly and Izenpe's logs.