### PR TITLE
Faster cleaner

### DIFF
--- a/cpp/log/etcd_consistent_store_test.cc
+++ b/cpp/log/etcd_consistent_store_test.cc
@@ -728,7 +728,6 @@ TEST_F(EtcdConsistentStoreTest, TestCleansUpToNewSTH) {
   EXPECT_EQ(orig_seq_mapping.Entry().DebugString(),
             seq_mapping.Entry().DebugString());
 
-
   // Now update ServingSTH so that all sequenced entries should be cleaned up:
   sth.set_timestamp(sth.timestamp() + 1);
   sth.set_tree_size(105);
@@ -736,7 +735,7 @@ TEST_F(EtcdConsistentStoreTest, TestCleansUpToNewSTH) {
   {
     const StatusOr<int64_t> num_cleaned(CleanupOldEntries());
     ASSERT_OK(num_cleaned.status());
-    EXPECT_EQ(2, num_cleaned.ValueOrDie());
+    EXPECT_EQ(5, num_cleaned.ValueOrDie());
   }
 
 

--- a/cpp/util/etcd.cc
+++ b/cpp/util/etcd.cc
@@ -814,6 +814,14 @@ void EtcdClient::Delete(const string& key, const int64_t current_index,
 }
 
 
+void EtcdClient::ForceDelete(const string& key, Task* task) {
+  GenericResponse* const gen_resp(new GenericResponse);
+  task->DeleteWhenDone(gen_resp);
+
+  Generic(key, kKeysSpace, {}, UrlFetcher::Verb::DELETE, gen_resp, task);
+}
+
+
 void EtcdClient::GetStoreStats(StatsResponse* resp, Task* task) {
   map<string, string> params;
   GenericResponse* const gen_resp(new GenericResponse);

--- a/cpp/util/etcd.h
+++ b/cpp/util/etcd.h
@@ -110,6 +110,8 @@ class EtcdClient {
   virtual void Delete(const std::string& key, const int64_t current_index,
                       util::Task* task);
 
+  virtual void ForceDelete(const std::string& key, util::Task* task);
+
   virtual void GetStoreStats(StatsResponse* resp, util::Task* task);
 
   // The "cb" will be called on the "task" executor. Also, only one

--- a/cpp/util/etcd_delete.h
+++ b/cpp/util/etcd_delete.h
@@ -3,7 +3,6 @@
 
 #include <stdint.h>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "util/etcd.h"
@@ -11,9 +10,10 @@
 namespace cert_trans {
 
 
-void EtcdDeleteKeys(EtcdClient* client,
-                    std::vector<std::pair<std::string, int64_t>>&& keys,
-                    util::Task* task);
+// Force delete keys in batches (implemented using concurrent
+// requests). The "keys" argument are pairs of key and modified index.
+void EtcdForceDeleteKeys(EtcdClient* client, std::vector<std::string>&& keys,
+                         util::Task* task);
 
 
 }  // namespace cert_trans

--- a/cpp/util/fake_etcd.h
+++ b/cpp/util/fake_etcd.h
@@ -50,6 +50,8 @@ class FakeEtcdClient : public EtcdClient {
   void Delete(const std::string& key, const int64_t current_index,
               util::Task* task) override;
 
+  void ForceDelete(const std::string& key, util::Task* task) override;
+
   void GetStoreStats(StatsResponse* resp, util::Task* task) override;
 
   // The callbacks for *all* watches will be called one at a time, in
@@ -71,6 +73,9 @@ class FakeEtcdClient : public EtcdClient {
                    const std::chrono::system_clock::time_point& expires,
                    bool create, int64_t prev_index, Response* resp,
                    util::Task* task);
+
+  void InternalDelete(const std::string& key, const int64_t current_index,
+                      util::Task* task);
 
   void UpdateOperationStats(const std::string& op, const util::Task* task);
 

--- a/cpp/util/mock_etcd.h
+++ b/cpp/util/mock_etcd.h
@@ -34,6 +34,7 @@ class MockEtcdClient : public EtcdClient {
                     util::Task* task));
   MOCK_METHOD3(Delete, void(const std::string& key,
                             const int64_t current_index, util::Task* task));
+  MOCK_METHOD2(ForceDelete, void(const std::string& key, util::Task* task));
   MOCK_METHOD2(GetStoreStats,
                void(EtcdClient::StatsResponse* resp, util::Task* task));
   MOCK_METHOD3(Watch, void(const std::string& key, const WatchCallback& cb,


### PR DESCRIPTION
Since JSON parsing the big `GetPendingEntries()` response, and decoding all the base64 in it is quite intensive, don't do it so much. :smiley: 