### PR TITLE
Observations now can't raise while printing.

### DIFF
--- a/python/ct/cert_analysis/observation.py
+++ b/python/ct/cert_analysis/observation.py
@@ -1,3 +1,5 @@
+import logging
+
 class Observation(object):
     """Describes certificate observation."""
     def __init__(self, description, reason=None, details=None):
@@ -27,4 +29,11 @@ class Observation(object):
         """Conveience method, so it's easy to override how details have to be
         printed without overriding whole __str__.
         """
-        return self.details
+        try:
+            if isinstance(self.details, str):
+                return unicode(self.details, 'utf-8')
+            else:
+                return unicode(self.details)
+        except Exception as e:
+            logging.warning("Unprintable observation %r" % self.details)
+            return "UNPRINTABLE " + str(e)

--- a/python/ct/client/text_reporter.py
+++ b/python/ct/client/text_reporter.py
@@ -33,7 +33,7 @@ class TextCertificateReport(reporter.CertificateReport):
             msg = "Cert %d:" % index
             observations = []
             for obs in cert_observations:
-                observations.append(str(obs))
+                observations.append(unicode(obs))
             if observations:
                 logging.info("%s %s", msg, ', '.join(observations))
 


### PR DESCRIPTION
We shouldn't break whole text_reporter report because some observation is unprintable (for any reason), but we definitely should note that, so I changed default format details.