### PR TITLE
Python: Fix ordering of SCT fields in proto

### DIFF
--- a/python/ct/client/tls_message.py
+++ b/python/ct/client/tls_message.py
@@ -127,7 +127,9 @@ class TLSReader(object):
         """Read from the buffer into the protocol buffer message."""
         # TODO(ekasper): probably better not to modify the
         # original message until we're guaranteed to succeed?
-        for field in message.DESCRIPTOR.fields:
+        fields = message.DESCRIPTOR.fields_by_number
+        for i in sorted(fields):
+            field = fields[i]
             opts = field.GetOptions().Extensions[options.tls_opts]
             if opts.skip:
                 continue
@@ -257,7 +259,9 @@ class TLSWriter(object):
 
     def write(self, message):
         """Append a serialized message to the writer's buffer."""
-        for field in message.DESCRIPTOR.fields:
+        fields = message.DESCRIPTOR.fields_by_number
+        for i in sorted(fields):
+            field = fields[i]
             opts = field.GetOptions().Extensions[options.tls_opts]
             if opts.skip:
                 continue

--- a/python/ct/client/tls_message_test.py
+++ b/python/ct/client/tls_message_test.py
@@ -3,7 +3,7 @@
 import unittest
 
 from ct.client import tls_message
-from ct.proto import test_message_pb2
+from ct.proto import client_pb2, test_message_pb2
 
 
 valid_test_message = test_message_pb2.TestMessage()
@@ -209,6 +209,28 @@ class TLSWriterTest(unittest.TestCase):
         self.verify_encode_fails(test_message)
 
 
+class SCTEncodingTest(unittest.TestCase):
+    def test_correctly_encodes_sct(self):
+        sct_proto = client_pb2.SignedCertificateTimestamp()
+        sct_proto.version = client_pb2.V1
+        sct_proto.id.key_id = (
+            "a4b90990b418581487bb13a2cc67700a3c359804f91bdfb8e377cd0ec80ddc10"
+            ).decode('hex')
+
+        sct_proto.timestamp = 1365427532443
+        sct_proto.signature.hash_algorithm = client_pb2.DigitallySigned.SHA256
+        sct_proto.signature.sig_algorithm = client_pb2.DigitallySigned.ECDSA
+        sct_proto.signature.signature = (
+            "304502210089de897f603e590b1aa0d7c4236c2f697e90602795f7a469215fda5e"
+            "460123fc022065ab501ce3dbaf49bd563d1c9ff0ac76120bc11f65a44122b3cd8b"
+            "89fc77a48c").decode("hex")
+        sct = tls_message.encode(sct_proto)
+        expected_sct = ("00a4b90990b418581487bb13a2cc67700a3c359804f91bdfb8e377"
+                        "cd0ec80ddc100000013de9d2b29b000004030047304502210089de"
+                        "897f603e590b1aa0d7c4236c2f697e90602795f7a469215fda5e46"
+                        "0123fc022065ab501ce3dbaf49bd563d1c9ff0ac76120bc11f65a4"
+                        "4122b3cd8b89fc77a48c").decode("hex")
+        self.assertEqual(sct, expected_sct)
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/ct/proto/client.proto
+++ b/python/ct/proto/client.proto
@@ -199,9 +199,9 @@ message LogID {
 message SignedCertificateTimestamp {
   optional Version version = 1 [ default = UNKNOWN_VERSION ];
   optional LogID id = 2;
-  optional bytes extensions = 5 [ (tls_opts).min_length = 0,
-                                  (tls_opts).max_length = 0xffff ];
   // UTC time in milliseconds, since January 1, 1970, 00:00.
   optional uint64 timestamp = 3;
-  optional DigitallySigned signature = 4;
+  optional bytes extensions = 4 [ (tls_opts).min_length = 0,
+                                  (tls_opts).max_length = 0xffff ];
+  optional DigitallySigned signature = 5;
 }

--- a/python/ct/proto/tls_options.proto
+++ b/python/ct/proto/tls_options.proto
@@ -51,6 +51,9 @@ package ct;
 //                             (tls_opts).select_value = 0];
 //   optional Orange orange = 3 [(tls_opts).select_field = "fruit_type",
 //                               (tls_opts).select_value = 1];
+//
+// Note that the numbering of the fields in the message determines their order
+// appearance in the TLS encoding.
 
 message TLSOptions {
   // Applies to uint32 and uint64, allowing to restrict the field


### PR DESCRIPTION
The incorrect order led to the TLS encoder creating SCTs that were
incorrectly encoded (the extensions come after the timestamp).