### PR TITLE
Python: API for verifying SCTs.

### DIFF
--- a/python/ct/crypto/error.py
+++ b/python/ct/crypto/error.py
@@ -118,6 +118,11 @@ class SignatureError(VerifyError):
     pass
 
 
+class UnsupportedVersionError(Error):
+    """The version of the data structure is unknown."""
+    pass
+
+
 def returns_true_or_raises(f):
     """A safety net.
 

--- a/python/ct/crypto/tools/verify_util.py
+++ b/python/ct/crypto/tools/verify_util.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+"""verify_util.py: CT signature verification utility.
+
+Usage:
+
+  verify_util.py <command> [flags] [cert_file]
+
+Known commands:
+
+  verify_sct: Verify Signed Certificate Timestamp over X.509 certificate.
+
+  The cert_file must contain one or more PEM-encoded certificates.
+
+  For example:
+
+  verify_util.py verify_sct --sct=cert_sct.tls --log_key=log_key.pem cert.pem
+"""
+
+import sys
+from ct.crypto import cert
+from ct.crypto import verify
+from ct.proto import client_pb2
+from ct.serialization import tls_message
+import gflags
+
+FLAGS = gflags.FLAGS
+gflags.DEFINE_string("sct", None, "TLS-encoded SCT file")
+gflags.DEFINE_string("log_key", None, "PEM-encoded CT log key")
+
+def exit_with_message(error_message):
+    print error_message
+    print "Use --helpshort or --help to get help."
+    sys.exit(1)
+
+
+def verify_sct(c, sct_tls, log_key_pem):
+    sct = client_pb2.SignedCertificateTimestamp()
+    tls_message.decode(sct_tls, sct)
+
+    key_info = client_pb2.KeyInfo()
+    key_info.type = client_pb2.KeyInfo.ECDSA
+    key_info.pem_key = log_key_pem
+
+    lv = verify.LogVerifier(key_info)
+    print lv.verify_sct(sct, c)
+
+
+def main(argv):
+    if len(argv) <= 1 or argv[1][0] == "-":
+        # No command. Parse flags anyway to trigger help flags.
+        try:
+            argv = FLAGS(argv)
+            exit_with_message("No command")
+        except gflags.FlagsError as e:
+            exit_with_message("Error parsing flags: %s" % e)
+
+    argv = argv[1:]
+
+    try:
+        argv = FLAGS(argv)
+    except gflags.FlagsError as e:
+        exit_with_message("Error parsing flags: %s" % e)
+
+    command, cert_file = (argv[0:2])
+
+    if command != "verify_sct":
+        exit_with_message("Unknown command %s" % command)
+
+    if not cert_file:
+        exit_with_message("No certificate file given")
+
+    verify_sct(cert.Certificate.from_pem_file(cert_file, strict_der=False),
+               open(FLAGS.sct, 'rb').read(),
+               open(FLAGS.log_key, 'rb').read())
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/python/ct/proto/client.proto
+++ b/python/ct/proto/client.proto
@@ -110,6 +110,12 @@ enum LogEntryType {
   PRECERT_ENTRY = 1;
 }
 
+enum SignatureType {
+  option (tls_enum_opts).max_value = 255;
+  CERTIFICATE_TIMESTAMP = 0;
+  TREE_HASH = 1;
+}
+
 message PreCert {
   optional bytes issuer_key_hash = 1 [(tls_opts).fixed_length = 32];
   optional bytes tbs_certificate = 2 [(tls_opts).min_length = 1,
@@ -126,6 +132,22 @@ message TimestampedEntry {
   optional PreCert pre_cert = 4 [(tls_opts).select_field = "entry_type",
                                 (tls_opts).select_value = 1];
   optional bytes ct_extensions = 5 [(tls_opts).max_length = 0xffff];
+}
+
+
+message DigitallySignedTimestampedEntry {
+  optional Version sct_version = 1;
+  optional SignatureType signature_type = 2 [default = CERTIFICATE_TIMESTAMP];
+  optional uint64 timestamp = 3;
+  optional LogEntryType entry_type = 4;
+  optional bytes asn1_cert = 5 [(tls_opts).select_field = "entry_type",
+                                (tls_opts).select_value = 0,
+                                (tls_opts).min_length = 1,
+                                (tls_opts).max_length = 0xffffff];
+  optional PreCert pre_cert = 6 [(tls_opts).select_field = "entry_type",
+                                (tls_opts).select_value = 1];
+  optional bytes ct_extensions = 7 [(tls_opts).min_length = 0,
+                                    (tls_opts).max_length = 0xffff];
 }
 
 message MerkleTreeLeaf {


### PR DESCRIPTION
Only for X.509 certificates (not Precertificates), for now.