### PR TITLE
Add mapping from LogVerifier::INVALID_MERKLE_PATH to debug string.

### DIFF
--- a/cpp/log/log_verifier.h
+++ b/cpp/log/log_verifier.h
@@ -44,6 +44,8 @@ class LogVerifier {
         return "Inconsistent timestamps.";
       case INVALID_SIGNATURE:
         return "Invalid signature.";
+      case INVALID_MERKLE_PATH:
+        return "Invalid Merkle path.";
       default:
         assert(false);
         return "";


### PR DESCRIPTION
The VerifyResultString() function got out of sync with the enum it accepts.