### PR TITLE
Disable exceptions.

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -5,7 +5,7 @@ default: all
 
 -include local.mk
 
-CXXFLAG = -std=c++11 -Wall -Werror -g -O3
+CXXFLAG = -std=c++11 -fno-exceptions -Wall -Werror -g -O3
 LINK.o = $(LINK.cc)
 
 INCLUDE = -I .


### PR DESCRIPTION
As per the [style guide](http://google-styleguide.googlecode.com/svn/trunk/cppguide.html#Exceptions), we're already avoiding exceptions, but disabling them altogether lets us see better where any library-generated exceptions are (uncaught exceptions in threads only report the thread entry point, which makes it rather difficult to debug).