### PR TITLE
Make TreeHasher thread-safe.

### DIFF
--- a/cpp/merkletree/tree_hasher.cc
+++ b/cpp/merkletree/tree_hasher.cc
@@ -10,8 +10,8 @@ using std::string;
 
 namespace {
 
-const string kLeafPrefix(1, '\x00');
-const string kNodePrefix(1, '\x01');
+const char kLeafPrefix('\x00');
+const char kNodePrefix('\x01');
 
 std::string EmptyHash(SerialHasher* hasher) {
   hasher->Reset();
@@ -27,7 +27,7 @@ TreeHasher::TreeHasher(SerialHasher* hasher)
 string TreeHasher::HashLeaf(const string& data) const {
   lock_guard<mutex> lock(lock_);
   hasher_->Reset();
-  hasher_->Update(kLeafPrefix);
+  hasher_->Update(string(1, kLeafPrefix));
   hasher_->Update(data);
   return hasher_->Final();
 }
@@ -36,7 +36,7 @@ string TreeHasher::HashChildren(const string& left_child,
                                 const string& right_child) const {
   lock_guard<mutex> lock(lock_);
   hasher_->Reset();
-  hasher_->Update(kNodePrefix);
+  hasher_->Update(string(1, kNodePrefix));
   hasher_->Update(left_child);
   hasher_->Update(right_child);
   return hasher_->Final();

--- a/cpp/merkletree/tree_hasher.cc
+++ b/cpp/merkletree/tree_hasher.cc
@@ -1,31 +1,31 @@
 #include "merkletree/tree_hasher.h"
 
+#include <glog/logging.h>
+
 #include "merkletree/serial_hasher.h"
 
+using std::lock_guard;
+using std::mutex;
 using std::string;
 
-const string TreeHasher::kLeafPrefix(1, '\x00');
-const string TreeHasher::kNodePrefix(1, '\x01');
+namespace {
 
-TreeHasher::TreeHasher(SerialHasher* hasher) : hasher_(hasher) {
+const string kLeafPrefix(1, '\x00');
+const string kNodePrefix(1, '\x01');
+
+std::string EmptyHash(SerialHasher* hasher) {
+  hasher->Reset();
+  return hasher->Final();
 }
 
-TreeHasher::~TreeHasher() {
-  delete hasher_;
-}
+}  // namespace
 
-string TreeHasher::HashEmpty() {
-  if (emptyhash_.empty()) {
-    // First call to HashEmpty(); since the hash of an empty string is
-    // constant,
-    // set it up once and for all.
-    hasher_->Reset();
-    emptyhash_ = hasher_->Final();
-  }
-  return emptyhash_;
+TreeHasher::TreeHasher(SerialHasher* hasher)
+    : hasher_(CHECK_NOTNULL(hasher)), empty_hash_(EmptyHash(hasher_.get())) {
 }
 
 string TreeHasher::HashLeaf(const string& data) const {
+  lock_guard<mutex> lock(lock_);
   hasher_->Reset();
   hasher_->Update(kLeafPrefix);
   hasher_->Update(data);
@@ -33,7 +33,8 @@ string TreeHasher::HashLeaf(const string& data) const {
 }
 
 string TreeHasher::HashChildren(const string& left_child,
-                                const string& right_child) {
+                                const string& right_child) const {
+  lock_guard<mutex> lock(lock_);
   hasher_->Reset();
   hasher_->Update(kNodePrefix);
   hasher_->Update(left_child);

--- a/cpp/merkletree/tree_hasher.h
+++ b/cpp/merkletree/tree_hasher.h
@@ -1,7 +1,10 @@
 #ifndef TREEHASHER_H
 #define TREEHASHER_H
 
+#include <memory>
+#include <mutex>
 #include <stddef.h>
+#include <string>
 
 #include "base/macros.h"
 #include "merkletree/serial_hasher.h"
@@ -10,28 +13,28 @@ class TreeHasher {
  public:
   // Takes ownership of the SerialHasher.
   TreeHasher(SerialHasher* hasher);
-  ~TreeHasher();
 
   size_t DigestSize() const {
     return hasher_->DigestSize();
   }
 
-  std::string HashEmpty();
+  const std::string& HashEmpty() const {
+    return empty_hash_;
+  }
 
   std::string HashLeaf(const std::string& data) const;
 
-  // Accepts arbitrary strings as children. When hashing
-  // digests, it is the responsibility of the caller to
-  // ensure the inputs are of correct size.
+  // Accepts arbitrary strings as children. When hashing digests, it
+  // is the responsibility of the caller to ensure the inputs are of
+  // correct size.
   std::string HashChildren(const std::string& left_child,
-                           const std::string& right_child);
+                           const std::string& right_child) const;
 
  private:
-  SerialHasher* hasher_;
-  static const std::string kLeafPrefix;
-  static const std::string kNodePrefix;
-  // The dummy hash of an empty tree.
-  std::string emptyhash_;
+  mutable std::mutex lock_;
+  const std::unique_ptr<SerialHasher> hasher_;
+  // The pre-computed hash of an empty tree.
+  const std::string empty_hash_;
 
   DISALLOW_COPY_AND_ASSIGN(TreeHasher);
 };


### PR DESCRIPTION
Also, a few other cleanups: formatting, hiding constants away, improved const-correctness, etc...