### PR TITLE
Sanity checks of a request include "do we have one?".

### DIFF
--- a/cpp/client/async_log_client.cc
+++ b/cpp/client/async_log_client.cc
@@ -50,6 +50,11 @@ string UriEncode(const string& input) {
 // error if something is wrong.
 bool SanityCheck(libevent::HttpRequest* req,
                  const AsyncLogClient::Callback& done) {
+  if (!req) {
+    done(AsyncLogClient::UNKNOWN_ERROR);
+    return false;
+  }
+
   if (evhttp_request_get_response_code(req->get()) < 1) {
     done(AsyncLogClient::CONNECT_FAILED);
     return false;


### PR DESCRIPTION
See ```HttpRequest::Done``` for more "information".

This is a backport of 6d39c3551c4260a1b72d2306c6b0922dedb09659.