### PR TITLE
Add HTTP request logging to server stdout

### DIFF
--- a/cpp/server/handler.cc
+++ b/cpp/server/handler.cc
@@ -49,16 +49,52 @@ namespace {
 const char kJsonContentType[] = "application/json; charset=ISO-8859-1";
 
 
+void LogRequest(evhttp_request* req, int http_status, int resp_body_length) {
+  evhttp_connection* conn = evhttp_request_get_connection(req);
+  char* peer_addr;
+  ev_uint16_t peer_port;
+  evhttp_connection_get_peer(conn, &peer_addr, &peer_port);
+
+  string http_verb;
+  switch (evhttp_request_get_command(req)) {
+    case EVHTTP_REQ_DELETE:
+      http_verb = "DELETE";
+      break;
+    case EVHTTP_REQ_GET:
+      http_verb = "GET";
+      break;
+    case EVHTTP_REQ_HEAD:
+      http_verb = "HEAD";
+      break;
+    case EVHTTP_REQ_POST:
+      http_verb = "POST";
+      break;
+    case EVHTTP_REQ_PUT:
+      http_verb = "PUT";
+      break;
+    default:
+      http_verb = "UNKNOWN";
+      break;
+  }
+
+  const string uri(evhttp_request_get_uri(req));
+  LOG(INFO) << string(peer_addr) << " \"" << http_verb << " " << uri << "\" "
+            << http_status << " " << resp_body_length;
+}
+
+
 void SendJsonReply(evhttp_request* req, int http_status,
                    const JsonObject& json) {
   CHECK_EQ(evhttp_add_header(evhttp_request_get_output_headers(req),
                              "Content-Type", kJsonContentType),
            0);
+  const string resp_body(json.ToString());
   CHECK_GT(evbuffer_add_printf(evhttp_request_get_output_buffer(req), "%s",
-                               json.ToString()),
+                               resp_body.c_str()),
            0);
 
   evhttp_send_reply(req, http_status, /*reason*/ NULL, /*databuf*/ NULL);
+  LogRequest(req, http_status, resp_body.size());
 }
 
 
@@ -243,8 +279,9 @@ void HttpHandler::Add(libevent::HttpServer* server) {
 
 
 void HttpHandler::GetEntries(evhttp_request* req) const {
-  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET)
+  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
     return SendError(req, HTTP_BADMETHOD, "Method not allowed.");
+  }
 
   const multimap<string, string> query(ParseQuery(req));
 
@@ -301,8 +338,9 @@ void HttpHandler::GetRoots(evhttp_request* req) const {
 
 
 void HttpHandler::GetProof(evhttp_request* req) const {
-  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET)
+  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
     SendError(req, HTTP_BADMETHOD, "Method not allowed.");
+  }
 
   const multimap<string, string> query(ParseQuery(req));
 
@@ -344,8 +382,9 @@ void HttpHandler::GetProof(evhttp_request* req) const {
 
 
 void HttpHandler::GetSTH(evhttp_request* req) const {
-  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET)
+  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
     SendError(req, HTTP_BADMETHOD, "Method not allowed.");
+  }
 
   const SignedTreeHead& sth(log_lookup_->GetSTH());
 


### PR DESCRIPTION
This is useful for debugging what a client is sending to the server.
I've approximately borrowed the Apache request log format.
example:
127.0.0.1 - - [2015-Jan-14 11:53:12] "GET /ct/v1/get-sth" 200 492
127.0.0.1 - - [2015-Jan-14 11:53:26] "GET /ct/v1/get-roots" 200 1565
127.0.0.1 - - [2015-Jan-14 11:53:32] "GET /ct/v1/get-entries" 400 80
127.0.0.1 - - [2015-Jan-14 11:53:44] "GET /ct/v1/get-entries?start=1&end=1" 200 3923
