### PR TITLE
Swap two lines that were erroneously transposed.

### DIFF
--- a/cpp/merkletree/serial_hasher.cc
+++ b/cpp/merkletree/serial_hasher.cc
@@ -28,8 +28,8 @@ string Sha256Hasher::Final() {
 
   unsigned char hash[SHA256_DIGEST_LENGTH];
   SHA256_Final(hash, &ctx_);
-  return string(reinterpret_cast<char*>(hash), SHA256_DIGEST_LENGTH);
   initialized_ = false;
+  return string(reinterpret_cast<char*>(hash), SHA256_DIGEST_LENGTH);
 }
 
 SerialHasher* Sha256Hasher::Create() const {

--- a/cpp/merkletree/serial_hasher.h
+++ b/cpp/merkletree/serial_hasher.h
@@ -16,8 +16,10 @@ class SerialHasher {
 
   virtual size_t DigestSize() const = 0;
 
-  // Reset the context. Must be called before the first
-  // Update() call (and again after each Final() call).
+  // Reset the context. Must be called before the first Update() call.
+  // Optionally it can be called after each Final() call; however
+  // doing so is a no-op since Final() will leave the hasher in a
+  // reset state.
   virtual void Reset() = 0;
 
   // Update the hash context with (binary) data.


### PR DESCRIPTION
Looks like someone hit the editor key that swaps the line under the cursor with the line above.
The code as it stands does not reset initialized_ properly at the end of Sha256Hasher::Final().