### PR TITLE
Allow duplicate entries in the DB.

### DIFF
--- a/cpp/log/database.h
+++ b/cpp/log/database.h
@@ -48,9 +48,13 @@
 // };
 //
 // NOTE: This is a database interface for the log server.
-// Monitors/auditors shouldn't assume that log entries are keyed
-// uniquely by certificate hash -- it is an artefact of this
-// implementation, not a requirement of the I-D.
+// Implementations of this interface MUST provide for the same certificate
+// being sequenced multiple times in the tree.
+// Although the log server implementation which uses this database interface
+// should not allow duplicate entries to be created, this code base will also
+// support running in a log mirroring mode, and since the RFC does not forbid
+// the same certificate appearing multiple times in a log 3rd party logs may
+// exhibit this behavour the mirror must permit it too.
 
 
 template <class Logged>
@@ -114,13 +118,9 @@ class Database : public ReadOnlyDatabase<Logged> {
     MISSING_CERTIFICATE_HASH,
     // Create failed, an entry with this hash already exists.
     DUPLICATE_CERTIFICATE_HASH,
-    // Update failed, entry already has a sequence number.
-    ENTRY_ALREADY_LOGGED,
     // Update failed, entry does not exist.
     ENTRY_NOT_FOUND,
     // Another entry has this sequence number already.
-    // We only report this if the entry is pending (i.e., ENTRY_NOT_FOUND
-    // and ENTRY_ALREADY_LOGGED did not happen).
     SEQUENCE_NUMBER_ALREADY_IN_USE,
     // Timestamp is primary key, it must exist and be unique,
     DUPLICATE_TREE_HEAD_TIMESTAMP,

--- a/cpp/log/database_test.cc
+++ b/cpp/log/database_test.cc
@@ -111,19 +111,25 @@ TYPED_TEST(DBTest, CreateSequencedDuplicateEntryNewSequenceNumber) {
 
   EXPECT_EQ(DB::OK, this->db()->CreateSequencedEntry(logged_cert));
 
-  EXPECT_EQ(DB::ENTRY_ALREADY_LOGGED,
-            this->db()->CreateSequencedEntry(duplicate_cert));
+  EXPECT_EQ(DB::OK, this->db()->CreateSequencedEntry(duplicate_cert));
 
   EXPECT_EQ(DB::LOOKUP_OK,
             this->db()->LookupByHash(logged_cert.Hash(), &lookup_cert));
   // Check that we get the original entry back.
   TestSigner::TestEqualLoggedCerts(logged_cert, lookup_cert);
 
+  // Check that we can find it by sequence number too:
   lookup_cert.Clear();
   EXPECT_EQ(DB::LOOKUP_OK,
             this->db()->LookupByIndex(logged_cert.sequence_number(),
                                       &lookup_cert));
-  TestSigner::TestEqualLoggedCerts(logged_cert, lookup_cert);
+
+  // And that we can find the duplicate ok as well:
+  lookup_cert.Clear();
+  EXPECT_EQ(DB::LOOKUP_OK,
+            this->db()->LookupByIndex(duplicate_cert.sequence_number(),
+                                      &lookup_cert));
+  TestSigner::TestEqualLoggedCerts(duplicate_cert, lookup_cert);
 }
 
 


### PR DESCRIPTION
Mainly to allow for mirroring other logs which do allow duplicate submissions.