### PR TITLE
Lazy-load the TLD list in CheckTldMatches

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -37,6 +37,7 @@ test: all
 	PYTHONPATH=$(PYTHONPATH):. ./ct/cert_analysis/validity_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/cert_analysis/crl_pointers_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/cert_analysis/ocsp_pointers_test.py
+	PYTHONPATH=$(PYTHONPATH):. ./ct/cert_analysis/tld_check_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/cert_analysis/tld_list_test.py
 	PYTHONPATH=$(PYTHONPATH):. ./ct/serialization/tls_message_test.py
 # Tests using twisted trial instead of plain unittest.

--- a/python/ct/cert_analysis/common_name_test.py
+++ b/python/ct/cert_analysis/common_name_test.py
@@ -29,7 +29,7 @@ NON_UNICODE_TLD = gen_common_name("\xff\x00.com")
 
 class CommonNameTest(base_check_test.BaseCheckTest):
     def setUp(self):
-        tld_check.CheckTldMatches.TLD_LIST = tld_list.TLDList(
+        tld_check.CheckTldMatches.TLD_LIST_ = tld_list.TLDList(
                 tld_dir="ct/cert_analysis/test_data/",
                 tld_file_name="test_tld_list")
 

--- a/python/ct/cert_analysis/dnsnames_test.py
+++ b/python/ct/cert_analysis/dnsnames_test.py
@@ -32,7 +32,7 @@ NON_UNICODE_TLD = gen_dns_name("\xff\x00.com")
 
 class DnsnamesTest(base_check_test.BaseCheckTest):
     def setUp(self):
-        tld_check.CheckTldMatches.TLD_LIST = tld_list.TLDList(
+        tld_check.CheckTldMatches.TLD_LIST_ = tld_list.TLDList(
                 tld_dir="ct/cert_analysis/test_data/",
                 tld_file_name="test_tld_list")
 

--- a/python/ct/cert_analysis/tld_check.py
+++ b/python/ct/cert_analysis/tld_check.py
@@ -38,7 +38,13 @@ class GenericWildcard(TldCheckObservation):
 
 
 class CheckTldMatches(object):
-    TLD_LIST = tld_list.TLDList()
+    TLD_LIST_ = None
+    @classmethod
+    def get_tld_list(cls):
+        if not cls.TLD_LIST_:
+            cls.TLD_LIST_ = tld_list.TLDList()
+        return cls.TLD_LIST_
+
     @classmethod
     def check(cls, names, prefix=None):
         # This check is different from others, because it's supposed to be used
@@ -53,7 +59,7 @@ class CheckTldMatches(object):
             name = name.value
             try:
                 tld_match, idna_match, unicode_fail = (
-                        cls.TLD_LIST.match_certificate_name(name))
+                        cls.get_tld_list().match_certificate_name(name))
             except ValueError:
                 observations += [NotAnAddress(details=name, prefix=prefix)]
                 continue
@@ -68,8 +74,8 @@ class CheckTldMatches(object):
             # Check for generic wildcard
             if name.startswith('*.'):
                 name_without_wildcard = name[2:]
-                tld_match, idna_match, _ = cls.TLD_LIST.match_certificate_name(
-                        name_without_wildcard)
+                tld_match, idna_match, _ = cls.get_tld_list().match_certificate_name(
+                                               name_without_wildcard)
                 if (tld_match == name_without_wildcard or
                     idna_match == name_without_wildcard):
                     observations += [GenericWildcard(details=(name,

--- a/python/ct/cert_analysis/tld_check_test.py
+++ b/python/ct/cert_analysis/tld_check_test.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# coding=utf-8
+import mock
+import unittest
+from ct.cert_analysis import tld_check
+
+def gen_dns_name(name):
+    dns_name = mock.Mock()
+    dns_name.value = name
+    return dns_name
+
+EXAMPLE = gen_dns_name("example.com")
+
+class TLDCheckTest(unittest.TestCase):
+    @mock.patch('ct.cert_analysis.tld_list.TLDList')
+    def test_tld_list_not_created_until_check_called(self, tld_list):
+        instance = mock.Mock()
+        instance.match_certificate_name.return_value = [False, False, False]
+        tld_list.return_value = instance
+
+        self.assertIsNone(tld_check.CheckTldMatches.TLD_LIST_)
+        _ = tld_check.CheckTldMatches.check([EXAMPLE], "dNSNames: ")
+        self.assertIsNotNone(tld_check.CheckTldMatches.TLD_LIST_)
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
We don't want the tld_list.TLDList() to be instantiated during module loading.
Defer instantation until the first call to tld_check.CheckTldMatches.check()
