### PR TITLE
Gmock include

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 
 AM_CPPFLAGS = \
-	-I$(GMOCK_DIR)/gtest/include \
+	-I$(GTEST_DIR)/include \
 	$(json_c_CFLAGS)
 
 AM_CXXFLAGS = \
@@ -86,7 +86,7 @@ endif
 %.pb.h %.pb.cc: %.proto
 	$(AM_V_GEN)protoc $^ --cpp_out=.
 
-cpp/gtest-all.cc: $(GMOCK_DIR)/gtest/src/gtest-all.cc
+cpp/gtest-all.cc: $(GTEST_DIR)/src/gtest-all.cc
 	$(AM_V_at)cp $^ $@
 
 cpp/gmock-all.cc: $(GMOCK_DIR)/src/gmock-all.cc
@@ -143,7 +143,7 @@ cpp_libcore_a_SOURCES = \
 
 cpp_libtest_a_CPPFLAGS = \
 	-I$(GMOCK_DIR) \
-	-I$(GMOCK_DIR)/gtest \
+	-I$(GTEST_DIR) \
 	$(AM_CPPFLAGS)
 cpp_libtest_a_SOURCES = \
 	cpp/gmock-all.cc \

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,6 @@
 
 AM_CPPFLAGS = \
+	-I$(GMOCK_DIR)/include \
 	-I$(GTEST_DIR)/include \
 	$(json_c_CFLAGS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,8 @@ AC_CHECK_FUNCS([alarm gettimeofday memset mkdir select socket strdup strerror st
 
 GMOCK_DIR="${GMOCK_DIR=/usr/src/gmock}"
 AC_ARG_VAR([GMOCK_DIR], [directory containing Google Mock])
+GTEST_DIR="${GTEST_DIR="\$\(GMOCK_DIR\)/gtest"}"
+AC_ARG_VAR([GTEST_DIR], [directory containing Google Test])
 
 # TODO(pphaneuf): We should validate that we have all the tools and
 # libraries that we require here, instead of letting the compilation


### PR DESCRIPTION
This is to fix a build issue that @aeijdenberg encountered on Ubuntu Utopic. He was able to work around it by specifying ```CPPFLAGS=-I/usr/src/gmock/include``` to the ```configure``` script (as promised, this new build system is at least fixable without having to modify makefiles!), but this should get it going out of the box.

It also allows pointing to a GTest source tree more easily. I don't want to add this sort of support for every dependency (for others, just add the appropriate bits to ```CPPFLAGS``` and/or ```LDFLAGS```), but the special nature of those packages (normally not pre-compiled) warrants a bit of a special treatment, I think.