### PR TITLE
Install a signal handler to get stack traces.

### DIFF
--- a/cpp/server/ct-server.cc
+++ b/cpp/server/ct-server.cc
@@ -178,6 +178,7 @@ void SignMerkleTree(TreeSigner<LoggedCertificate>* tree_signer,
 int main(int argc, char* argv[]) {
   google::ParseCommandLineFlags(&argc, &argv, true);
   google::InitGoogleLogging(argv[0]);
+  google::InstallFailureSignalHandler();
   OpenSSL_add_all_algorithms();
   ERR_load_crypto_strings();
   cert_trans::LoadCtExtensions();


### PR DESCRIPTION
This is a backport of 91cf65f07dec3cee1a14820b9450d8878e3e8f12.