### PR TITLE
Set WatchUpdate::exists_ from Node::deleted_.

### DIFF
--- a/cpp/util/etcd.h
+++ b/cpp/util/etcd.h
@@ -45,7 +45,7 @@ class EtcdClient {
 
   struct WatchUpdate {
     WatchUpdate();
-    WatchUpdate(const Node& node, const bool exists);
+    WatchUpdate(const Node& node);
 
     const Node node_;
     const bool exists_;

--- a/cpp/util/fake_etcd.cc
+++ b/cpp/util/fake_etcd.cc
@@ -57,7 +57,8 @@ void FakeEtcdClient::Watch(const string& key, const WatchCallback& cb,
   vector<WatchUpdate> initial_updates;
   for (const auto& pair : entries_) {
     if (pair.first.find(key) == 0) {
-      initial_updates.emplace_back(WatchUpdate(pair.second, true /*exists*/));
+      CHECK(!pair.second.deleted_);
+      initial_updates.emplace_back(WatchUpdate(pair.second));
     }
   }
   ScheduleWatchCallback(lock, task, bind(cb, move(initial_updates)));
@@ -157,8 +158,7 @@ void FakeEtcdClient::NotifyForPath(const unique_lock<mutex>& lock,
       for (const auto& cb_cookie : pair.second) {
         ScheduleWatchCallback(lock, cb_cookie.second,
                               bind(cb_cookie.first,
-                                   vector<WatchUpdate>{
-                                       WatchUpdate(node, !node.deleted_)}));
+                                   vector<WatchUpdate>{WatchUpdate(node)}));
       }
     }
   }


### PR DESCRIPTION
This pull request is specifically small to act as a stepping stone where we are confident in each of the steps.

I'm trying to cut down the number of code paths and combine some parsing code, and I'm thinking ```WatchUpdate``` doesn't need to exist, but I want to make sure this is palatable.