### PR TITLE
Make EtcdConsistentStore::NextAvailableSequenceNumber() use /serving_sth

### DIFF
--- a/cpp/log/etcd_consistent_store-inl.h
+++ b/cpp/log/etcd_consistent_store-inl.h
@@ -72,10 +72,12 @@ EtcdConsistentStore<Logged>::NextAvailableSequenceNumber() const {
     return sequenced_entries.back().Entry().sequence_number() + 1;
   }
 
-  // TODO(alcutter): Implement the rest of the logic around /serving_sth too
-  // once there are methods to inspect that.
-  LOG(WARNING) << "NextAvailableSequenceNumber() not checking /serving_sth.";
-  return 0;
+  if (!serving_sth_) {
+    LOG(WARNING) << "Log has no Serving STH [new log?], returning 0";
+    return 0;
+  }
+
+  return serving_sth_->Entry().tree_size();
 }
 
 

--- a/cpp/log/etcd_consistent_store_test.cc
+++ b/cpp/log/etcd_consistent_store_test.cc
@@ -142,7 +142,9 @@ class EtcdConsistentStoreTest : public ::testing::Test {
 typedef class EtcdConsistentStoreTest EtcdConsistentStoreDeathTest;
 
 
-TEST_F(EtcdConsistentStoreDeathTest, TestNextAvailableSequenceNumber) {
+TEST_F(
+    EtcdConsistentStoreDeathTest,
+    TestNextAvailableSequenceNumberWhenNoSequencedEntriesOrServingSTHExist) {
   EXPECT_EQ(0, store_->NextAvailableSequenceNumber().ValueOrDie());
 }
 
@@ -155,6 +157,18 @@ TEST_F(EtcdConsistentStoreTest,
   InsertEntry(string(kRoot) + "/sequenced/1", two);
 
   EXPECT_EQ(2, store_->NextAvailableSequenceNumber().ValueOrDie());
+}
+
+
+TEST_F(EtcdConsistentStoreTest,
+       TestNextAvailableSequenceNumberWhenNoSequencedEntriesExistButHaveSTH) {
+  ct::SignedTreeHead serving_sth;
+  serving_sth.set_timestamp(123);
+  serving_sth.set_tree_size(600);
+  EXPECT_TRUE(store_->SetServingSTH(serving_sth).ok());
+
+  EXPECT_EQ(serving_sth.tree_size(),
+            store_->NextAvailableSequenceNumber().ValueOrDie());
 }
 
 


### PR DESCRIPTION
When there are no entries in `/sequenced_entries` then our next available sequence number is the one after the numbers covered by `/serving_sth`.