### PR TITLE
etcd watch tweaks

### DIFF
--- a/cpp/log/cluster_state_controller_test.cc
+++ b/cpp/log/cluster_state_controller_test.cc
@@ -48,7 +48,6 @@ class ClusterStateControllerTest : public ::testing::Test {
       : pool_(3),
         base_(make_shared<libevent::Base>()),
         pump_(base_),
-        etcd_(base_),
         store1_(new EtcdConsistentStore<LoggedCertificate>(&pool_, &etcd_,
                                                            &election1_, "",
                                                            kNodeId1)),

--- a/cpp/log/etcd_consistent_store_test.cc
+++ b/cpp/log/etcd_consistent_store_test.cc
@@ -60,8 +60,7 @@ class EtcdConsistentStoreTest : public ::testing::Test {
   EtcdConsistentStoreTest()
       : base_(make_shared<libevent::Base>()),
         executor_(2),
-        event_pump_(base_),
-        client_(base_) {
+        event_pump_(base_) {
   }
 
  protected:

--- a/cpp/log/frontend_signer_test.cc
+++ b/cpp/log/frontend_signer_test.cc
@@ -55,7 +55,6 @@ class FrontendSignerTest : public ::testing::Test {
                   new MerkleVerifier(new Sha256Hasher())),
         base_(make_shared<libevent::Base>()),
         event_pump_(base_),
-        etcd_client_(base_),
         pool_(2),
         store_(&pool_, &etcd_client_, &election_, "/root", "id"),
         frontend_(db(), &store_, TestSigner::DefaultLogSigner()) {

--- a/cpp/log/frontend_test.cc
+++ b/cpp/log/frontend_test.cc
@@ -90,7 +90,6 @@ class FrontendTest : public ::testing::Test {
         checker_(),
         base_(make_shared<libevent::Base>()),
         event_pump_(base_),
-        etcd_client_(base_),
         pool_(2),
         store_(&pool_, &etcd_client_, &election_, "/root", "id"),
         frontend_(new CertSubmissionHandler(&checker_),

--- a/cpp/log/log_lookup_test.cc
+++ b/cpp/log/log_lookup_test.cc
@@ -53,7 +53,6 @@ class LogLookupTest : public ::testing::Test {
       : test_db_(),
         base_(make_shared<libevent::Base>()),
         event_pump_(base_),
-        etcd_client_(base_),
         pool_(2),
         store_(&pool_, &etcd_client_, &election_, "/root", "id"),
         test_signer_(),

--- a/cpp/log/tree_signer_test.cc
+++ b/cpp/log/tree_signer_test.cc
@@ -47,7 +47,6 @@ class TreeSignerTest : public ::testing::Test {
       : test_db_(),
         base_(make_shared<libevent::Base>()),
         event_pump_(base_),
-        etcd_client_(base_),
         pool_(2),
         test_signer_(),
         verifier_(),

--- a/cpp/server/ct-server.cc
+++ b/cpp/server/ct-server.cc
@@ -428,9 +428,9 @@ int main(int argc, char* argv[]) {
             << (stand_alone_mode ? "STAND-ALONE" : "CLUSTERED") << " mode.";
 
   std::unique_ptr<EtcdClient> etcd_client(
-      stand_alone_mode ? new FakeEtcdClient(event_base)
-                       : new EtcdClient(event_base, &url_fetcher,
-                                        FLAGS_etcd_host, FLAGS_etcd_port));
+      stand_alone_mode
+          ? new FakeEtcdClient
+          : new EtcdClient(&url_fetcher, FLAGS_etcd_host, FLAGS_etcd_port));
 
   // No real reason to let this be configurable per node; you can really
   // shoot yourself in the foot that way by effectively running multiple

--- a/cpp/tools/clustertool_main.cc
+++ b/cpp/tools/clustertool_main.cc
@@ -148,8 +148,7 @@ int main(int argc, char* argv[]) {
       new libevent::EventPumpThread(event_base));
   UrlFetcher fetcher(event_base.get());
 
-  EtcdClient etcd_client(event_base, &fetcher, FLAGS_etcd_host,
-                         FLAGS_etcd_port);
+  EtcdClient etcd_client(&fetcher, FLAGS_etcd_host, FLAGS_etcd_port);
 
   const string node_id("clustertool");
   unique_ptr<MasterElection> election(

--- a/cpp/util/bench_etcd.cc
+++ b/cpp/util/bench_etcd.cc
@@ -85,7 +85,7 @@ void test_etcd(int thread_num) {
   const shared_ptr<libevent::Base> event_base(make_shared<libevent::Base>());
   libevent::EventPumpThread pump(event_base);
   UrlFetcher fetcher(event_base.get());
-  EtcdClient etcd(event_base, &fetcher, FLAGS_etcd, FLAGS_etcd_port);
+  EtcdClient etcd(&fetcher, FLAGS_etcd, FLAGS_etcd_port);
   SyncTask task(event_base.get());
   State state(&etcd, thread_num, task.task());
 

--- a/cpp/util/etcd.cc
+++ b/cpp/util/etcd.cc
@@ -5,6 +5,7 @@
 #include <utility>
 
 #include "util/json_wrapper.h"
+#include "util/libevent_wrapper.h"
 #include "util/statusor.h"
 
 namespace libevent = cert_trans::libevent;
@@ -589,21 +590,15 @@ bool EtcdClient::Node::HasExpiry() const {
 }
 
 
-EtcdClient::EtcdClient(const shared_ptr<libevent::Base>& event_base,
-                       UrlFetcher* fetcher, const string& host, uint16_t port)
-    : event_base_(event_base),
-      fetcher_(CHECK_NOTNULL(fetcher)),
-      endpoint_(host, port) {
-  CHECK_NOTNULL(event_base_.get());
+EtcdClient::EtcdClient(UrlFetcher* fetcher, const string& host, uint16_t port)
+    : fetcher_(CHECK_NOTNULL(fetcher)), endpoint_(host, port) {
   CHECK(!endpoint_.first.empty());
   CHECK_GT(endpoint_.second, 0);
   VLOG(1) << "EtcdClient: " << this;
 }
 
 
-EtcdClient::EtcdClient(const shared_ptr<libevent::Base>& event_base)
-    : event_base_(event_base), fetcher_(nullptr) {
-  CHECK_NOTNULL(event_base_.get());
+EtcdClient::EtcdClient() : fetcher_(nullptr) {
 }
 
 

--- a/cpp/util/etcd.h
+++ b/cpp/util/etcd.h
@@ -11,7 +11,6 @@
 
 #include "base/macros.h"
 #include "net/url_fetcher.h"
-#include "util/libevent_wrapper.h"
 #include "util/status.h"
 #include "util/task.h"
 
@@ -78,8 +77,7 @@ class EtcdClient {
   typedef std::function<void(const std::vector<Node>& updates)> WatchCallback;
 
   // TODO(pphaneuf): This should take a set of servers, not just one.
-  EtcdClient(const std::shared_ptr<libevent::Base>& event_base,
-             UrlFetcher* fetcher, const std::string& host, uint16_t port);
+  EtcdClient(UrlFetcher* fetcher, const std::string& host, uint16_t port);
 
   virtual ~EtcdClient();
 
@@ -122,7 +120,7 @@ class EtcdClient {
 
  protected:
   // Testing only
-  EtcdClient(const std::shared_ptr<libevent::Base>& event_base);
+  EtcdClient();
 
   virtual void Generic(const std::string& key,
                        const std::map<std::string, std::string>& params,
@@ -146,7 +144,6 @@ class EtcdClient {
   void WatchRequestDone(WatchState* state, GetResponse* gen_resp,
                         util::Task* child_task);
 
-  const std::shared_ptr<libevent::Base> event_base_;
   UrlFetcher* const fetcher_;
 
   mutable std::mutex lock_;

--- a/cpp/util/etcd_masterelection.cc
+++ b/cpp/util/etcd_masterelection.cc
@@ -30,7 +30,7 @@ int main(int argc, char* argv[]) {
   const shared_ptr<libevent::Base> event_base(make_shared<libevent::Base>());
   UrlFetcher fetcher(event_base.get());
 
-  EtcdClient etcd(event_base, &fetcher, FLAGS_etcd, FLAGS_etcd_port);
+  EtcdClient etcd(&fetcher, FLAGS_etcd, FLAGS_etcd_port);
   MasterElection election(event_base, &etcd, FLAGS_proposal_dir,
                           FLAGS_node_id);
   election.StartElection();

--- a/cpp/util/etcd_test.cc
+++ b/cpp/util/etcd_test.cc
@@ -162,7 +162,7 @@ class EtcdTest : public ::testing::Test {
   EtcdTest()
       : base_(make_shared<libevent::Base>()),
         pump_(base_),
-        client_(base_, &url_fetcher_, kEtcdHost, kEtcdPort) {
+        client_(&url_fetcher_, kEtcdHost, kEtcdPort) {
   }
 
   shared_ptr<JsonObject> MakeJson(const string& json) {

--- a/cpp/util/fake_etcd.cc
+++ b/cpp/util/fake_etcd.cc
@@ -98,8 +98,7 @@ bool GetParam(const map<string, string>& params, const string& name,
 }  // namespace
 
 
-FakeEtcdClient::FakeEtcdClient(const std::shared_ptr<libevent::Base>& base)
-    : EtcdClient(base), base_(base), index_(1) {
+FakeEtcdClient::FakeEtcdClient() : index_(1) {
 }
 
 

--- a/cpp/util/fake_etcd.h
+++ b/cpp/util/fake_etcd.h
@@ -14,7 +14,7 @@ namespace cert_trans {
 
 class FakeEtcdClient : public EtcdClient {
  public:
-  FakeEtcdClient(const std::shared_ptr<libevent::Base>& base);
+  FakeEtcdClient();
 
   virtual ~FakeEtcdClient() = default;
 
@@ -72,7 +72,6 @@ class FakeEtcdClient : public EtcdClient {
                              const std::function<void()>& callback);
   void RunWatchCallback();
 
-  const std::shared_ptr<libevent::Base> base_;
   std::mutex mutex_;
   int64_t index_;
   std::map<std::string, Node> entries_;

--- a/cpp/util/fake_etcd_test.cc
+++ b/cpp/util/fake_etcd_test.cc
@@ -45,9 +45,7 @@ const char kValue2[] = "value2";
 class FakeEtcdTest : public ::testing::Test {
  public:
   FakeEtcdTest()
-      : base_(std::make_shared<libevent::Base>()),
-        event_pump_(base_),
-        client_(base_) {
+      : base_(std::make_shared<libevent::Base>()), event_pump_(base_) {
   }
 
  protected:

--- a/cpp/util/masterelection_test.cc
+++ b/cpp/util/masterelection_test.cc
@@ -147,10 +147,9 @@ class ElectionTest : public ::testing::Test {
   ElectionTest()
       : base_(make_shared<libevent::Base>()),
         url_fetcher_(base_.get()),
-        client_(FLAGS_etcd.empty()
-                    ? new FakeEtcdClient(base_)
-                    : new EtcdClient(base_, &url_fetcher_, FLAGS_etcd,
-                                     FLAGS_etcd_port)),
+        client_(FLAGS_etcd.empty() ? new FakeEtcdClient
+                                   : new EtcdClient(&url_fetcher_, FLAGS_etcd,
+                                                    FLAGS_etcd_port)),
         event_pump_(base_) {
   }
 


### PR DESCRIPTION
Remove some pointless bouncing around executor (when we're already on the right one), and it looks like the only case we used ```libevent::Base::Delay``` was when handling a timeout, we can just retry immediately, which is much simpler.