### PR TITLE
Add support to Node for directories.

### DIFF
--- a/cpp/util/etcd.h
+++ b/cpp/util/etcd.h
@@ -29,7 +29,8 @@ class EtcdClient {
     }
 
     Node(int64_t created_index, int64_t modified_index, const std::string& key,
-         const std::string& value, bool deleted);
+         bool is_dir, const std::string& value, std::vector<Node>&& nodes,
+         bool deleted);
 
     bool HasExpiry() const;
 
@@ -38,7 +39,9 @@ class EtcdClient {
     int64_t created_index_;
     int64_t modified_index_;
     std::string key_;
+    bool is_dir_;
     std::string value_;
+    std::vector<Node> nodes_;
     std::chrono::system_clock::time_point expires_;
     bool deleted_;
   };

--- a/cpp/util/fake_etcd.cc
+++ b/cpp/util/fake_etcd.cc
@@ -266,7 +266,7 @@ void FakeEtcdClient::HandlePost(const string& key,
   const string path(EnsureEndsWithSlash(key) + to_string(index_));
   CHECK(params.find("value") != params.end());
   const string& value(params.find("value")->second);
-  Node node(index_, index_, path, value, false);
+  Node node(index_, index_, path, false, value, {}, false);
   MaybeSetExpiry(params, &node);
   entries_[path] = node;
 
@@ -286,7 +286,7 @@ void FakeEtcdClient::HandlePut(const string& key,
   CHECK(key.back() != '/');
   CHECK(params.find("value") != params.end());
   const string& value(params.find("value")->second);
-  Node node(index_, index_, key, value, false);
+  Node node(index_, index_, key, false, value, {}, false);
   MaybeSetExpiry(params, &node);
   Status status(CheckCompareFlags(params, key));
   if (!status.ok()) {

--- a/cpp/util/masterelection.cc
+++ b/cpp/util/masterelection.cc
@@ -414,7 +414,7 @@ void MasterElection::UpdateProposalView(
 
 bool MasterElection::DetermineApparentMaster(
     EtcdClient::Node* apparent_master) const {
-  EtcdClient::Node tmp_master(INT_MAX, INT_MAX, "", "", true);
+  EtcdClient::Node tmp_master(INT_MAX, INT_MAX, "", false, "", {}, true);
   bool found(false);
   for (const auto& pair : proposals_) {
     CHECK_EQ(pair.first, pair.second.key_);


### PR DESCRIPTION
I looked at a lot of etcd response recently, and was annoyed by ```KeyIsDirectory``` in the watch support, and I finally saw the light: slashes have nothing to do with it, etcd doesn't care, and I think this maps really the closest to what it keeps internally.

Going step-by-step here, but that means that ```GetAll``` will disappear, and you'd just ```Get```, and check that the entry you received is a directory, if you expected one.

I'm also not 100% sure why we use "recursive" on watches, because I think it works more or less the same if you watch a directory with just immediate sub-keys (no sub-directories), which is always the case for us?