### PR TITLE
Add a tool for managing a cluster.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@
 /cpp/server/blob-server
 /cpp/server/ct-dns-server
 /cpp/server/ct-server
+/cpp/tools/clustertool
 /cpp/tools/dump_cert
 /cpp/tools/dump_sth
 /cpp/util/bench_etcd

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN groupadd -r ctlog && useradd -r -g ctlog ctlog
 RUN mkdir /mnt/ctlog
 COPY cpp/server/ct-server /usr/local/bin/
 COPY test/testdata/ct-server-key.pem /usr/local/etc/
+COPY cpp/tools/ct-clustertool /usr/local/bin/
 VOLUME /mnt/ctlog
 CMD cd /mnt/ctlog/ && \
     if [ ! -d logs ]; then mkdir logs; fi && \

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -102,8 +102,9 @@ EXTRA_TESTS = \
 	log/ct_extensions_test \
 	log/frontend_test
 
-all: client/ct server/ct-server server/ct-dns-server tools/dump_cert \
-     tools/dump_sth util/bench_etcd util/etcd_masterelection util/etcd_watch
+all: client/ct server/ct-server server/ct-dns-server tools/ct-clustertool \
+     tools/dump_cert tools/dump_sth util/bench_etcd util/etcd_masterelection \
+     util/etcd_watch
 
 tests: all $(TESTS) $(DISABLED_TESTS) $(EXTRA_TESTS)
 
@@ -345,6 +346,13 @@ server/ct-server: server/ct-server.o util/read_key.o server/handler.o \
 	base/notification.o log/logged_certificate.o fetcher/fetcher.o \
         fetcher/peer.o fetcher/peer_group.o fetcher/remote_peer.o \
         client/async_log_client.o $(LOCAL_LIBS)
+
+tools/ct-clustertool: tools/clustertool_main.o \
+                      merkletree/libmerkletree.a util/read_key.o \
+                      base/notification.o merkletree/serial_hasher.o \
+                      log/libcluster.a log/libdatabase.a \
+                      log/liblog.a util/libutil.a proto/libproto.a
+	$(CXX) -o $@ $(LDLIBS) $^
 
 tools/dump_cert: tools/dump_cert.o proto/libproto.a util/libutil.a
 

--- a/cpp/tools/clustertool-inl.h
+++ b/cpp/tools/clustertool-inl.h
@@ -1,0 +1,60 @@
+#ifndef CERT_TRANS_TOOLS_CLUSTERTOOL_INL_H_
+#define CERT_TRANS_TOOLS_CLUSTERTOOL_INL_H_
+#include <event2/thread.h>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <google/protobuf/text_format.h>
+#include <memory>
+#include <openssl/err.h>
+#include <string>
+
+#include "util/etcd.h"
+#include "log/etcd_consistent_store.h"
+#include "log/logged_certificate.h"
+#include "log/log_signer.h"
+#include "log/sqlite_db.h"
+#include "log/strict_consistent_store.h"
+#include "log/tree_signer.h"
+#include "proto/ct.pb.h"
+#include "tools/clustertool.h"
+#include "util/masterelection.h"
+#include "util/read_key.h"
+#include "util/status.h"
+#include "util/thread_pool.h"
+
+namespace cert_trans {
+
+// TODO(alcutter): have a way of passing in other configs
+const char kDefaultClusterConfig[] =
+    "minimum_serving_nodes: 2\n"
+    "minimum_serving_fraction: 0.75\n";
+
+
+// static
+template <class Logged>
+util::Status ClusterTool<Logged>::InitLog(
+    TreeSigner<Logged>* tree_signer,
+    ConsistentStore<Logged>* consistent_store) {
+  if (tree_signer->UpdateTree() != TreeSigner<LoggedCertificate>::OK) {
+    return util::Status(util::error::UNKNOWN, "Failed to Update Tree");
+  }
+
+  util::Status status(
+      consistent_store->SetServingSTH(tree_signer->LatestSTH()));
+  if (!status.ok()) {
+    return status;
+  }
+
+  ct::ClusterConfig config;
+  if (!google::protobuf::TextFormat::ParseFromString(kDefaultClusterConfig,
+                                                     &config)) {
+    return util::Status(util::error::INVALID_ARGUMENT,
+                        "Couldn't parse ClusterConfig");
+  }
+  status = consistent_store->SetClusterConfig(config);
+  return status;
+}
+
+
+}  // namespace cert_trans
+#endif  // CERT_TRANS_TOOLS_CLUSTERTOOL_INL_H_

--- a/cpp/tools/clustertool.h
+++ b/cpp/tools/clustertool.h
@@ -1,0 +1,24 @@
+#ifndef CERT_TRANS_TOOLS_CLUSTERTOOL_H_
+#define CERT_TRANS_TOOLS_CLUSTERTOOL_H_
+
+namespace cert_trans {
+
+
+template <class Logged>
+class ClusterTool {
+ public:
+  // Initialise a fresh log cluster:
+  //  - Creates /serving_sth containing a new STH of size zero
+  //  - Creates the /cluster_config entry.
+  static util::Status InitLog(TreeSigner<Logged>* tree_signer,
+                              ConsistentStore<Logged>* consistent_store);
+
+ private:
+  ClusterTool() = default;
+};
+
+
+}  // namespace cert_trans
+
+
+#endif  // CERT_TRANS_TOOLS_CLUSTERTOOL_H_

--- a/cpp/tools/clustertool_main.cc
+++ b/cpp/tools/clustertool_main.cc
@@ -1,0 +1,110 @@
+#include <event2/thread.h>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <iostream>
+#include <openssl/err.h>
+
+#include "util/etcd.h"
+#include "log/etcd_consistent_store.h"
+#include "log/logged_certificate.h"
+#include "log/log_signer.h"
+#include "log/sqlite_db.h"
+#include "log/strict_consistent_store.h"
+#include "log/tree_signer.h"
+#include "proto/ct.pb.h"
+#include "tools/clustertool-inl.h"
+#include "util/masterelection.h"
+#include "util/read_key.h"
+#include "util/status.h"
+#include "util/thread_pool.h"
+
+namespace libevent = cert_trans::libevent;
+
+using cert_trans::ClusterTool;
+using cert_trans::EtcdClient;
+using cert_trans::EtcdConsistentStore;
+using cert_trans::LoggedCertificate;
+using cert_trans::MasterElection;
+using cert_trans::ReadPrivateKey;
+using cert_trans::StrictConsistentStore;
+using cert_trans::ThreadPool;
+using cert_trans::TreeSigner;
+using ct::ClusterConfig;
+using ct::SignedTreeHead;
+using libevent::EventPumpThread;
+using std::make_shared;
+using std::shared_ptr;
+using std::string;
+using util::Status;
+
+DEFINE_string(key, "", "PEM-encoded server private key file");
+DEFINE_string(etcd_host, "", "Hostname of the etcd server");
+DEFINE_int32(etcd_port, 0, "Port of the etcd server.");
+
+
+void Usage() {
+  std::cerr << "Usage:\n"
+            << "  clustertool [flags] <command> [command opts]\n"
+            << "\n"
+            << "Commands:\n"
+            << "  initlog     Initialise a new log.\n";
+}
+
+
+int main(int argc, char* argv[]) {
+  google::ParseCommandLineFlags(&argc, &argv, true);
+  google::InitGoogleLogging(argv[0]);
+  OpenSSL_add_all_algorithms();
+  ERR_load_crypto_strings();
+  evthread_use_pthreads();
+
+  if (argc == 1) {
+    Usage();
+    return util::error::INVALID_ARGUMENT;
+  }
+
+  CHECK(!FLAGS_key.empty());
+  CHECK(!FLAGS_etcd_host.empty());
+  CHECK_NE(0, FLAGS_etcd_port);
+
+  util::StatusOr<EVP_PKEY*> pkey(ReadPrivateKey(FLAGS_key));
+  CHECK_EQ(pkey.status(), util::Status::OK);
+  LogSigner log_signer(pkey.ValueOrDie());
+
+  const shared_ptr<libevent::Base> event_base(make_shared<libevent::Base>());
+  std::unique_ptr<libevent::EventPumpThread> pump(
+      new libevent::EventPumpThread(event_base));
+
+  EtcdClient etcd_client(event_base, FLAGS_etcd_host, FLAGS_etcd_port);
+
+  const string kLockDir("/election");
+  const string node_id("clustertool");
+  MasterElection election(event_base, &etcd_client, kLockDir, node_id);
+  election.StartElection();
+  election.WaitToBecomeMaster();
+
+  ThreadPool internal_pool(4);
+  StrictConsistentStore<LoggedCertificate> consistent_store(
+      &election,
+      new EtcdConsistentStore<LoggedCertificate>(&internal_pool, &etcd_client,
+                                                 &election, "/root", node_id));
+
+  SQLiteDB<LoggedCertificate> db("/tmp/loginitdb");
+  TreeSigner<LoggedCertificate> tree_signer(std::chrono::duration<double>(0),
+                                            &db, &consistent_store,
+                                            &log_signer);
+
+  const string command(argv[1]);
+  Status status;
+  if (command == "initlog") {
+    status = ClusterTool<LoggedCertificate>::InitLog(&tree_signer,
+                                                     &consistent_store);
+  } else {
+    Usage();
+  }
+
+  LOG(INFO) << status;
+  election.StopElection();
+
+  return status.error_code();
+}


### PR DESCRIPTION
Currently only has a method to initialise the default entries in etcd.
Laid out as it is with the intention of being able to call into it from `ct-server.cc` when that's being run in "standalone" mode in order to get its `FakeEtcd` initialised too.