### PR TITLE
Clean up old entries from etcd.

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -280,7 +280,7 @@ log/frontend_signer_test: log/frontend_signer_test.o \
                           log/libcluster.a log/libdatabase.a \
                           merkletree/libmerkletree.a \
                           proto/libproto.a util/libutil.a base/notification.o \
-                          $(GTESTLIB)
+                          $(GTESTLIB) $(GMOCKLIB)
 
 log/frontend_test: log/frontend_test.o log/frontend.o \
                    log/frontend_signer.o \
@@ -288,12 +288,13 @@ log/frontend_test: log/frontend_test.o log/frontend.o \
                    log/log_verifier.o log/test_signer.o \
                    log/libcert.a log/libcluster.a log/libdatabase.a \
                    merkletree/libmerkletree.a \
-                   proto/libproto.a util/libutil.a base/notification.o $(GTESTLIB)
+                   proto/libproto.a util/libutil.a base/notification.o \
+                   $(GTESTLIB) $(GMOCKLIB)
 
 log/log_lookup_test: log/log_lookup_test.o log/test_signer.o \
                      log/libcluster.a log/libdatabase.a \
                      log/liblog.a merkletree/libmerkletree.a proto/libproto.a \
-                     util/libutil.a base/notification.o $(GTESTLIB)
+                     util/libutil.a base/notification.o $(GTESTLIB) $(GMOCKLIB)
 
 log/log_signer_test: log/log_signer_test.o log/log_signer.o log/signer.o \
                      log/verifier.o log/test_signer.o \
@@ -310,7 +311,7 @@ log/tree_signer_test: log/tree_signer_test.o log/log_signer.o log/signer.o \
                       log/log_verifier.o log/libcluster.a \
                       log/libdatabase.a merkletree/libmerkletree.a \
                       proto/libproto.a util/libutil.a base/notification.o \
-                      $(GTESTLIB)
+                      $(GTESTLIB) $(GMOCKLIB)
 
 log/logged_certificate_test: log/logged_certificate_test.o proto/libproto.a \
                              util/libutil.a merkletree/libmerkletree.a \

--- a/cpp/log/frontend_signer_test.cc
+++ b/cpp/log/frontend_signer_test.cc
@@ -17,6 +17,7 @@
 #include "proto/serializer.h"
 #include "util/fake_etcd.h"
 #include "util/libevent_wrapper.h"
+#include "util/mock_masterelection.h"
 #include "util/testing.h"
 #include "util/status.h"
 #include "util/util.h"
@@ -30,6 +31,7 @@ using cert_trans::EntryHandle;
 using cert_trans::EtcdConsistentStore;
 using cert_trans::FakeEtcdClient;
 using cert_trans::LoggedCertificate;
+using cert_trans::MockMasterElection;
 using cert_trans::ThreadPool;
 using ct::LogEntry;
 using ct::SignedCertificateTimestamp;
@@ -37,6 +39,7 @@ using std::make_shared;
 using std::shared_ptr;
 using std::string;
 using std::vector;
+using testing::NiceMock;
 
 typedef Database<LoggedCertificate> DB;
 typedef FrontendSigner FS;
@@ -53,7 +56,7 @@ class FrontendSignerTest : public ::testing::Test {
         event_pump_(base_),
         etcd_client_(base_),
         pool_(2),
-        store_(&pool_, &etcd_client_, "/root", "id"),
+        store_(&pool_, &etcd_client_, &election_, "/root", "id"),
         frontend_(db(), &store_, TestSigner::DefaultLogSigner()) {
   }
 
@@ -69,6 +72,7 @@ class FrontendSignerTest : public ::testing::Test {
   libevent::EventPumpThread event_pump_;
   FakeEtcdClient etcd_client_;
   ThreadPool pool_;
+  NiceMock<MockMasterElection> election_;
   EtcdConsistentStore<LoggedCertificate> store_;
   FS frontend_;
 };

--- a/cpp/log/frontend_test.cc
+++ b/cpp/log/frontend_test.cc
@@ -20,6 +20,7 @@
 #include "merkletree/serial_hasher.h"
 #include "proto/ct.pb.h"
 #include "util/fake_etcd.h"
+#include "util/mock_masterelection.h"
 #include "util/testing.h"
 #include "util/util.h"
 
@@ -57,6 +58,7 @@ using cert_trans::EtcdConsistentStore;
 using cert_trans::FakeEtcdClient;
 using cert_trans::EntryHandle;
 using cert_trans::LoggedCertificate;
+using cert_trans::MockMasterElection;
 using cert_trans::PreCertChain;
 using cert_trans::ThreadPool;
 using ct::LogEntry;
@@ -65,6 +67,7 @@ using std::make_shared;
 using std::shared_ptr;
 using std::string;
 using std::vector;
+using testing::NiceMock;
 
 typedef Database<LoggedCertificate> DB;
 typedef Frontend FE;
@@ -87,7 +90,7 @@ class FrontendTest : public ::testing::Test {
         event_pump_(base_),
         etcd_client_(base_),
         pool_(2),
-        store_(&pool_, &etcd_client_, "/root", "id"),
+        store_(&pool_, &etcd_client_, &election_, "/root", "id"),
         frontend_(new CertSubmissionHandler(&checker_),
                   new FrontendSigner(db(), &store_,
                                      TestSigner::DefaultLogSigner())) {
@@ -143,6 +146,7 @@ class FrontendTest : public ::testing::Test {
   libevent::EventPumpThread event_pump_;
   FakeEtcdClient etcd_client_;
   ThreadPool pool_;
+  NiceMock<MockMasterElection> election_;
   EtcdConsistentStore<LoggedCertificate> store_;
   FE frontend_;
   string cert_dir_;

--- a/cpp/log/log_lookup_test.cc
+++ b/cpp/log/log_lookup_test.cc
@@ -17,6 +17,7 @@
 #include "merkletree/merkle_verifier.h"
 #include "merkletree/serial_hasher.h"
 #include "util/fake_etcd.h"
+#include "util/mock_masterelection.h"
 #include "util/testing.h"
 #include "util/util.h"
 
@@ -27,12 +28,14 @@ namespace libevent = cert_trans::libevent;
 using cert_trans::EntryHandle;
 using cert_trans::FakeEtcdClient;
 using cert_trans::LoggedCertificate;
+using cert_trans::MockMasterElection;
 using cert_trans::ThreadPool;
 using cert_trans::TreeSigner;
 using ct::MerkleAuditProof;
 using std::make_shared;
 using std::string;
 using std::shared_ptr;
+using testing::NiceMock;
 
 typedef Database<LoggedCertificate> DB;
 typedef TreeSigner<LoggedCertificate> TS;
@@ -48,7 +51,7 @@ class LogLookupTest : public ::testing::Test {
         event_pump_(base_),
         etcd_client_(base_),
         pool_(2),
-        store_(&pool_, &etcd_client_, "/root", "id"),
+        store_(&pool_, &etcd_client_, &election_, "/root", "id"),
         test_signer_(),
         tree_signer_(std::chrono::duration<double>(0), db(), &store_,
                      TestSigner::DefaultLogSigner()),
@@ -79,6 +82,7 @@ class LogLookupTest : public ::testing::Test {
   libevent::EventPumpThread event_pump_;
   FakeEtcdClient etcd_client_;
   ThreadPool pool_;
+  NiceMock<MockMasterElection> election_;
   cert_trans::EtcdConsistentStore<LoggedCertificate> store_;
   TestSigner test_signer_;
   TS tree_signer_;

--- a/cpp/server/ct-server.cc
+++ b/cpp/server/ct-server.cc
@@ -257,9 +257,10 @@ int main(int argc, char* argv[]) {
   // via HTTP.
   ThreadPool internal_pool(4);
   StrictConsistentStore<LoggedCertificate> consistent_store(
-      &election, new EtcdConsistentStore<LoggedCertificate>(&internal_pool,
-                                                            etcd_client.get(),
-                                                            "/root", node_id));
+      &election,
+      new EtcdConsistentStore<LoggedCertificate>(&internal_pool,
+                                                 etcd_client.get(), &election,
+                                                 "/root", node_id));
 
   TreeSigner<LoggedCertificate> tree_signer(std::chrono::duration<double>(
                                                 FLAGS_guard_window_seconds),


### PR DESCRIPTION
Entries can be deleted from etcd's `/sequenced` and `/unsequenced` dirs once `/serving_sth` once they're covered by the cluster's `/serving_sth` (because that can only be updated once *sufficient* replication of those entries has occured.)