### PR TITLE
When processing subject name, don't downcase strings unless processing dot-separated DNS names.

### DIFF
--- a/python/ct/client/db/cert_db_test.py
+++ b/python/ct/client/db/cert_db_test.py
@@ -108,7 +108,7 @@ class CertDBTest(object):
         for i in range(4):
             cert = certificate_pb2.X509Description()
             cert.der = "hello-%d" % i
-            cert.subject.extend([name_attribute("trusty ca %d" % i)])
+            cert.subject.extend([name_attribute("Trusty CA %d" % i)])
             cert.sha256_hash = str(i)
             self.db().store_cert_desc(cert, i, 0)
 

--- a/python/ct/client/db/cert_desc.py
+++ b/python/ct/client/db/cert_desc.py
@@ -81,8 +81,7 @@ def process_name(subject, reverse=True):
     # For now, make indexing work for the common case:
     # allow letter-digit-hyphen, as well as wildcards (RFC 2818).
     forbidden = re.compile(r"[^a-z\d\-\*]")
-    subject = subject.lower()
-    labels = subject.split(".")
+    labels = subject.lower().split(".")
     valid = all(map(lambda x: len(x) and not forbidden.search(x), labels))
 
     if valid:
@@ -91,7 +90,7 @@ def process_name(subject, reverse=True):
         return list(reversed(labels)) if reverse else labels
 
     else:
-        # ["john smith"], ["trustworthy certificate authority"],
+        # ["John Smith"], ["Trustworthy Certificate Authority"],
         # ["google.com\x00"], etc.
         # TODO(ekasper): figure out what to do (use stringprep as specified
         # by RFC 5280?) to properly handle non-letter-digit-hyphen names.


### PR DESCRIPTION
Examining the function, the only time it's important to downcase is where the subject string is interpreted as a DNS name.  In other cases, the string is human-readable and shouldn't be downcased.