### PR TITLE
Fix two small mistakes.

### DIFF
--- a/cpp/fetcher/peer.cc
+++ b/cpp/fetcher/peer.cc
@@ -8,7 +8,7 @@ namespace cert_trans {
 
 
 Peer::Peer(unique_ptr<AsyncLogClient>&& client) : client_(move(client)) {
-  CHECK(client_);
+  CHECK_NOTNULL(client_.get());
 }
 
 

--- a/cpp/log/cluster_state_controller-inl.h
+++ b/cpp/log/cluster_state_controller-inl.h
@@ -34,7 +34,7 @@ std::unique_ptr<AsyncLogClient> BuildAsyncLogClient(
 
 
 template <class Logged>
-class ClusterStateController<Logged>::ClusterPeer : Peer {
+class ClusterStateController<Logged>::ClusterPeer : public Peer {
  public:
   ClusterPeer(const std::shared_ptr<libevent::Base>& base,
               const ct::ClusterNodeState& state)


### PR DESCRIPTION
The ```CHECK_NOTNULL``` only improves the logs, but the missing ```public``` keyword has an impact on an upcoming pull requests.