### PR TITLE
Clear the HTTP headers in a response before filling them in.

### DIFF
--- a/cpp/net/url_fetcher.cc
+++ b/cpp/net/url_fetcher.cc
@@ -151,6 +151,7 @@ void State::RequestDone(evhttp_request* req) {
     return;
   }
 
+  response_->headers.clear();
   for (evkeyval* ptr = evhttp_request_get_input_headers(req)->tqh_first; ptr;
        ptr = ptr->next.tqe_next) {
     response_->headers.insert(make_pair(ptr->key, ptr->value));


### PR DESCRIPTION
This caused a bug if you re-used an UrlFetcher::Response.