### PR TITLE
Only participate in the election when caught up

### DIFF
--- a/cpp/log/cluster_state_controller-inl.h
+++ b/cpp/log/cluster_state_controller-inl.h
@@ -86,6 +86,15 @@ ClusterStateController<Logged>::GetCalculatedServingSTH() const {
 
 
 template <class Logged>
+void ClusterStateController<Logged>::GetLocalNodeState(
+    ct::ClusterNodeState* state) const {
+  CHECK_NOTNULL(state);
+  std::lock_guard<std::mutex> lock(mutex_);
+  *state = local_node_state_;
+}
+
+
+template <class Logged>
 void ClusterStateController<Logged>::PushLocalNodeState(
     const std::unique_lock<std::mutex>& lock) {
   CHECK(lock.owns_lock());

--- a/cpp/log/cluster_state_controller.h
+++ b/cpp/log/cluster_state_controller.h
@@ -47,6 +47,8 @@ class ClusterStateController {
   // Really only intended for testing.
   util::StatusOr<ct::SignedTreeHead> GetCalculatedServingSTH() const;
 
+  void GetLocalNodeState(ct::ClusterNodeState* state) const;
+
  private:
   // Updates the representation of *this* node's state in the consistent store.
   void PushLocalNodeState(const std::unique_lock<std::mutex>& lock);

--- a/cpp/log/cluster_state_controller_test.cc
+++ b/cpp/log/cluster_state_controller_test.cc
@@ -322,6 +322,21 @@ TEST_F(ClusterStateControllerTest,
 }
 
 
+TEST_F(ClusterStateControllerTest, TestGetLocalNodeState) {
+  const int kContiguousSize(2345);
+  SignedTreeHead sth;
+  sth.set_timestamp(10000);
+  sth.set_tree_size(2344);
+  controller_.NewTreeHead(sth);
+  controller_.ContiguousTreeSizeUpdated(kContiguousSize);
+
+  ClusterNodeState state;
+  controller_.GetLocalNodeState(&state);
+  EXPECT_EQ(kContiguousSize, state.contiguous_tree_size());
+  EXPECT_EQ(sth.DebugString(), state.newest_sth().DebugString());
+}
+
+
 }  // namespace cert_trans
 
 


### PR DESCRIPTION
This is the first half of this, also planning to add a ConsistentStore wrapper which only allows calls to modify cluster-wide state if the caller is currently master.