### PR TITLE
Print observations as they come.

### DIFF
--- a/python/ct/client/text_reporter.py
+++ b/python/ct/client/text_reporter.py
@@ -18,53 +18,41 @@ class TextCertificateReport(reporter.CertificateReport):
         """Report stored changes and reset report."""
         super(TextCertificateReport, self).report()
         logging.info("Report:")
-        entries_with_issues = 0
-        for obs in self._observations_by_index.values():
-            if len(obs):
-                entries_with_issues +=1
-        new_entries_count = len(self._observations_by_index)
         logging.info("New entries since last verified STH: %s" %
-                     new_entries_count)
+                     self.new_entries_count)
         logging.info("Number of entries with observations: %d" %
-                     entries_with_issues)
+                     self.entries_with_issues)
         logging.info("Observations:")
-        for index, cert_observations in sorted(
-                self._observations_by_index.iteritems()):
-            msg = "Cert %d:" % index
-            observations = []
-            for obs in cert_observations:
-                observations.append(unicode(obs))
-            if observations:
-                logging.info("%s %s", msg, ', '.join(observations))
-
-        stats = defaultdict(int)
-        for observations in self._observations_by_index.itervalues():
-            # here we care only about description and reason, because details
-            # will be probably different for every single observation
-            unique_observations = set((obs.description, obs.reason)
-                                      for obs in observations)
-            for obs in unique_observations:
-                stats[obs] += 1
         # if number of new entries is unknown then we just count percentages
         # based on number of certificates with observations
         logging.info("Stats:")
-        for description_reason, count in stats.iteritems():
+        for description_reason, count in self.stats.iteritems():
             description, reason = description_reason
             logging.info("%s %s: %d (%.5f%%)"
                          % (description,
                             "(%s)" % reason if reason else '',
                             count,
-                            float(count) / new_entries_count * 100.))
-        ret = self._observations_by_index
+                            float(count) / self.new_entries_count * 100.))
         self.reset()
-        return ret
 
     def reset(self):
         """Clean up report.
 
         It's also ran at start."""
-        self._observations_by_index = defaultdict(list)
+        self.stats = defaultdict(int)
+        self.entries_with_issues = 0
+        self.new_entries_count = 0
 
     def _batch_scanned_callback(self, result):
-        for desc, log_index, observations in result:
-            self._observations_by_index[log_index] += observations
+        for _, log_index, cert_observations in result:
+            msg = "Cert %d:" % log_index
+            observations = [unicode(obs) for obs in cert_observations]
+            if observations:
+                logging.info("%s %s", msg, ', '.join(observations))
+            unique_observations = set((obs.description, obs.reason)
+                                      for obs in cert_observations)
+            for obs in unique_observations:
+                self.stats[obs] += 1
+            if len(cert_observations) > 0:
+                self.entries_with_issues += 1
+            self.new_entries_count += 1


### PR DESCRIPTION
With this change text reporter will report observations as they come, so it will greatly reduce memory consumption.