### PR TITLE
Centralise the parsing of etcd nodes.

### DIFF
--- a/cpp/util/etcd_test.cc
+++ b/cpp/util/etcd_test.cc
@@ -236,6 +236,7 @@ TEST_F(EtcdTest, TestGetAll) {
   client_.GetAll(kDirKey, &resp, task.task());
   task.Wait();
   EXPECT_EQ(Status::OK, task.status());
+  ASSERT_EQ(2, resp.nodes.size());
   EXPECT_EQ(9, resp.nodes[0].modified_index_);
   EXPECT_EQ("123", resp.nodes[0].value_);
   EXPECT_EQ(7, resp.nodes[1].modified_index_);

--- a/cpp/util/fake_etcd.cc
+++ b/cpp/util/fake_etcd.cc
@@ -111,11 +111,12 @@ void FillJsonForEntry(const EtcdClient::Node& node, const string& action,
 }
 
 
-void FillJsonForDir(const vector<EtcdClient::Node>& nodes,
+void FillJsonForDir(const string& key, const vector<EtcdClient::Node>& nodes,
                     const string& action, const shared_ptr<JsonObject>& json) {
   JsonObject node;
   node.Add("modifiedIndex", 1);
   node.Add("createdIndex", 1);
+  node.Add("key", key);
   node.AddBoolean("dir", true);
   if (nodes.size() > 0) {
     JsonArray json_nodes;
@@ -191,7 +192,7 @@ void FakeEtcdClient::GetDirectory(const string& key, GenericResponse* resp,
   }
   resp->etcd_index = index_;
   resp->json_body = make_shared<JsonObject>();
-  FillJsonForDir(nodes, "get", resp->json_body);
+  FillJsonForDir(key, nodes, "get", resp->json_body);
   VLOG(1) << resp->json_body->ToString();
   task->Return();
 }


### PR DESCRIPTION
This one is a bit more delicate... I don't think I changed the semantics in any significant way? It now a bit more strict, checking for some things that it might not need, but I checked that the real etcd does provide them in all the cases I changed (I did have to update ```fake_etcd.cc``` to follow suit).