### PR TITLE
Improve signal handling.

### DIFF
--- a/cpp/server/ct-server.cc
+++ b/cpp/server/ct-server.cc
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <memory>
 #include <openssl/err.h>
+#include <signal.h>
 #include <string>
 
 #include "log/cert_checker.h"
@@ -176,6 +177,11 @@ void SignMerkleTree(TreeSigner<LoggedCertificate>* tree_signer,
 }
 
 int main(int argc, char* argv[]) {
+  // Ignore various signals whilst we start up.
+  signal(SIGHUP, SIG_IGN);
+  signal(SIGINT, SIG_IGN);
+  signal(SIGTERM, SIG_IGN);
+
   google::ParseCommandLineFlags(&argc, &argv, true);
   google::InitGoogleLogging(argv[0]);
   google::InstallFailureSignalHandler();


### PR DESCRIPTION
During startup, ignore SIGHUP, SIGINT and SIGTERM signals.

Exit the libevent dispatch loop when a SIGHUP, SIGINT or SIGTERM signal is received, allowing the process to terminate normally.