### PR TITLE
Store issuer from root certificate.

### DIFF
--- a/python/ct/client/db/sqlite_cert_db.py
+++ b/python/ct/client/db/sqlite_cert_db.py
@@ -23,6 +23,7 @@ class SQLiteCertDB(cert_db.CertDB):
             # subject common names and dnsnames for easy lookup of given
             # domain name
             ("subject_names", [("name", "TEXT")]),
+            ("root_issuer", [("type", "TEXT"), ("name", "TEXT")]),
             ("observations", [("description", "TEXT"),
                               ("reason", "TEXT"),
                               ("details", "BLOB")])]
@@ -107,6 +108,11 @@ class SQLiteCertDB(cert_db.CertDB):
 
         for iss in cert.issuer:
             cursor.execute("INSERT INTO issuer(log, cert_id, type, name)"
+                           "VALUES(?, ?, ?, ?)",
+                           (log_key, index, iss.type, iss.value))
+
+        for iss in cert.root_issuer:
+            cursor.execute("INSERT INTO root_issuer(log, cert_id, type, name)"
                            "VALUES(?, ?, ?, ?)",
                            (log_key, index, iss.type, iss.value))
 

--- a/python/ct/client/monitor.py
+++ b/python/ct/client/monitor.py
@@ -306,10 +306,15 @@ class Monitor(object):
             ts_entry = parsed_entry.merkle_leaf.timestamped_entry
             if ts_entry.entry_type == client_pb2.X509_ENTRY:
                 der_cert = ts_entry.asn1_cert
+                der_chain = parsed_entry.extra_data.certificate_chain
             else:
                 der_cert = (
                     parsed_entry.extra_data.precert_chain_entry.pre_certificate)
-            der_certs.append((entry_index, der_cert))
+                der_chain = (
+                    parsed_entry.extra_data.
+                    precert_chain_entry.precertificate_chain)
+            der_chain = der_chain[:]
+            der_certs.append((entry_index, der_cert, der_chain))
         self.__report.scan_der_certs(der_certs)
 
     class EntryConsumer(object):

--- a/python/ct/client/reporter_test.py
+++ b/python/ct/client/reporter_test.py
@@ -47,13 +47,13 @@ class CertificateReportTest(base_check_test.BaseCheckTest):
 
     def test_scan_der_cert_no_checks(self):
         report = self.CertificateReportBase([])
-        report.scan_der_certs([(0, STRICT_DER)])
+        report.scan_der_certs([(0, STRICT_DER, [''])])
         result = report.report()
         self.assertEqual(len(sum(result.values(), [])), 0)
 
     def test_scan_der_cert_broken_cert(self):
         report = self.CertificateReportBase([])
-        report.scan_der_certs([(0, "asdf")])
+        report.scan_der_certs([(0, "asdf", [''])])
         result = report.report()
         self.assertObservationIn(asn1.All(),
                       sum(result.values(), []))
@@ -61,7 +61,7 @@ class CertificateReportTest(base_check_test.BaseCheckTest):
 
     def test_scan_der_cert_check(self):
         report = self.CertificateReportBase([FakeCheck()])
-        report.scan_der_certs([(0, STRICT_DER)])
+        report.scan_der_certs([(0, STRICT_DER, [''])])
         result = report.report()
 
         self.assertObservationIn(asn1.Strict("Boom!"),
@@ -70,7 +70,7 @@ class CertificateReportTest(base_check_test.BaseCheckTest):
 
     def test_scan_der_cert_check_non_strict(self):
         report = self.CertificateReportBase([FakeCheck()])
-        report.scan_der_certs([(0, NON_STRICT_DER)])
+        report.scan_der_certs([(0, NON_STRICT_DER, [''])])
         result = report.report()
         # There should be FakeCheck and asn.1 strict parsing failure
         self.assertEqual(len(sum(result.values(), [])), 2)

--- a/python/ct/proto/certificate.proto
+++ b/python/ct/proto/certificate.proto
@@ -54,4 +54,6 @@ message X509Description {
   optional bytes sha256_hash = 10;
 
   repeated Observation observations = 11;
+
+  repeated DNAttribute root_issuer = 12;
 }


### PR DESCRIPTION
It's easy to store whole certificate chain, but because parsing them is slightly exhausting for now lets just pull out the root issuer which is most interesting bit.