### PR TITLE
Detect some libraries, and put them in LIBS.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -160,7 +160,7 @@ cpp_server_ct_server_LDADD = \
 	cpp/libcore.a \
 	$(json_c_LIBS) \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lcrypto -lprotobuf -lpthread -lsqlite3 -lleveldb -lsnappy
+	-lcrypto -lprotobuf -lsqlite3 -lleveldb -lsnappy
 cpp_server_ct_server_SOURCES = \
 	cpp/client/async_log_client.cc \
 	cpp/proto/serializer.cc \
@@ -184,7 +184,7 @@ cpp_tools_ct_clustertool_LDADD = \
 	cpp/libcore.a \
 	$(json_c_LIBS) \
 	$(libevent_LIBS) \
-	-lgflags -lglog -lpthread -lprotobuf -lcrypto -lsqlite3
+	-lprotobuf -lcrypto -lsqlite3
 cpp_tools_ct_clustertool_SOURCES = \
 	cpp/proto/serializer.cc \
 	cpp/tools/clustertool_main.cc \
@@ -200,7 +200,7 @@ cpp_client_ct_LDADD = \
 	cpp/libcore.a \
 	$(json_c_LIBS) \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lprotobuf -lcrypto -lssl -lpthread -lsqlite3
+	-lprotobuf -lcrypto -lssl -lsqlite3
 cpp_client_ct_SOURCES = \
 	cpp/client/async_log_client.cc \
 	cpp/client/client.cc \
@@ -219,7 +219,7 @@ cpp_client_ct_SOURCES = \
 
 cpp_server_ct_dns_server_LDADD = \
 	cpp/libcore.a \
-	-lprotobuf -lgflags -lglog -lldns -lsqlite3 -lcrypto
+	-lprotobuf -lldns -lsqlite3 -lcrypto
 cpp_server_ct_dns_server_SOURCES = \
 	cpp/proto/serializer.cc \
 	cpp/server/ct-dns-server.cc \
@@ -229,22 +229,21 @@ cpp_server_ct_dns_server_SOURCES = \
 
 cpp_tools_dump_cert_LDADD = \
 	cpp/libcore.a \
-	-lprotobuf -lglog -lgflags
+	-lprotobuf
 cpp_tools_dump_cert_SOURCES = \
 	cpp/tools/dump_cert.cc \
 	cpp/util/util.cc
 
 cpp_tools_dump_sth_LDADD = \
 	cpp/libcore.a \
-	-lprotobuf -lglog -lgflags
+	-lprotobuf
 cpp_tools_dump_sth_SOURCES = \
 	cpp/tools/dump_sth.cc
 
 cpp_tools_etcd_watch_LDADD = \
 	cpp/libcore.a \
 	$(json_c_LIBS) \
-	$(libevent_LIBS) \
-	-lgflags -lglog -lpthread
+	$(libevent_LIBS)
 cpp_tools_etcd_watch_SOURCES = \
 	cpp/tools/etcd_watch.cc \
 	cpp/util/json_wrapper.cc \
@@ -253,8 +252,7 @@ cpp_tools_etcd_watch_SOURCES = \
 cpp_util_bench_etcd_LDADD = \
 	cpp/libcore.a \
 	$(json_c_LIBS) \
-	$(libevent_LIBS) \
-	-lgflags -lglog -lpthread
+	$(libevent_LIBS)
 cpp_util_bench_etcd_SOURCES = \
 	cpp/util/bench_etcd.cc \
 	cpp/util/json_wrapper.cc \
@@ -264,7 +262,7 @@ cpp_util_etcd_masterelection_LDADD = \
 	cpp/libcore.a \
 	$(json_c_LIBS) \
 	$(libevent_LIBS) \
-	-lgflags -lglog -lpthread -lprotobuf
+	-lprotobuf
 cpp_util_etcd_masterelection_SOURCES = \
 	cpp/util/etcd_masterelection.cc \
 	cpp/util/json_wrapper.cc \
@@ -274,8 +272,7 @@ cpp_util_etcd_masterelection_SOURCES = \
 
 cpp_base_notification_test_LDADD = \
 	cpp/libtest.a \
-	$(libevent_LIBS) \
-	-lglog -lgflags -lpthread
+	$(libevent_LIBS)
 cpp_base_notification_test_SOURCES = \
 	cpp/base/notification.cc \
 	cpp/base/notification_test.cc
@@ -285,7 +282,7 @@ cpp_log_cluster_state_controller_test_LDADD = \
 	cpp/libtest.a \
 	$(json_c_LIBS) \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lprotobuf -lpthread -lsqlite3 -lcrypto -lleveldb -lsnappy
+	-lprotobuf -lsqlite3 -lcrypto -lleveldb -lsnappy
 cpp_log_cluster_state_controller_test_SOURCES = \
 	cpp/client/async_log_client.cc \
 	cpp/log/cluster_state_controller_test.cc \
@@ -302,7 +299,7 @@ cpp_log_database_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lprotobuf -lpthread -lsqlite3 -lpthread -lcrypto -lleveldb -lsnappy
+	-lprotobuf -lsqlite3 -lcrypto -lleveldb -lsnappy
 cpp_log_database_test_SOURCES = \
 	cpp/log/database_test.cc \
 	cpp/log/test_signer.cc \
@@ -315,7 +312,7 @@ cpp_log_etcd_consistent_store_test_LDADD = \
 	cpp/libtest.a \
 	$(json_c_LIBS) \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lprotobuf -lpthread -lcrypto
+	-lprotobuf -lcrypto
 cpp_log_etcd_consistent_store_test_SOURCES = \
 	cpp/log/etcd_consistent_store_test.cc \
 	cpp/proto/serializer.cc \
@@ -330,7 +327,7 @@ cpp_log_file_storage_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lprotobuf -lpthread -lcrypto -lsqlite3 -lleveldb -lsnappy
+	-lprotobuf -lcrypto -lsqlite3 -lleveldb -lsnappy
 cpp_log_file_storage_test_SOURCES = \
 	cpp/log/file_storage.cc \
 	cpp/log/file_storage_test.cc \
@@ -343,7 +340,7 @@ cpp_log_frontend_signer_test_LDADD = \
 	cpp/libtest.a \
 	$(json_c_LIBS) \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lprotobuf -lpthread -lcrypto -lsqlite3 -lleveldb -lsnappy
+	-lprotobuf -lcrypto -lsqlite3 -lleveldb -lsnappy
 cpp_log_frontend_signer_test_SOURCES = \
 	cpp/log/frontend_signer_test.cc \
 	cpp/log/test_signer.cc \
@@ -360,7 +357,7 @@ cpp_log_log_lookup_test_LDADD = \
 	cpp/libtest.a \
 	$(json_c_LIBS) \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lprotobuf -lpthread -lcrypto -lsqlite3 -lleveldb -lsnappy
+	-lprotobuf -lcrypto -lsqlite3 -lleveldb -lsnappy
 cpp_log_log_lookup_test_SOURCES = \
 	cpp/log/log_lookup_test.cc \
 	cpp/log/test_signer.cc \
@@ -376,7 +373,7 @@ cpp_log_log_signer_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lprotobuf -lpthread -lcrypto
+	-lprotobuf -lcrypto
 cpp_log_log_signer_test_SOURCES = \
 	cpp/log/log_signer_test.cc \
 	cpp/log/test_signer.cc \
@@ -387,7 +384,7 @@ cpp_log_logged_certificate_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lprotobuf -lpthread -lcrypto
+	-lprotobuf -lcrypto
 cpp_log_logged_certificate_test_SOURCES = \
 	cpp/log/logged_certificate_test.cc \
 	cpp/proto/serializer.cc \
@@ -398,7 +395,7 @@ cpp_log_strict_consistent_store_test_LDADD = \
 	cpp/libtest.a \
 	$(json_c_LIBS) \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lprotobuf -lpthread
+	-lprotobuf
 cpp_log_strict_consistent_store_test_SOURCES = \
 	cpp/log/strict_consistent_store_cert.cc \
 	cpp/log/strict_consistent_store_test.cc \
@@ -412,7 +409,7 @@ cpp_log_tree_signer_test_LDADD = \
 	cpp/libtest.a \
 	$(json_c_LIBS) \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lprotobuf -lpthread -lcrypto -lsqlite3 -lleveldb -lsnappy
+	-lprotobuf -lcrypto -lsqlite3 -lleveldb -lsnappy
 cpp_log_tree_signer_test_SOURCES = \
 	cpp/log/test_signer.cc \
 	cpp/log/tree_signer_test.cc \
@@ -428,7 +425,7 @@ cpp_log_signer_verifier_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lprotobuf -lpthread -lcrypto
+	-lprotobuf -lcrypto
 cpp_log_signer_verifier_test_SOURCES = \
 	cpp/log/signer_verifier_test.cc \
 	cpp/log/test_signer.cc \
@@ -439,7 +436,7 @@ cpp_monitor_database_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lprotobuf -lcrypto -lsqlite3 -lpthread
+	-lprotobuf -lcrypto -lsqlite3
 cpp_monitor_database_test_SOURCES = \
 	cpp/log/test_signer.cc \
 	cpp/monitor/database.cc \
@@ -452,7 +449,7 @@ cpp_monitoring_prometheus_counter_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lprotobuf -lpthread
+	-lprotobuf
 cpp_monitoring_prometheus_counter_test_SOURCES = \
 	cpp/monitoring/prometheus/counter_test.cc \
 	cpp/util/protobuf_util.cc
@@ -461,7 +458,7 @@ cpp_monitoring_prometheus_gauge_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lprotobuf -lpthread
+	-lprotobuf
 cpp_monitoring_prometheus_gauge_test_SOURCES = \
 	cpp/monitoring/prometheus/gauge_test.cc \
 	cpp/util/protobuf_util.cc
@@ -470,7 +467,7 @@ cpp_monitoring_registry_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lprotobuf -lpthread
+	-lprotobuf
 cpp_monitoring_registry_test_SOURCES = \
 	cpp/monitoring/registry_test.cc \
 	cpp/util/protobuf_util.cc
@@ -479,7 +476,7 @@ cpp_proto_serializer_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lprotobuf -lpthread
+	-lprotobuf
 cpp_proto_serializer_test_SOURCES = \
 	cpp/proto/serializer.cc \
 	cpp/proto/serializer_test.cc \
@@ -490,7 +487,7 @@ cpp_server_proxy_test_LDADD = \
 	cpp/libtest.a \
 	$(json_c_LIBS) \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lprotobuf -lpthread
+	-lprotobuf
 cpp_server_proxy_test_SOURCES = \
 	cpp/server/json_output.cc \
 	cpp/server/proxy.cc \
@@ -503,8 +500,7 @@ cpp_util_etcd_delete_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
 	$(json_c_LIBS) \
-	$(libevent_LIBS) \
-	-lglog -lgflags -lpthread
+	$(libevent_LIBS)
 cpp_util_etcd_delete_test_SOURCES = \
 	cpp/util/etcd_delete_test.cc \
 	cpp/util/json_wrapper.cc \
@@ -515,8 +511,7 @@ cpp_util_etcd_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
 	$(json_c_LIBS) \
-	$(libevent_LIBS) \
-	-lglog -lgflags -lpthread
+	$(libevent_LIBS)
 cpp_util_etcd_test_SOURCES = \
 	cpp/util/etcd_test.cc \
 	cpp/util/json_wrapper.cc \
@@ -526,8 +521,7 @@ cpp_util_fake_etcd_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
 	$(json_c_LIBS) \
-	$(libevent_LIBS) \
-	-lglog -lgflags -lpthread
+	$(libevent_LIBS)
 cpp_util_fake_etcd_test_SOURCES = \
 	cpp/util/fake_etcd_test.cc \
 	cpp/util/json_wrapper.cc \
@@ -537,8 +531,7 @@ cpp_util_fake_etcd_test_SOURCES = \
 cpp_util_json_wrapper_test_LDADD = \
 	cpp/libtest.a \
 	$(json_c_LIBS) \
-	$(libevent_LIBS) \
-	-lglog -lgflags -lpthread
+	$(libevent_LIBS)
 cpp_util_json_wrapper_test_SOURCES = \
 	cpp/util/json_wrapper.cc \
 	cpp/util/json_wrapper_test.cc \
@@ -547,8 +540,7 @@ cpp_util_json_wrapper_test_SOURCES = \
 cpp_util_libevent_wrapper_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
-	$(libevent_LIBS) \
-	-lglog -lgflags -lpthread
+	$(libevent_LIBS)
 cpp_util_libevent_wrapper_test_SOURCES = \
 	cpp/util/libevent_wrapper.cc \
 	cpp/util/libevent_wrapper_test.cc
@@ -558,7 +550,7 @@ cpp_util_masterelection_test_LDADD = \
 	cpp/libtest.a \
 	$(json_c_LIBS) \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lprotobuf -lpthread -lleveldb -lsnappy
+	-lprotobuf -lleveldb -lsnappy
 cpp_util_masterelection_test_SOURCES = \
 	cpp/util/json_wrapper.cc \
 	cpp/util/libevent_wrapper.cc \
@@ -570,7 +562,7 @@ cpp_merkletree_merkle_tree_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lpthread -lcrypto
+	-lcrypto
 cpp_merkletree_merkle_tree_test_SOURCES = \
 	cpp/util/util.cc \
 	cpp/merkletree/merkle_tree_test.cc
@@ -579,7 +571,7 @@ cpp_merkletree_serial_hasher_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lpthread -lcrypto
+	-lcrypto
 cpp_merkletree_serial_hasher_test_SOURCES = \
 	cpp/util/util.cc \
 	cpp/merkletree/serial_hasher_test.cc
@@ -588,7 +580,7 @@ cpp_merkletree_tree_hasher_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lpthread -lcrypto
+	-lcrypto
 cpp_merkletree_tree_hasher_test_SOURCES = \
 	cpp/util/util.cc \
 	cpp/merkletree/tree_hasher_test.cc
@@ -596,8 +588,7 @@ cpp_merkletree_tree_hasher_test_SOURCES = \
 cpp_util_sync_task_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
-	$(libevent_LIBS) \
-	-lglog -lgflags -lpthread
+	$(libevent_LIBS)
 cpp_util_sync_task_test_SOURCES = \
 	cpp/util/sync_task_test.cc \
 	cpp/util/thread_pool.cc
@@ -605,8 +596,7 @@ cpp_util_sync_task_test_SOURCES = \
 cpp_util_task_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
-	$(libevent_LIBS) \
-	-lglog -lgflags -lpthread
+	$(libevent_LIBS)
 cpp_util_task_test_SOURCES = \
 	cpp/util/task_test.cc \
 	cpp/util/thread_pool.cc
@@ -615,7 +605,7 @@ cpp_log_cert_checker_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lpthread -lcrypto
+	-lcrypto
 cpp_log_cert_checker_test_SOURCES = \
 	cpp/log/cert_checker_test.cc \
 	cpp/util/openssl_util.cc \
@@ -625,7 +615,7 @@ cpp_log_cert_submission_handler_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lprotobuf -lpthread -lcrypto
+	-lprotobuf -lcrypto
 cpp_log_cert_submission_handler_test_SOURCES = \
 	cpp/log/cert_submission_handler_test.cc \
 	cpp/util/openssl_util.cc \
@@ -635,7 +625,7 @@ cpp_log_cert_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lpthread -lcrypto
+	-lcrypto
 cpp_log_cert_test_SOURCES = \
 	cpp/log/cert_test.cc \
 	cpp/util/openssl_util.cc \
@@ -645,7 +635,7 @@ cpp_log_ct_extensions_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lpthread -lcrypto
+	-lcrypto
 cpp_log_ct_extensions_test_SOURCES = \
 	cpp/log/ct_extensions_test.cc \
 	cpp/util/openssl_util.cc \
@@ -655,7 +645,7 @@ cpp_log_database_large_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lprotobuf -lpthread -lcrypto -lsqlite3 -lleveldb -lsnappy
+	-lprotobuf -lcrypto -lsqlite3 -lleveldb -lsnappy
 cpp_log_database_large_test_SOURCES = \
 	cpp/log/database_large_test.cc \
 	cpp/log/test_signer.cc \
@@ -668,7 +658,7 @@ cpp_log_frontend_test_LDADD = \
 	cpp/libtest.a \
 	$(json_c_LIBS) \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lprotobuf -lpthread -lcrypto -lsqlite3 -lleveldb -lsnappy
+	-lprotobuf -lcrypto -lsqlite3 -lleveldb -lsnappy
 cpp_log_frontend_test_SOURCES = \
 	cpp/log/frontend_test.cc \
 	cpp/log/test_signer.cc \
@@ -685,7 +675,7 @@ cpp_merkletree_merkle_tree_large_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
 	$(libevent_LIBS) \
-	-lglog -lgflags -lpthread -lcrypto
+	-lcrypto
 cpp_merkletree_merkle_tree_large_test_SOURCES = \
 	cpp/merkletree/merkle_tree_large_test.cc \
 	cpp/util/util.cc

--- a/configure.ac
+++ b/configure.ac
@@ -58,6 +58,21 @@ AS_IF([test -n "$missing_gmock"],
 
 # Checks for libraries.
 AC_SEARCH_LIBS([__b64_ntop], [resolv])
+AC_SEARCH_LIBS([pthread_create], [pthread])
+
+AC_MSG_CHECKING([checking for gflags library])
+LIBS="-lgflags $LIBS"
+AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <gflags/gflags.h>], [google::ParseCommandLineFlags(NULL, NULL, true)])], [have_gflags=yes], [have_gflags=no])
+AC_MSG_RESULT([$have_gflags])
+AS_IF([test "x$have_gflags" = "xno"],
+      [AC_MSG_ERROR([gflags library could not be found])])
+
+AC_MSG_CHECKING([checking for glog library])
+LIBS="-lglog $LIBS"
+AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <glog/logging.h>], [google::InitGoogleLogging(NULL)])], [have_glog=yes], [have_glog=no])
+AC_MSG_RESULT([$have_glog])
+AS_IF([test "x$have_glog" = "xno"],
+      [AC_MSG_ERROR([glog library could not be found])])
 
 save_LIBS="$LIBS"
 AS_UNSET([LIBS])


### PR DESCRIPTION
Those libraries we always need, just putting them in `LIBS` is simpler.