### PR TITLE
Run the etcd watch callback runs on a specific executor.

### DIFF
--- a/cpp/util/etcd.cc
+++ b/cpp/util/etcd.cc
@@ -22,6 +22,7 @@ using std::make_pair;
 using std::make_shared;
 using std::map;
 using std::max;
+using std::move;
 using std::mutex;
 using std::ostringstream;
 using std::pair;
@@ -549,7 +550,7 @@ void EtcdClient::WatchState::InitialGetAllDone(Status status,
     updates.emplace_back(WatchUpdate(node, true /*exists*/));
   }
 
-  cb_(updates);
+  task_->executor()->Add(bind(cb_, move(updates)));
 
   StartRequest();
 }
@@ -637,7 +638,7 @@ void EtcdClient::WatchState::RequestDone(Status status,
     Status status(HandleSingleValueRequestDone(node, &updates));
 
     if (status.ok()) {
-      cb_(updates);
+      task_->executor()->Add(bind(cb_, move(updates)));
     } else {
       LOG(ERROR) << status;
     }

--- a/cpp/util/etcd.h
+++ b/cpp/util/etcd.h
@@ -105,6 +105,7 @@ class EtcdClient {
   void Delete(const std::string& key, const int64_t current_index,
               const DeleteCallback& cb);
 
+  // The "cb" will be called on the "task" executor.
   virtual void Watch(const std::string& key, const WatchCallback& cb,
                      util::Task* task);
 


### PR DESCRIPTION
As usual, testing is everything. :stuck_out_tongue: 