### PR TITLE
A few improvements to UrlFetcher

### DIFF
--- a/cpp/client/async_log_client.cc
+++ b/cpp/client/async_log_client.cc
@@ -354,9 +354,9 @@ AsyncLogClient::AsyncLogClient(util::Executor* const executor,
 
 void AsyncLogClient::GetSTH(SignedTreeHead* sth, const Callback& done) {
   UrlFetcher::Response* const resp(new UrlFetcher::Response);
-  fetcher_->Get(GetURL("get-sth"), resp,
-                new util::Task(bind(DoneGetSTH, resp, sth, done, _1),
-                               executor_));
+  fetcher_->Fetch(GetURL("get-sth"), resp,
+                  new util::Task(bind(DoneGetSTH, resp, sth, done, _1),
+                                 executor_));
 }
 
 
@@ -364,9 +364,9 @@ void AsyncLogClient::GetRoots(vector<shared_ptr<Cert> >* roots,
                               const Callback& done) {
   UrlFetcher::Response* const resp(new UrlFetcher::Response);
 
-  fetcher_->Get(GetURL("get-roots"), resp,
-                new util::Task(bind(DoneGetRoots, resp, roots, done, _1),
-                               executor_));
+  fetcher_->Fetch(GetURL("get-roots"), resp,
+                  new util::Task(bind(DoneGetRoots, resp, roots, done, _1),
+                                 executor_));
 }
 
 
@@ -385,9 +385,9 @@ void AsyncLogClient::GetEntries(int first, int last,
   url.SetQuery("start=" + to_string(first) + "&end=" + to_string(last));
 
   UrlFetcher::Response* const resp(new UrlFetcher::Response);
-  fetcher_->Get(url, resp,
-                new util::Task(bind(DoneGetEntries, resp, entries, done, _1),
-                               executor_));
+  fetcher_->Fetch(url, resp,
+                  new util::Task(bind(DoneGetEntries, resp, entries, done, _1),
+                                 executor_));
 }
 
 
@@ -402,9 +402,9 @@ void AsyncLogClient::QueryInclusionProof(const SignedTreeHead& sth,
                "&tree_size=" + to_string(sth.tree_size()));
 
   UrlFetcher::Response* const resp(new UrlFetcher::Response);
-  fetcher_->Get(url, resp, new util::Task(bind(DoneQueryInclusionProof, resp,
-                                               sth, proof, done, _1),
-                                          executor_));
+  fetcher_->Fetch(url, resp, new util::Task(bind(DoneQueryInclusionProof, resp,
+                                                 sth, proof, done, _1),
+                                            executor_));
 }
 
 
@@ -418,9 +418,9 @@ void AsyncLogClient::GetSTHConsistency(int64_t first, int64_t second,
   url.SetQuery("first=" + to_string(first) + "&second=" + to_string(second));
 
   UrlFetcher::Response* const resp(new UrlFetcher::Response);
-  fetcher_->Get(url, resp, new util::Task(bind(DoneGetSTHConsistency, resp,
-                                               proof, done, _1),
-                                          executor_));
+  fetcher_->Fetch(url, resp, new util::Task(bind(DoneGetSTHConsistency, resp,
+                                                 proof, done, _1),
+                                            executor_));
 }
 
 
@@ -464,12 +464,13 @@ void AsyncLogClient::InternalAddChain(const CertChain& cert_chain,
   jsend.Add("chain", jchain);
 
   UrlFetcher::Request req(GetURL(pre_cert ? "add-pre-chain" : "add-chain"));
+  req.verb = UrlFetcher::Verb::POST;
   req.body = jsend.ToString();
 
   UrlFetcher::Response* const resp(new UrlFetcher::Response);
-  fetcher_->Post(req, resp, new util::Task(bind(DoneInternalAddChain, resp,
-                                                sct, done, _1),
-                                           executor_));
+  fetcher_->Fetch(req, resp, new util::Task(bind(DoneInternalAddChain, resp,
+                                                 sct, done, _1),
+                                            executor_));
 }
 
 

--- a/cpp/net/url_fetcher.h
+++ b/cpp/net/url_fetcher.h
@@ -24,10 +24,20 @@ class UrlFetcher {
   typedef std::multimap<std::string, std::string, ci_less<std::string>>
       Headers;
 
+  enum class Verb {
+    GET,
+    POST,
+    PUT,
+    DELETE,
+  };
+
   struct Request {
-    Request(const URL& input_url) : url(input_url) {
+    Request() : verb(Verb::GET) {
+    }
+    Request(const URL& input_url) : verb(Verb::GET), url(input_url) {
     }
 
+    Verb verb;
     URL url;
     std::string body;
   };
@@ -44,12 +54,11 @@ class UrlFetcher {
   UrlFetcher(libevent::Base* base);
   virtual ~UrlFetcher();
 
-  // With the following methods, if the status on the task is not OK,
-  // the response will be in an undefined state. If it is OK, it only
-  // means that the transaction with the remote server went correctly,
-  // you should still check Response::status_code.
-  virtual void Get(const Request& req, Response* resp, util::Task* task);
-  virtual void Post(const Request& req, Response* resp, util::Task* task);
+  // If the status on the task is not OK, the response will be in an
+  // undefined state. If it is OK, it only means that the transaction
+  // with the remote server went correctly, you should still check
+  // Response::status_code.
+  virtual void Fetch(const Request& req, Response* resp, util::Task* task);
 
  protected:
   UrlFetcher();

--- a/cpp/net/url_fetcher.h
+++ b/cpp/net/url_fetcher.h
@@ -39,6 +39,7 @@ class UrlFetcher {
 
     Verb verb;
     URL url;
+    Headers headers;
     std::string body;
   };
 


### PR DESCRIPTION
Having the HTTP verb in the ```UrlFetcher::Request``` makes retries a lot easier, and also everything is a bit more general (no ```switch``` statement to call different ```Get```/```Post```/etc methods).