### PR TITLE
Remove CR characters from the plain-text dump in some PEM files.

### DIFF
--- a/python/ct/crypto/testdata/multiple_eku.pem
+++ b/python/ct/crypto/testdata/multiple_eku.pem
@@ -59,8 +59,8 @@ Certificate:
             X509v3 Extended Key Usage: 
                 TLS Web Server Authentication
             S/MIME Capabilities: 
-                0i0...*.H........0...*.H........0...`.H.e...*0...`.H.e...-0...`.H.e....0...`.H.e....0...+....0
-..*.H....
+                0i0...*.H........0...*.H........0...`.H.e...*0...`.H.e...-0...`.H.e....0...`.H.e....0...+....0
+..*.H....
             X509v3 Subject Key Identifier: 
                 00:3F:6A:20:2D:F3:91:47:1F:9D:87:1E:86:1E:76:97:03:62:63:D9
     Signature Algorithm: sha1WithRSAEncryption

--- a/test/testdata/test-embedded-with-preca-cert.pem
+++ b/test/testdata/test-embedded-with-preca-cert.pem
@@ -33,7 +33,7 @@ Certificate:
             X509v3 Basic Constraints: 
                 CA:FALSE
             1.3.6.1.4.1.11129.2.4.2: 
-                .z.x.v........RG.ah2].\yY..........?t.d...=.'.[.....G0E. z....t..r{.O....y......C.*)|.:5\.!......dL..Ri..c..5l.P"O.......#.
+                .z.x.v........RG.ah2].\yY..........?t.d...=.'.[.....G0E. z....t..r{.O....y......C.*)|.:5\.!......dL..Ri..c..5l.P"O.......#.
     Signature Algorithm: sha1WithRSAEncryption
          a3:a8:6c:41:ad:00:88:a2:5a:ed:c4:e7:b5:29:a2:dd:bf:9e:
          18:7f:fb:36:21:57:e9:30:2d:96:1b:73:b4:3c:ba:0a:e1:e2:


### PR DESCRIPTION
Am I correct in thinking that only the Base64 chunks in those files really matter, and those plain-text bits are just for convenience?