### PR TITLE
Store sequencing information in a single proto in etcd.

### DIFF
--- a/cloud/google/create_new_cluster.sh
+++ b/cloud/google/create_new_cluster.sh
@@ -25,8 +25,8 @@ function PopulateEtcd() {
   gcloud compute ssh k8s-${CLUSTER}-node-1 --command "\
     ${PUT} ${ETCD}/v2/keys/root/serving_sth && \
     ${PUT} ${ETCD}/v2/keys/root/cluster_config && \
-    ${PUT} ${ETCD}/v2/keys/root/sequenced/ -d dir=true && \
-    ${PUT} ${ETCD}/v2/keys/root/unsequenced/ -d dir=true && \
+    ${PUT} ${ETCD}/v2/keys/root/sequence_mapping && \
+    ${PUT} ${ETCD}/v2/keys/root/entries/ -d dir=true && \
     ${PUT} ${ETCD}/v2/keys/root/nodes/ -d dir=true"
   gcloud compute copy-files ${DIR}/../../cpp/tools/ct-clustertool \
     k8s-${CLUSTER}-node-1:.

--- a/cpp/log/cluster_state_controller-inl.h
+++ b/cpp/log/cluster_state_controller-inl.h
@@ -8,7 +8,7 @@
 
 #include "fetcher/peer.h"
 #include "log/database.h"
-#include "log/etcd_consistent_store-inl.h"
+#include "log/etcd_consistent_store.h"
 #include "monitoring/monitoring.h"
 #include "proto/ct.pb.h"
 

--- a/cpp/log/consistent_store.h
+++ b/cpp/log/consistent_store.h
@@ -131,14 +131,11 @@ class ConsistentStore {
   virtual util::Status GetPendingEntries(
       std::vector<EntryHandle<Logged>>* entries) const = 0;
 
-  virtual util::Status GetSequencedEntries(
-      std::vector<EntryHandle<Logged>>* entries) const = 0;
+  virtual util::Status GetSequenceMapping(
+      EntryHandle<ct::SequenceMapping>* entry) const = 0;
 
-  virtual util::Status GetSequencedEntry(const int64_t sequence_number,
-                                         EntryHandle<Logged>* entry) const = 0;
-
-  virtual util::Status AssignSequenceNumber(const int64_t sequence_number,
-                                            EntryHandle<Logged>* entry) = 0;
+  virtual util::Status UpdateSequenceMapping(
+      EntryHandle<ct::SequenceMapping>* entry) = 0;
 
   virtual util::StatusOr<ct::ClusterNodeState> GetClusterNodeState() const = 0;
 

--- a/cpp/log/etcd_consistent_store.h
+++ b/cpp/log/etcd_consistent_store.h
@@ -44,14 +44,11 @@ class EtcdConsistentStore : public ConsistentStore<Logged> {
   util::Status GetPendingEntries(
       std::vector<EntryHandle<Logged>>* entries) const override;
 
-  util::Status GetSequencedEntries(
-      std::vector<EntryHandle<Logged>>* entries) const override;
+  util::Status GetSequenceMapping(
+      EntryHandle<ct::SequenceMapping>* entry) const override;
 
-  util::Status GetSequencedEntry(const int64_t sequence_number,
-                                 EntryHandle<Logged>* entry) const override;
-
-  util::Status AssignSequenceNumber(const int64_t sequence_number,
-                                    EntryHandle<Logged>* entry) override;
+  util::Status UpdateSequenceMapping(
+      EntryHandle<ct::SequenceMapping>* entry) override;
 
   util::StatusOr<ct::ClusterNodeState> GetClusterNodeState() const override;
 
@@ -71,8 +68,8 @@ class EtcdConsistentStore : public ConsistentStore<Logged> {
 
   util::Status SetClusterConfig(const ct::ClusterConfig& config) override;
 
-  // Removes entries in /sequenced (and their corresponding entries in
-  // /unsequened) with sequence numbers covered by the current serving STH.
+  // Removes sequenced entries with sequence numbers covered by the current
+  // serving STH.
   util::Status CleanupOldEntries() override;
 
  private:
@@ -102,15 +99,16 @@ class EtcdConsistentStore : public ConsistentStore<Logged> {
   template <class T>
   util::Status DeleteEntry(EntryHandle<T>* entry);
 
-  std::string GetUnsequencedPath(const Logged& unseq) const;
+  std::string GetEntryPath(const Logged& entry) const;
 
-  std::string GetUnsequencedPath(const std::string& hash) const;
-
-  std::string GetSequencedPath(int64_t seq) const;
+  std::string GetEntryPath(const std::string& hash) const;
 
   std::string GetNodePath(const std::string& node_id) const;
 
   std::string GetFullPath(const std::string& key) const;
+
+  void CheckMappingIsContiguousWithServingTree(
+      const ct::SequenceMapping& mapping) const;
 
 
   // The following 3 methods are static just so that they have friend access to

--- a/cpp/log/mock_consistent_store.h
+++ b/cpp/log/mock_consistent_store.h
@@ -27,16 +27,11 @@ class MockConsistentStore : public ConsistentStore<Logged> {
       util::Status(std::vector<EntryHandle<Logged>>* entries));
 
   MOCK_CONST_METHOD1_T(
-      GetSequencedEntries,
-      util::Status(std::vector<EntryHandle<Logged>>* entries));
+      GetSequenceMapping,
+      util::Status(EntryHandle<ct::SequenceMapping>* mapping));
 
-  MOCK_CONST_METHOD2_T(GetSequencedEntry,
-                       util::Status(const int64_t sequence_number,
-                                    EntryHandle<Logged>* entry));
-
-  MOCK_METHOD2_T(AssignSequenceNumber,
-                 util::Status(const int64_t sequence_number,
-                              EntryHandle<Logged>*));
+  MOCK_METHOD1_T(UpdateSequenceMapping,
+                 util::Status(EntryHandle<ct::SequenceMapping>* mapping));
 
   MOCK_CONST_METHOD0_T(GetClusterNodeState,
                        util::StatusOr<ct::ClusterNodeState>());

--- a/cpp/log/strict_consistent_store-inl.h
+++ b/cpp/log/strict_consistent_store-inl.h
@@ -35,13 +35,13 @@ util::Status StrictConsistentStore<Logged>::SetServingSTH(
 
 
 template <class Logged>
-util::Status StrictConsistentStore<Logged>::AssignSequenceNumber(
-    const int64_t sequence_number, EntryHandle<Logged>* entry) {
+util::Status StrictConsistentStore<Logged>::UpdateSequenceMapping(
+    EntryHandle<ct::SequenceMapping>* entry) {
   if (!election_->IsMaster()) {
     return util::Status(util::error::PERMISSION_DENIED,
                         "Not currently master.");
   }
-  return peer_->AssignSequenceNumber(sequence_number, entry);
+  return peer_->UpdateSequenceMapping(entry);
 }
 
 

--- a/cpp/log/strict_consistent_store.h
+++ b/cpp/log/strict_consistent_store.h
@@ -29,8 +29,8 @@ class StrictConsistentStore : public ConsistentStore<Logged> {
 
   util::Status SetServingSTH(const ct::SignedTreeHead& new_sth) override;
 
-  util::Status AssignSequenceNumber(const int64_t sequence_number,
-                                    EntryHandle<Logged>* entry) override;
+  util::Status UpdateSequenceMapping(
+      EntryHandle<ct::SequenceMapping>* entry) override;
 
   util::Status SetClusterConfig(const ct::ClusterConfig& config) override;
 
@@ -42,53 +42,49 @@ class StrictConsistentStore : public ConsistentStore<Logged> {
     return peer_->GetServingSTH();
   }
 
-  util::Status AddPendingEntry(Logged* entry) {
+  util::Status AddPendingEntry(Logged* entry) override {
     return peer_->AddPendingEntry(entry);
   }
 
-  util::Status GetPendingEntryForHash(const std::string& hash,
-                                      EntryHandle<Logged>* entry) const {
+  util::Status GetPendingEntryForHash(
+      const std::string& hash, EntryHandle<Logged>* entry) const override {
     return peer_->GetPendingEntryForHash(hash, entry);
   }
 
   util::Status GetPendingEntries(
-      std::vector<EntryHandle<Logged>>* entries) const {
+      std::vector<EntryHandle<Logged>>* entries) const override {
     return peer_->GetPendingEntries(entries);
   }
 
-  util::Status GetSequencedEntries(
-      std::vector<EntryHandle<Logged>>* entries) const {
-    return peer_->GetSequencedEntries(entries);
+  util::Status GetSequenceMapping(
+      EntryHandle<ct::SequenceMapping>* entry) const override {
+    return peer_->GetSequenceMapping(entry);
   }
 
-  util::Status GetSequencedEntry(const int64_t sequence_number,
-                                 EntryHandle<Logged>* entry) const {
-    return peer_->GetSequencedEntry(sequence_number, entry);
-  }
-
-  util::StatusOr<ct::ClusterNodeState> GetClusterNodeState() const {
+  util::StatusOr<ct::ClusterNodeState> GetClusterNodeState() const override {
     return peer_->GetClusterNodeState();
   }
 
-  util::Status SetClusterNodeState(const ct::ClusterNodeState& state) {
+  util::Status SetClusterNodeState(
+      const ct::ClusterNodeState& state) override {
     return peer_->SetClusterNodeState(state);
   }
 
   void WatchServingSTH(
       const typename ConsistentStore<Logged>::ServingSTHCallback& cb,
-      util::Task* task) {
+      util::Task* task) override {
     return peer_->WatchServingSTH(cb, task);
   }
 
   void WatchClusterNodeStates(
       const typename ConsistentStore<Logged>::ClusterNodeStateCallback& cb,
-      util::Task* task) {
+      util::Task* task) override {
     return peer_->WatchClusterNodeStates(cb, task);
   }
 
   void WatchClusterConfig(
       const typename ConsistentStore<Logged>::ClusterConfigCallback& cb,
-      util::Task* task) {
+      util::Task* task) override {
     return peer_->WatchClusterConfig(cb, task);
   }
 

--- a/cpp/log/strict_consistent_store_test.cc
+++ b/cpp/log/strict_consistent_store_test.cc
@@ -15,6 +15,7 @@ DECLARE_int32(node_state_ttl_seconds);
 
 namespace cert_trans {
 
+using ct::SequenceMapping;
 using testing::_;
 using testing::NiceMock;
 using testing::Return;
@@ -80,16 +81,16 @@ TEST_P(StrictConsistentStoreTest, TestSetServingSTH) {
 }
 
 
-TEST_P(StrictConsistentStoreTest, TestAssignSequenceNumber) {
+TEST_P(StrictConsistentStoreTest, TestUpdateSequenceMapping) {
   if (IsMaster()) {
-    EXPECT_CALL(*peer_, AssignSequenceNumber(_, _))
+    EXPECT_CALL(*peer_, UpdateSequenceMapping(_))
         .WillOnce(Return(util::Status::OK));
   } else {
-    EXPECT_CALL(*peer_, AssignSequenceNumber(_, _)).Times(0);
+    EXPECT_CALL(*peer_, UpdateSequenceMapping(_)).Times(0);
   }
 
-  EntryHandle<LoggedCertificate> cert;
-  util::Status status(strict_store_.AssignSequenceNumber(7, &cert));
+  EntryHandle<SequenceMapping> mapping;
+  util::Status status(strict_store_.UpdateSequenceMapping(&mapping));
 
   if (IsMaster()) {
     EXPECT_TRUE(status.ok());

--- a/cpp/log/tree_signer.h
+++ b/cpp/log/tree_signer.h
@@ -62,8 +62,6 @@ class TreeSigner {
   }
 
  private:
-  util::Status HandlePreviouslySequencedEntries(
-      std::vector<cert_trans::EntryHandle<Logged>>* pending_entries) const;
   void BuildTree();
   bool Append(const Logged& logged);
   void AppendToTree(const Logged& logged_cert);

--- a/proto/ct.proto
+++ b/proto/ct.proto
@@ -175,8 +175,6 @@ message LoggedCertificatePB {
     optional LogEntry entry = 2;
   }
   required Contents contents = 3;
-
-  optional int64 provisional_sequence_number = 4;
 }
 
 message SignedTreeHead {
@@ -252,4 +250,13 @@ message ClusterConfig {
   // serving STH candidate must be servable from at least 3 of your 4 nodes.
   optional double minimum_serving_fraction = 2;
   /////////////////////////////////
+}
+
+message SequenceMapping {
+  message Mapping {
+    optional bytes entry_hash = 1;
+    optional int64 sequence_number = 2;
+  }
+
+  repeated Mapping mapping = 1;
 }


### PR DESCRIPTION
Here's an implementation of the idea I mentioned the other day about storing sequencing info in a single proto.
We can drop the `provisional_sequence_number` stuff because now the whole sequence info update is atomic with CAS, it also speeds the whole sequencing shebang up quite a bit.