### PR TITLE
Use unique_ptr&& to indicate passing of ownership.

### DIFF
--- a/cpp/fetcher/peer.cc
+++ b/cpp/fetcher/peer.cc
@@ -2,10 +2,13 @@
 
 #include <glog/logging.h>
 
+using std::unique_ptr;
+
 namespace cert_trans {
 
 
-Peer::Peer(AsyncLogClient* client) : client_(CHECK_NOTNULL(client)) {
+Peer::Peer(unique_ptr<AsyncLogClient>&& client) : client_(move(client)) {
+  CHECK(client_);
 }
 
 

--- a/cpp/fetcher/peer.h
+++ b/cpp/fetcher/peer.h
@@ -11,8 +11,7 @@ namespace cert_trans {
 
 class Peer {
  public:
-  // Takes ownership of "client".
-  Peer(AsyncLogClient* client);
+  Peer(std::unique_ptr<AsyncLogClient>&& client);
   virtual ~Peer() {
   }
 

--- a/cpp/fetcher/remote_peer.h
+++ b/cpp/fetcher/remote_peer.h
@@ -10,10 +10,10 @@ namespace cert_trans {
 
 class RemotePeer : public Peer {
  public:
-  // Takes ownership of "client" and "verifier". The "task" will
-  // return when the object is fully destroyed (destroying this object
-  // starts the asynchronous destruction).
-  RemotePeer(AsyncLogClient* client, LogVerifier* verifier, util::Task* task);
+  // The "task" will return when the object is fully destroyed
+  // (destroying this object starts the asynchronous destruction).
+  RemotePeer(std::unique_ptr<AsyncLogClient>&& client,
+             std::unique_ptr<LogVerifier>&& verifier, util::Task* task);
   ~RemotePeer() override;
 
   int64_t TreeSize() const override;


### PR DESCRIPTION
And avoid mistakes.