### PR TITLE
Fix a few lint errors from 558cab0

### DIFF
--- a/python/ct/client/db/cert_desc.py
+++ b/python/ct/client/db/cert_desc.py
@@ -82,7 +82,8 @@ def process_name(subject, reverse=True):
     # allow letter-digit-hyphen, as well as wildcards (RFC 2818).
     forbidden = re.compile(r"[^a-z\d\-\*]")
     labels = subject.lower().split(".")
-    valid_dns_name = len(labels) > 1 and all(map(lambda x: len(x) and not forbidden.search(x), labels))
+    valid_dns_name = len(labels) > 1 and all(
+        map(lambda x: len(x) and not forbidden.search(x), labels))
 
     if valid_dns_name:
         # ["com", "example", "*"], ["com", "example", "mail"],

--- a/python/ct/client/db/cert_desc_test.py
+++ b/python/ct/client/db/cert_desc_test.py
@@ -61,16 +61,19 @@ class CertificateDescriptionTest(unittest.TestCase):
         self.assertItemsEqual(proto_obs, observations_tuples)
 
     def test_process_value(self):
-        self.assertEqual(['London'], cert_desc.process_name('London'))
-        self.assertEqual(['Bob Smith'], cert_desc.process_name('Bob Smith'))
-        self.assertEqual(['com', 'googleapis', 'ct'], cert_desc.process_name('ct.googleapis.com'))
-        self.assertEqual(['com', 'github'], cert_desc.process_name('gItHuB.CoM'))
+        self.assertEqual(["London"], cert_desc.process_name("London"))
+        self.assertEqual(["Bob Smith"], cert_desc.process_name("Bob Smith"))
+        self.assertEqual(["com", "googleapis", "ct"],
+                         cert_desc.process_name("ct.googleapis.com"))
+        self.assertEqual(["com", "github"],
+                         cert_desc.process_name("gItHuB.CoM"))
         # These two are unfortunate outcomes:
         # 1. single-word hostnames are indistinguishable from single-word CN
         # terms like State, City, Organization
-        self.assertEqual(['LOCALhost'], cert_desc.process_name('LOCALhost'))
+        self.assertEqual(["LOCALhost"], cert_desc.process_name("LOCALhost"))
         # 2. IP addresses should perhaps not be reversed like hostnames are
-        self.assertEqual(['1', '0', '168', '192'], cert_desc.process_name('192.168.0.1'))
+        self.assertEqual(["1", "0", "168", "192"],
+                         cert_desc.process_name("192.168.0.1"))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Some too-long lines and wrong types of quotes.
The file produces a ton of indentation lint errors which I'm not fixing here.