### PR TITLE
Fix #628 - Include cert validity in parsed fields of certificate_pb2.X509Description

### DIFF
--- a/python/ct/client/db/cert_desc.py
+++ b/python/ct/client/db/cert_desc.py
@@ -1,5 +1,6 @@
 import re
 import hashlib
+import time
 from ct.crypto import cert
 from ct.proto import certificate_pb2
 
@@ -43,6 +44,13 @@ def from_cert(certificate, observations=[]):
     try:
         proto.serial_number = str(certificate.serial_number().human_readable()
                                   .upper().replace(':', ''))
+    except cert.CertificateError:
+        pass
+
+    try:
+        proto.validity.not_before, proto.validity.not_after = (
+            1000 * int(time.mktime(certificate.not_before())),
+            1000 * int(time.mktime(certificate.not_after())))
     except cert.CertificateError:
         pass
 

--- a/python/ct/client/db/cert_desc_test.py
+++ b/python/ct/client/db/cert_desc_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
+import time
 import unittest
 from ct.client.db import cert_desc
 from ct.crypto import cert
@@ -46,6 +47,11 @@ class CertificateDescriptionTest(unittest.TestCase):
         self.assertEqual(proto.serial_number,
                          str(CERT.serial_number().human_readable()
                              .upper().replace(':', '')))
+        self.assertEqual(time.gmtime(proto.validity.not_before / 1000),
+                         CERT.not_before())
+        self.assertEqual(time.gmtime(proto.validity.not_after / 1000),
+                         CERT.not_after())
+
         observations_tuples = [(unicode(obs.description),
                                 unicode(obs.reason) if obs.reason else u'',
                                 obs.details_to_proto())

--- a/python/ct/proto/certificate.proto
+++ b/python/ct/proto/certificate.proto
@@ -3,8 +3,10 @@ syntax = "proto2";
 package ct;
 
 message Validity {
+  // Milliseconds since epoch.
   optional uint64 not_before = 1;
 
+  // Milliseconds since epoch.
   optional uint64 not_after = 2;
 }
 


### PR DESCRIPTION
The validity period was not being filled out in the X509Description proto by cert_desc.py.