### PR TITLE
Always decrement outstanding_, even if there was an error.

### DIFF
--- a/cpp/util/etcd_delete.cc
+++ b/cpp/util/etcd_delete.cc
@@ -61,15 +61,16 @@ class DeleteState {
 
 
 void DeleteState::RequestDone(Task* child_task) {
+  unique_lock<mutex> lock(mutex_);
+  --outstanding_;
+
   // If a child task has an error, return that error, and do not start
   // any more requests.
   if (!child_task->status().ok()) {
+    lock.unlock();
     task_->Return(child_task->status());
     return;
   }
-
-  unique_lock<mutex> lock(mutex_);
-  --outstanding_;
 
   if (it_ != keys_.end()) {
     StartNextRequest(move(lock));


### PR DESCRIPTION
This is so the ```CHECK``` in ```~DeleteState``` doesn't trip.