### PR TITLE
make SQLite<>::TreeSize() lazily evaluated

### DIFF
--- a/cpp/fetcher/continuous_fetcher.cc
+++ b/cpp/fetcher/continuous_fetcher.cc
@@ -128,12 +128,13 @@ void ContinuousFetcherImpl::FetchDone(Task* task) {
   fetch_task_.reset();
 
   if (restart_fetch_) {
-    base_->Add(bind(&ContinuousFetcherImpl::FetchDelayDone, this, nullptr));
+    executor_->Add(
+        bind(&ContinuousFetcherImpl::FetchDelayDone, this, nullptr));
   } else {
     base_->Delay(seconds(FLAGS_delay_between_fetches_seconds),
                  new Task(bind(&ContinuousFetcherImpl::FetchDelayDone, this,
                                _1),
-                          base_));
+                          executor_));
   }
 }
 

--- a/cpp/log/sqlite_db.h
+++ b/cpp/log/sqlite_db.h
@@ -50,7 +50,6 @@ class SQLiteDB : public Database<Logged> {
 
  private:
   LookupResult LatestTreeHeadNoLock(ct::SignedTreeHead* result) const;
-  void UpdateTreeSize();
   LookupResult NodeId(const std::unique_lock<std::mutex>& lock,
                       std::string* node_id);
 
@@ -62,7 +61,9 @@ class SQLiteDB : public Database<Logged> {
 
   mutable std::mutex lock_;
   sqlite3* const db_;
-  int64_t tree_size_;
+  // This is marked mutable, as it is a lazily updated cache updated
+  // from some of the getters.
+  mutable int64_t tree_size_;
   cert_trans::DatabaseNotifierHelper callbacks_;
   int64_t transaction_size_;
   bool in_transaction_;


### PR DESCRIPTION
Starts with a few commits to try to avoid calling `TreeSize()` from the libevent thread.

This fixes #568.