### PR TITLE
Set default encoding to utf-8.

### DIFF
--- a/python/utilities/logobserver/logobserver.py
+++ b/python/utilities/logobserver/logobserver.py
@@ -33,6 +33,9 @@ def create_directory(directory):
         os.makedirs(directory)
 
 if __name__ == '__main__':
+    reload(sys)
+    # we really need utf-8 for all accented characters and such in certificates
+    sys.setdefaultencoding('UTF-8')
     sys.argv = FLAGS(sys.argv)
     logging.basicConfig(level=FLAGS.log_level)
 


### PR DESCRIPTION
Since in every log we will have to deal with utf-8 characters it makes sense to set it to default. Also without setting it manually it's set sometimes to None, which causes exceptions while printing observations (we get UNPRINTABLE, when printing unicode strings which is horrible). I honestly couldn't find better way, but this change makes sense nonetheless.