### PR TITLE
Test EtcdClient at the UrlFetcher level.

### DIFF
--- a/cpp/net/mock_url_fetcher.h
+++ b/cpp/net/mock_url_fetcher.h
@@ -10,11 +10,23 @@ namespace cert_trans {
 
 class MockUrlFetcher : public UrlFetcher {
  public:
-  MOCK_METHOD3(Get,
-               void(const Request& req, Response* resp, util::Task* task));
-  MOCK_METHOD3(Post,
+  MOCK_METHOD3(Fetch,
                void(const Request& req, Response* resp, util::Task* task));
 };
+
+
+inline testing::Matcher<const UrlFetcher::Request&> IsUrlFetchRequest(
+    const testing::Matcher<UrlFetcher::Verb>& verb,
+    const testing::Matcher<URL>& url,
+    const testing::Matcher<UrlFetcher::Headers>& headers,
+    const testing::Matcher<std::string>& body) {
+  // TODO(pphaneuf): We should make our own matcher with an output
+  // that is easier to read, and also support form submissions.
+  return testing::AllOf(testing::Field(&UrlFetcher::Request::verb, verb),
+                        testing::Field(&UrlFetcher::Request::url, url),
+                        testing::Field(&UrlFetcher::Request::headers, headers),
+                        testing::Field(&UrlFetcher::Request::body, body));
+}
 
 
 }  // namespace cert_trans

--- a/cpp/net/url.cc
+++ b/cpp/net/url.cc
@@ -50,4 +50,14 @@ string URL::PathQuery() const {
 }
 
 
+std::ostream& operator<<(std::ostream& out, const URL& url) {
+  out << url.Protocol() << "://" << url.Host();
+  if (url.Port() > 0) {
+    out << ":" << url.Port();
+  }
+  out << url.PathQuery();
+  return out;
+}
+
+
 }  // namespace cert_trans

--- a/cpp/net/url.h
+++ b/cpp/net/url.h
@@ -1,6 +1,7 @@
 #ifndef CERT_TRANS_NET_URL_H_
 #define CERT_TRANS_NET_URL_H_
 
+#include <ostream>
 #include <stdint.h>
 #include <string>
 
@@ -61,6 +62,11 @@ class URL {
            port_ < rhs.port_ && path_ < rhs.path_ && query_ < rhs.query_;
   }
 
+  bool operator==(const URL& rhs) const {
+    return protocol_ == rhs.protocol_ && host_ == rhs.host_ &&
+           port_ == rhs.port_ && path_ == rhs.path_ && query_ == rhs.query_;
+  }
+
  private:
   std::string protocol_;
   std::string host_;
@@ -68,6 +74,10 @@ class URL {
   std::string path_;
   std::string query_;
 };
+
+
+// For testing and debugging.
+std::ostream& operator<<(std::ostream& out, const URL& url);
 
 
 }  // namespace cert_trans


### PR DESCRIPTION
This is a straightforward conversion, but this allows testing of the parsing layer as well, which was previously mocked out inside ```EtcdClient::Generic```.