### PR TITLE
Travis upgraded their version of OpenSSL?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
  - sudo apt-add-repository -y ppa:fcitx-team/nightly
  - sudo apt-add-repository -y ppa:chris-lea/protobuf
  - sudo apt-get update -qq
- - sudo apt-get install -qq protobuf-compiler libprotobuf-java libprotobuf-dev python-dev libjson-c-dev libgoogle-glog-dev libgflags-dev libldns-dev libstdc++-4.8-dev
+ - sudo apt-get install -qq openssl libssl-dev protobuf-compiler libprotobuf-java libprotobuf-dev python-dev libjson-c-dev libgoogle-glog-dev libgflags-dev libldns-dev libstdc++-4.8-dev
 # Stupid frikkin' google-mock package on Precise is b0rked, so hack it up:
  - wget https://googlemock.googlecode.com/files/gmock-1.7.0.zip -O /tmp/gmock-1.7.0.zip
  - unzip -d /tmp /tmp/gmock-1.7.0.zip
@@ -28,15 +28,8 @@ before_install:
  - java -version
  - javac -version
  - go version
-# Need a recent version of openssl
- - wget https://www.openssl.org/source/openssl-1.0.1l.tar.gz -O /tmp/openssl-1.0.1l.tar.gz
- - tar -zxf /tmp/openssl-1.0.1l.tar.gz
- - cd openssl-1.0.1l
- - ./config --prefix=/usr/local --openssldir=/usr/local/openssl
- - make
- - sudo make install
- - cd ..
+ - openssl version
 
 script:
- - make alltests OPENSSLDIR=/usr/local/openssl
+ - make alltests
  - go test -v ./go/...


### PR DESCRIPTION
I seem to remember that it was one of the 1.0.0 before, and now it's 1.0.1? But that's from 2012?!? And still, the test from 0c3dbfd18bb6f93491144e0723ba3033935fae71 passes (which was the whole reason for having a newer version of OpenSSL installed)?

Is that 1.0.1 version sufficient? Or is the test insufficient?

At any rate, it passes...