### PR TITLE
Move CNS refresh into a dedicated thread, and add a watchdog.

### DIFF
--- a/cpp/log/cluster_state_controller-inl.h
+++ b/cpp/log/cluster_state_controller-inl.h
@@ -205,6 +205,13 @@ void ClusterStateController<Logged>::SetNodeHostPort(const std::string& host,
 
 
 template <class Logged>
+void ClusterStateController<Logged>::RefreshNodeState() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  PushLocalNodeState(lock);
+}
+
+
+template <class Logged>
 void ClusterStateController<Logged>::PushLocalNodeState(
     const std::unique_lock<std::mutex>& lock) {
   CHECK(lock.owns_lock());

--- a/cpp/log/cluster_state_controller.h
+++ b/cpp/log/cluster_state_controller.h
@@ -59,6 +59,8 @@ class ClusterStateController {
   // other nodes can request entries from its database.
   void SetNodeHostPort(const std::string& host, const uint16_t port);
 
+  void RefreshNodeState();
+
  private:
   class ClusterPeer;
 


### PR DESCRIPTION
Having the refresh happen via a threadpool can lead to all the threads being used up if etcd wedges, making it harder to know what's happening.
