### PR TITLE
Allow fetching of SCTs along with log entries.

### DIFF
--- a/cpp/client/async_log_client.h
+++ b/cpp/client/async_log_client.h
@@ -34,6 +34,7 @@ class AsyncLogClient {
   struct Entry {
     ct::MerkleTreeLeaf leaf;
     ct::LogEntry entry;
+    std::unique_ptr<ct::SignedCertificateTimestamp> sct;
   };
 
   typedef std::function<void(Status)> Callback;
@@ -57,6 +58,13 @@ class AsyncLogClient {
   void GetEntries(int first, int last, std::vector<Entry>* entries,
                   const Callback& done);
 
+  // This is NON-standard, and only works with SuperDuper logs.
+  // It's intended for internal use when running in a clustered configuration.
+  // This does not clear "entries" before appending the retrieved
+  // entries.
+  void GetEntriesAndSCTs(int first, int last, std::vector<Entry>* entries,
+                         const Callback& done);
+
   void QueryInclusionProof(const ct::SignedTreeHead& sth,
                            const std::string& merkle_leaf_hash,
                            ct::MerkleAuditProof* proof, const Callback& done);
@@ -76,6 +84,9 @@ class AsyncLogClient {
 
  private:
   URL GetURL(const std::string& subpath) const;
+
+  void InternalGetEntries(int first, int last, std::vector<Entry>* entries,
+                          bool request_scts, const Callback& done);
 
   void InternalAddChain(const CertChain& cert_chain,
                         ct::SignedCertificateTimestamp* sct, bool pre_cert,

--- a/cpp/fetcher/fetcher.cc
+++ b/cpp/fetcher/fetcher.cc
@@ -217,6 +217,9 @@ void FetchState::WriteToDatabase(int64_t index, Range* range,
       LOG(WARNING) << "could not convert entry to a LoggedCertificate";
       break;
     }
+    if (entry.sct) {
+      *cert.mutable_sct() = *entry.sct;
+    }
     cert.set_sequence_number(index++);
     if (db_->CreateSequencedEntry(cert) == Database<LoggedCertificate>::OK) {
       ++processed;

--- a/cpp/fetcher/peer_group.cc
+++ b/cpp/fetcher/peer_group.cc
@@ -76,8 +76,9 @@ void PeerGroup::FetchEntries(int64_t start_index, int64_t end_index,
   }
 
   // TODO(pphaneuf): Handle the case where we have no peer more cleanly.
-  peer->client().GetEntries(start_index, end_index, CHECK_NOTNULL(entries),
-                            bind(GetEntriesDone, _1, entries, task));
+  peer->client().GetEntriesAndSCTs(start_index, end_index,
+                                   CHECK_NOTNULL(entries),
+                                   bind(GetEntriesDone, _1, entries, task));
 }
 
 

--- a/cpp/server/handler.h
+++ b/cpp/server/handler.h
@@ -58,8 +58,8 @@ class HttpHandler {
   void AddChain(evhttp_request* req);
   void AddPreChain(evhttp_request* req);
 
-  void BlockingGetEntries(evhttp_request* req, int64_t start,
-                          int64_t end) const;
+  void BlockingGetEntries(evhttp_request* req, int64_t start, int64_t end,
+                          bool include_scts) const;
   void BlockingAddChain(evhttp_request* req,
                         const std::shared_ptr<CertChain>& chain) const;
   void BlockingAddPreChain(evhttp_request* req,


### PR DESCRIPTION
Currently, the follower code just downloads certs from other nodes in the log, but if a certificate is presented by a user to add-chain, unless that request just happens to hit the same node the cert was originally presented to, the local DB will only contain the cert - crucially, it will not contain the SCT and so a 'null' SCT is returned.

This PR addresses that.