### PR TITLE
Switch to C++11.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
  - sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test
  - sudo apt-add-repository -y ppa:fcitx-team/nightly
  - sudo apt-get update -qq
- - sudo apt-get install -qq protobuf-compiler libprotobuf-java libprotobuf-dev python-dev libjson-c-dev libboost-dev libboost-system-dev libboost-thread-dev libgoogle-glog-dev libgflags-dev libldns-dev libstdc++-4.8-dev
+ - sudo apt-get install -qq protobuf-compiler libprotobuf-java libprotobuf-dev python-dev libjson-c-dev libgoogle-glog-dev libgflags-dev libldns-dev libstdc++-4.8-dev
 # Stupid frikkin' google-mock package on Precise is b0rked, so hack it up:
  - wget https://googlemock.googlecode.com/files/gmock-1.6.0.zip -O /tmp/gmock-1.6.0.zip
  - unzip -d /tmp /tmp/gmock-1.6.0.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 
 language: cpp
 
+compiler:
+ - clang
+
 cache: apt
 
 before_install:
  - sudo apt-add-repository -y ppa:sao/backports
+ - sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test
  - sudo apt-add-repository -y ppa:fcitx-team/nightly
  - sudo apt-get update -qq
- - sudo apt-get install -qq protobuf-compiler libprotobuf-java libprotobuf-dev python-dev libjson-c-dev libboost-dev libboost-system-dev libboost-thread-dev libgoogle-glog-dev libgflags-dev libldns-dev
+ - sudo apt-get install -qq protobuf-compiler libprotobuf-java libprotobuf-dev python-dev libjson-c-dev libboost-dev libboost-system-dev libboost-thread-dev libgoogle-glog-dev libgflags-dev libldns-dev libstdc++-4.8-dev
 # Stupid frikkin' google-mock package on Precise is b0rked, so hack it up:
  - wget https://googlemock.googlecode.com/files/gmock-1.6.0.zip -O /tmp/gmock-1.6.0.zip
  - unzip -d /tmp /tmp/gmock-1.6.0.zip
@@ -31,5 +35,5 @@ before_install:
 
 
 script:
- - make alltests CC=clang CXX=clang++ OPENSSLDIR=/usr/local/openssl
+ - make alltests OPENSSLDIR=/usr/local/openssl
  - go test -v ./go/...

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Auditing for TLS certificates.
 
 ## Dependencies ##
 
+ - A working C++11 compiler.
+
  - [OpenSSL](https://www.openssl.org/source/), at least 1.0.0q, preferably 1.0.1l or 1.0.2 (and up)
 
 The checking of SCTs included in the [RFC 6962](http://tools.ietf.org/html/rfc6962) TLS extension is only included in OpenSSL 1.0.2. As of this writing, this version is not yet released, so this means hand building the ```OpenSSL_1_0_2-stable``` branch from the [OpenSSL git repository](https://www.openssl.org/source/repos.html).
@@ -28,7 +30,6 @@ If you are on FreeBSD, you may need to apply the patch in gtest.patch to the gte
 
 Make sure to install glog **after** gflags, to avoid linking errors.
 
- - [Boost](http://www.boost.org/), at least 1.48
  - [sqlite3](http://www.sqlite.org/)
  - [JSON-C](https://github.com/json-c/json-c/), at least 0.11
 

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -5,7 +5,7 @@ default: all
 
 -include local.mk
 
-CXXFLAG = -Wall -Werror -g -O3
+CXXFLAG = -std=c++11 -Wall -Werror -g -O3
 LINK.o = $(LINK.cc)
 
 INCLUDE = -I .

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -22,12 +22,6 @@ else
   LDLIBS += -lresolv
 endif
 
-ifeq ($(PLATFORM), Darwin)
-  LDLIBS += -lboost_system-mt -lboost_thread-mt
-else
-  LDLIBS += -lboost_system -lboost_thread
-endif
-
 # Need OpenSSL >= 1.0.0
 ifneq ($(OPENSSLDIR),)
   INCLUDE += -I $(OPENSSLDIR)/include

--- a/cpp/base/macros.h
+++ b/cpp/base/macros.h
@@ -5,8 +5,8 @@
 // A macro to disallow the copy constructor and operator= functions
 // This should be used in the private: declarations for a class
 #define DISALLOW_COPY_AND_ASSIGN(TypeName) \
-  TypeName(const TypeName&);               \
-  void operator=(const TypeName&)
+  TypeName(const TypeName&) = delete;      \
+  void operator=(const TypeName&) = delete
 
 
 #endif  // CERT_TRANS_BASE_MACROS_H_

--- a/cpp/client/async_log_client.cc
+++ b/cpp/client/async_log_client.cc
@@ -1,10 +1,9 @@
 #include "client/async_log_client.h"
 
 #include <algorithm>
-#include <boost/make_shared.hpp>
-#include <boost/scoped_ptr.hpp>
 #include <glog/logging.h>
 #include <iterator>
+#include <memory>
 #include <sstream>
 
 #include "log/cert.h"
@@ -14,10 +13,6 @@
 
 namespace libevent = cert_trans::libevent;
 
-using boost::function;
-using boost::make_shared;
-using boost::scoped_ptr;
-using boost::shared_ptr;
 using cert_trans::AsyncLogClient;
 using cert_trans::Cert;
 using cert_trans::CertChain;
@@ -27,9 +22,15 @@ using ct::MerkleAuditProof;
 using ct::SignedCertificateTimestamp;
 using ct::SignedTreeHead;
 using std::back_inserter;
+using std::bind;
 using std::copy;
+using std::function;
+using std::make_shared;
 using std::ostringstream;
+using std::placeholders::_1;
+using std::shared_ptr;
 using std::string;
+using std::unique_ptr;
 using std::vector;
 
 namespace {

--- a/cpp/client/async_log_client.cc
+++ b/cpp/client/async_log_client.cc
@@ -37,11 +37,8 @@ namespace {
 
 
 string UriEncode(const string& input) {
-  // TODO(pphaneuf): I just wanted the deleter, so std::unique_ptr
-  // would have worked, but it's not available to us (C++11).
-  const shared_ptr<char> output(evhttp_uriencode(input.data(), input.size(),
-                                                 false),
-                                free);
+  const unique_ptr<char, void (*)(void*)> output(
+      evhttp_uriencode(input.data(), input.size(), false), &free);
 
   return output.get();
 }

--- a/cpp/client/async_log_client.h
+++ b/cpp/client/async_log_client.h
@@ -1,8 +1,8 @@
 #ifndef CERT_TRANS_CLIENT_ASYNC_LOG_CLIENT_H_
 #define CERT_TRANS_CLIENT_ASYNC_LOG_CLIENT_H_
 
-#include <boost/function.hpp>
-#include <boost/shared_ptr.hpp>
+#include <functional>
+#include <memory>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -36,15 +36,15 @@ class AsyncLogClient {
     ct::LogEntry entry;
   };
 
-  typedef boost::function<void(Status)> Callback;
+  typedef std::function<void(Status)> Callback;
 
-  AsyncLogClient(const boost::shared_ptr<libevent::Base>& base,
+  AsyncLogClient(const std::shared_ptr<libevent::Base>& base,
                  const std::string& server_uri);
 
   void GetSTH(ct::SignedTreeHead* sth, const Callback& done);
 
   // This does not clear "roots" before appending to it.
-  void GetRoots(std::vector<boost::shared_ptr<Cert> >* roots,
+  void GetRoots(std::vector<std::shared_ptr<Cert> >* roots,
                 const Callback& done);
 
   // This does not clear "entries" before appending the retrieved
@@ -76,8 +76,8 @@ class AsyncLogClient {
                         ct::SignedCertificateTimestamp* sct, bool pre_cert,
                         const Callback& done);
 
-  const boost::shared_ptr<libevent::Base> base_;
-  const boost::shared_ptr<evhttp_uri> server_uri_;
+  const std::shared_ptr<libevent::Base> base_;
+  const std::shared_ptr<evhttp_uri> server_uri_;
   libevent::HttpConnection conn_;
 
   DISALLOW_COPY_AND_ASSIGN(AsyncLogClient);

--- a/cpp/client/ct.cc
+++ b/cpp/client/ct.cc
@@ -120,7 +120,7 @@ static const char kUsage[] =
     "monitor - use the monitor (see monitor_action flag)\n"
     "Use --help to display command-line flag options\n";
 
-using boost::shared_ptr;
+using std::shared_ptr;
 using cert_trans::AsyncLogClient;
 using cert_trans::Cert;
 using cert_trans::CertChain;

--- a/cpp/client/http_log_client.cc
+++ b/cpp/client/http_log_client.cc
@@ -1,10 +1,10 @@
 /* -*- indent-tabs-mode: nil -*- */
 #include "client/http_log_client.h"
 
-#include <boost/bind.hpp>
-#include <boost/make_shared.hpp>
 #include <event2/buffer.h>
+#include <functional>
 #include <glog/logging.h>
+#include <memory>
 
 #include "log/cert.h"
 #include "proto/ct.pb.h"
@@ -14,9 +14,6 @@
 
 namespace libevent = cert_trans::libevent;
 
-using boost::bind;
-using boost::make_shared;
-using boost::shared_ptr;
 using cert_trans::AsyncLogClient;
 using cert_trans::Cert;
 using cert_trans::CertChain;
@@ -25,6 +22,10 @@ using cert_trans::PreCertChain;
 using ct::MerkleAuditProof;
 using ct::SignedCertificateTimestamp;
 using ct::SignedTreeHead;
+using std::bind;
+using std::make_shared;
+using std::placeholders::_1;
+using std::shared_ptr;
 using std::string;
 using std::vector;
 

--- a/cpp/client/http_log_client.h
+++ b/cpp/client/http_log_client.h
@@ -2,7 +2,7 @@
 #ifndef HTTP_LOG_CLIENT_H
 #define HTTP_LOG_CLIENT_H
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <stdint.h>
 #include <string>
 
@@ -26,8 +26,7 @@ class HTTPLogClient {
 
   AsyncLogClient::Status GetSTH(ct::SignedTreeHead* sth);
 
-  AsyncLogClient::Status GetRoots(
-      std::vector<boost::shared_ptr<Cert> >* roots);
+  AsyncLogClient::Status GetRoots(std::vector<std::shared_ptr<Cert> >* roots);
 
   AsyncLogClient::Status QueryAuditProof(const std::string& merkle_leaf_hash,
                                          ct::MerkleAuditProof* proof);
@@ -41,7 +40,7 @@ class HTTPLogClient {
       int first, int last, std::vector<AsyncLogClient::Entry>* entries);
 
  private:
-  const boost::shared_ptr<libevent::Base> base_;
+  const std::shared_ptr<libevent::Base> base_;
   AsyncLogClient client_;
 
   DISALLOW_COPY_AND_ASSIGN(HTTPLogClient);

--- a/cpp/log/cert.cc
+++ b/cpp/log/cert.cc
@@ -18,8 +18,8 @@
 #include "merkletree/serial_hasher.h"
 #include "util/openssl_util.h"  // For LOG_OPENSSL_ERRORS
 
-using std::shared_ptr;
 using std::string;
+using std::unique_ptr;
 using util::ClearOpenSSLErrors;
 
 #if OPENSSL_VERSION_NUMBER < 0x10002000L
@@ -341,9 +341,7 @@ Cert::Status Cert::PemEncoding(string* result) const {
     return ERROR;
   }
 
-  // TODO(pphaneuf): I would have liked to use std::unique_ptr, but it
-  // is not available to us yet (C++11).
-  shared_ptr<BIO> bp(BIO_new(BIO_s_mem()), BIO_free);
+  unique_ptr<BIO, int (*)(BIO*)> bp(BIO_new(BIO_s_mem()), &BIO_free);
   if (!PEM_write_bio_X509(bp.get(), x509_)) {
     LOG(WARNING) << "Failed to serialize cert";
     LOG_OPENSSL_ERRORS(WARNING);

--- a/cpp/log/cert.cc
+++ b/cpp/log/cert.cc
@@ -1,8 +1,8 @@
 /* -*- indent-tabs-mode: nil -*- */
 #include "log/cert.h"
 
-#include <boost/shared_ptr.hpp>
 #include <glog/logging.h>
+#include <memory>
 #include <openssl/asn1.h>
 #include <openssl/bio.h>
 #include <openssl/err.h>
@@ -18,7 +18,7 @@
 #include "merkletree/serial_hasher.h"
 #include "util/openssl_util.h"  // For LOG_OPENSSL_ERRORS
 
-using boost::shared_ptr;
+using std::shared_ptr;
 using std::string;
 using util::ClearOpenSSLErrors;
 

--- a/cpp/server/ct-server.cc
+++ b/cpp/server/ct-server.cc
@@ -1,11 +1,10 @@
 /* -*- indent-tabs-mode: nil -*- */
 
-#include <boost/bind.hpp>
-#include <boost/function.hpp>
-#include <boost/make_shared.hpp>
-#include <boost/scoped_ptr.hpp>
 #include <event2/thread.h>
+#include <functional>
 #include <gflags/gflags.h>
+#include <iostream>
+#include <memory>
 #include <openssl/err.h>
 #include <string>
 
@@ -54,17 +53,16 @@ DEFINE_int32(tree_signing_frequency_seconds, 600,
 
 namespace libevent = cert_trans::libevent;
 
-using boost::bind;
-using boost::function;
-using boost::make_shared;
-using boost::scoped_ptr;
-using boost::shared_ptr;
 using cert_trans::CertChecker;
 using cert_trans::HttpHandler;
 using cert_trans::LoggedCertificate;
 using cert_trans::ThreadPool;
 using cert_trans::util::ReadPrivateKey;
 using google::RegisterFlagValidator;
+using std::bind;
+using std::function;
+using std::make_shared;
+using std::shared_ptr;
 using std::string;
 
 static const int kCtimeBufSize = 26;
@@ -235,8 +233,8 @@ int main(int argc, char* argv[]) {
   HttpHandler handler(&log_lookup, db, &checker, &frontend, &pool);
 
   PeriodicCallback tree_event(event_base, FLAGS_tree_signing_frequency_seconds,
-                              boost::bind(&SignMerkleTree, &tree_signer,
-                                          &log_lookup));
+                              bind(&SignMerkleTree, &tree_signer,
+                                   &log_lookup));
 
   libevent::HttpServer server(*event_base);
   handler.Add(&server);

--- a/cpp/server/event.h
+++ b/cpp/server/event.h
@@ -46,8 +46,7 @@ class FD {
 
   FD(EventLoop* loop, int fd, CanDelete deletable = DELETE);
 
-  virtual ~FD() {
-  }
+  virtual ~FD() = default;
 
   virtual bool WantsWrite() const = 0;
 

--- a/cpp/server/handler.cc
+++ b/cpp/server/handler.cc
@@ -1,15 +1,14 @@
 #include "server/handler.h"
 
 #include <algorithm>
-#include <boost/bind.hpp>
-#include <boost/make_shared.hpp>
-#include <boost/scoped_array.hpp>
 #include <event2/buffer.h>
 #include <event2/http.h>
 #include <event2/keyvalq_struct.h>
+#include <functional>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <map>
+#include <memory>
 #include <stdlib.h>
 #include <utility>
 #include <vector>
@@ -22,10 +21,6 @@
 #include "util/json_wrapper.h"
 #include "util/thread_pool.h"
 
-using boost::bind;
-using boost::make_shared;
-using boost::scoped_array;
-using boost::shared_ptr;
 using cert_trans::Cert;
 using cert_trans::CertChain;
 using cert_trans::CertChecker;
@@ -34,8 +29,12 @@ using cert_trans::LoggedCertificate;
 using ct::ShortMerkleAuditProof;
 using ct::SignedCertificateTimestamp;
 using ct::SignedTreeHead;
+using std::bind;
 using std::make_pair;
+using std::make_shared;
 using std::multimap;
+using std::placeholders::_1;
+using std::shared_ptr;
 using std::string;
 using std::vector;
 

--- a/cpp/server/handler.cc
+++ b/cpp/server/handler.cc
@@ -36,6 +36,7 @@ using std::multimap;
 using std::placeholders::_1;
 using std::shared_ptr;
 using std::string;
+using std::unique_ptr;
 using std::vector;
 
 DEFINE_int32(max_leaf_entries_per_response, 1000,
@@ -135,17 +136,14 @@ bool ExtractChain(evhttp_request* req, CertChain* chain) {
       return false;
     }
 
-    // TODO(pphaneuf): I would have used unique_ptr here to release
-    // the ownership, but we can't use it yet (C++11).
-    Cert* const cert(new Cert);
+    unique_ptr<Cert> cert(new Cert);
     cert->LoadFromDerString(json_cert.FromBase64());
     if (!cert->IsLoaded()) {
-      delete cert;
       SendError(req, HTTP_BADREQUEST, "Unable to parse provided chain.");
       return false;
     }
 
-    chain->AddCert(cert);
+    chain->AddCert(cert.release());
   }
 
   return true;

--- a/cpp/server/handler.h
+++ b/cpp/server/handler.h
@@ -1,6 +1,7 @@
 #ifndef CERT_TRANS_SERVER_HANDLER_H_
 #define CERT_TRANS_SERVER_HANDLER_H_
 
+#include <memory>
 #include <string>
 
 #include "util/libevent_wrapper.h"
@@ -40,9 +41,9 @@ class HttpHandler {
 
   void BlockingGetEntries(evhttp_request* req, int start, int end) const;
   void BlockingAddChain(evhttp_request* req,
-                        const boost::shared_ptr<CertChain>& chain) const;
+                        const std::shared_ptr<CertChain>& chain) const;
   void BlockingAddPreChain(evhttp_request* req,
-                           const boost::shared_ptr<PreCertChain>& chain) const;
+                           const std::shared_ptr<PreCertChain>& chain) const;
 
   LogLookup<LoggedCertificate>* const log_lookup_;
   const Database<LoggedCertificate>* const db_;

--- a/cpp/util/json_wrapper.cc
+++ b/cpp/util/json_wrapper.cc
@@ -2,14 +2,12 @@
 
 #include <memory>
 
-using std::shared_ptr;
+using std::unique_ptr;
 
 
 JsonObject::JsonObject(evbuffer* buffer) : obj_(NULL) {
-  // TODO(pphaneuf): We just want a deleter, but unique_ptr is not
-  // available to us yet (C++11).
-  const shared_ptr<json_tokener> tokener(json_tokener_new(),
-                                         json_tokener_free);
+  const unique_ptr<json_tokener, void (*)(json_tokener*)> tokener(
+      json_tokener_new(), json_tokener_free);
 
   evbuffer_ptr ptr;
   evbuffer_ptr_set(buffer, &ptr, 0, EVBUFFER_PTR_SET);

--- a/cpp/util/json_wrapper.cc
+++ b/cpp/util/json_wrapper.cc
@@ -1,8 +1,8 @@
 #include "json_wrapper.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
-using boost::shared_ptr;
+using std::shared_ptr;
 
 
 JsonObject::JsonObject(evbuffer* buffer) : obj_(NULL) {

--- a/cpp/util/json_wrapper_test.cc
+++ b/cpp/util/json_wrapper_test.cc
@@ -1,12 +1,12 @@
 #include "util/json_wrapper.h"
 
-#include <boost/shared_ptr.hpp>
 #include <gtest/gtest.h>
+#include <memory>
 
 #include "util/testing.h"
 #include "util/util.h"
 
-using boost::shared_ptr;
+using std::shared_ptr;
 using std::string;
 
 class JsonWrapperTest : public ::testing::Test {};

--- a/cpp/util/libevent_wrapper.cc
+++ b/cpp/util/libevent_wrapper.cc
@@ -6,9 +6,9 @@
 
 #include "base/time_support.h"
 
-using boost::lock_guard;
-using boost::mutex;
-using boost::shared_ptr;
+using std::lock_guard;
+using std::mutex;
+using std::shared_ptr;
 using std::string;
 using std::vector;
 

--- a/cpp/util/libevent_wrapper.h
+++ b/cpp/util/libevent_wrapper.h
@@ -1,13 +1,12 @@
 #ifndef CERT_TRANS_UTIL_LIBEVENT_WRAPPER_H_
 #define CERT_TRANS_UTIL_LIBEVENT_WRAPPER_H_
 
-#include <boost/function.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/thread.hpp>
-#include <boost/thread.hpp>
 #include <event2/dns.h>
 #include <event2/event.h>
 #include <event2/http.h>
+#include <functional>
+#include <memory>
+#include <mutex>
 #include <vector>
 
 #include "base/macros.h"
@@ -21,7 +20,7 @@ class Event;
 
 class Base {
  public:
-  typedef boost::function<void(evutil_socket_t, short)> Callback;
+  typedef std::function<void(evutil_socket_t, short)> Callback;
 
   Base();
   ~Base();
@@ -39,7 +38,7 @@ class Base {
  private:
   event_base* const base_;
 
-  boost::mutex dns_lock_;
+  std::mutex dns_lock_;
   evdns_base* dns_;
 
   DISALLOW_COPY_AND_ASSIGN(Base);
@@ -48,7 +47,7 @@ class Base {
 
 class Event {
  public:
-  typedef boost::function<void(evutil_socket_t, short)> Callback;
+  typedef std::function<void(evutil_socket_t, short)> Callback;
 
   Event(const Base& base, evutil_socket_t sock, short events,
         const Callback& cb);
@@ -68,7 +67,7 @@ class Event {
 
 class HttpServer {
  public:
-  typedef boost::function<void(evhttp_request*)> HandlerCallback;
+  typedef std::function<void(evhttp_request*)> HandlerCallback;
 
   explicit HttpServer(const Base& base);
   ~HttpServer();
@@ -94,7 +93,7 @@ class HttpServer {
 
 class HttpRequest {
  public:
-  typedef boost::function<void(HttpRequest*)> Callback;
+  typedef std::function<void(HttpRequest*)> Callback;
 
   explicit HttpRequest(const Callback& callback);
   ~HttpRequest();
@@ -115,7 +114,7 @@ class HttpRequest {
 
 class HttpConnection {
  public:
-  HttpConnection(const boost::shared_ptr<Base>& base, const evhttp_uri* uri);
+  HttpConnection(const std::shared_ptr<Base>& base, const evhttp_uri* uri);
   ~HttpConnection();
 
   // Takes ownership of "req", which will be automatically deleted

--- a/cpp/util/thread_pool.cc
+++ b/cpp/util/thread_pool.cc
@@ -25,11 +25,9 @@ class ThreadPool::Impl {
 
   void Worker();
 
-  // TODO(pphaneuf): Would have used vector<thread>, but this requires
-  // emplace_back, which is not available to us yet (C++11). I'd also
-  // like it to be const, but it required to jump a few more hoops,
-  // keeping it simple for now.
-  vector<thread*> threads_;
+  // TODO(pphaneuf): I'd like this to be const, but it required
+  // jumping through a few more hoops, keeping it simple for now.
+  vector<thread> threads_;
 
   mutex queue_lock_;
   condition_variable queue_cond_var_;
@@ -50,10 +48,8 @@ ThreadPool::Impl::~Impl() {
   queue_cond_var_.notify_all();
 
   // Wait for the threads to exit.
-  for (vector<thread*>::const_iterator it = threads_.begin();
-       it != threads_.end(); ++it) {
-    (*it)->join();
-    delete *it;
+  for (auto& thread : threads_) {
+    thread.join();
   }
 }
 
@@ -94,7 +90,7 @@ ThreadPool::ThreadPool() : impl_(new Impl) {
 
   LOG(INFO) << "ThreadPool starting with " << num_threads << " threads";
   for (int i = 0; i < num_threads; ++i)
-    impl_->threads_.push_back(new thread(&Impl::Worker, impl_.get()));
+    impl_->threads_.emplace_back(thread(&Impl::Worker, impl_.get()));
 }
 
 

--- a/cpp/util/thread_pool.h
+++ b/cpp/util/thread_pool.h
@@ -1,8 +1,8 @@
 #ifndef CERT_TRANS_UTIL_THREAD_POOL_H_
 #define CERT_TRANS_UTIL_THREAD_POOL_H_
 
-#include <boost/function.hpp>
-#include <boost/scoped_ptr.hpp>
+#include <functional>
+#include <memory>
 
 #include "base/macros.h"
 
@@ -21,11 +21,11 @@ class ThreadPool {
 
   // Arranges for "closure" to be called in the thread pool. The
   // function must not be empty.
-  void Add(const boost::function<void()>& closure);
+  void Add(const std::function<void()>& closure);
 
  private:
   class Impl;
-  const boost::scoped_ptr<Impl> impl_;
+  const std::unique_ptr<Impl> impl_;
 
   DISALLOW_COPY_AND_ASSIGN(ThreadPool);
 };

--- a/go/merkletree/merkle_tree.go
+++ b/go/merkletree/merkle_tree.go
@@ -3,6 +3,7 @@ package merkletree
 /*
 #cgo LDFLAGS: -lcrypto -lglog
 #cgo CPPFLAGS: -I../../cpp
+#cgo CXXFLAGS: -std=c++11
 #include "merkle_tree_go.h"
 */
 import "C"


### PR DESCRIPTION
We've been using C++11 on the ```super_duper``` branch for a while, but there's no reason not to backport this (which helps minimize gratuitous differences).