### PR TITLE
Add support for cancellation of fetches.

### DIFF
--- a/cpp/fetcher/fetcher.cc
+++ b/cpp/fetcher/fetcher.cc
@@ -105,6 +105,11 @@ void FetchState::WalkEntries() {
     return;
   }
 
+  if (task_->CancelRequested()) {
+    task_->Return(Status::CANCELLED);
+    return;
+  }
+
   lock_guard<mutex> lock(lock_);
 
   // Prune fetched sequences at the beginning.


### PR DESCRIPTION
This will be important, as a change of cluster membership will require cancelling an existing fetch.