### PR TITLE
Fix burst STH generation.

### DIFF
--- a/cpp/server/ct-server.cc
+++ b/cpp/server/ct-server.cc
@@ -164,7 +164,7 @@ void SignMerkleTree(TreeSigner<LoggedCertificate>* tree_signer) {
       target_run_time += period;
     }
 
-    sleep(duration_cast<seconds>(target_run_time - now).count());
+    std::this_thread::sleep_for(target_run_time - now);
   }
 }
 


### PR DESCRIPTION
When signing runs are quick (i.e. sub-second), `target_run_time` can be slightly ahead of `now` after the `sleep` has returned (because of `duration_cast<seconds>` rounding down), this means that new STHs will be generated in a tight loop until a second has passed (this can be many STHs when the tree size/delta is small.)