### PR TITLE
Fix #627 - Use utctimetuple() instead of timetuple() in validity analysis

### DIFF
--- a/python/ct/cert_analysis/validity.py
+++ b/python/ct/cert_analysis/validity.py
@@ -47,7 +47,7 @@ class CheckValidityNotBeforeFuture(object):
             now = datetime.datetime.utcnow()
             # time.mktime assumes localtime, but because both dates are in utc
             # comparision will be valid
-            if time.mktime(not_before) - time.mktime(now.timetuple()) > 0:
+            if time.mktime(not_before) - time.mktime(now.utctimetuple()) > 0:
                 return [NotBeforeInFuture(details=not_before)]
         except cert.CertificateError:
             pass


### PR DESCRIPTION
where timestamps with different DST flags could be compared.  This caused test failures, possibly related to the DST transition or because of the TZ of the computer running the test.