### PR TITLE
Build compact merkle tree for TreeSigner from LogLookup's full merkle tree.

### DIFF
--- a/cpp/log/log_lookup-inl.h
+++ b/cpp/log/log_lookup-inl.h
@@ -182,6 +182,13 @@ std::string LogLookup<Logged>::LeafHash(const Logged& logged) const {
   return cert_tree_.LeafHash(serialized_leaf);
 }
 
+template <class Logged>
+std::unique_ptr<CompactMerkleTree> LogLookup<Logged>::GetCompactMerkleTree(
+    SerialHasher* hasher) {
+  std::lock_guard<std::mutex> lock(lock_);
+  return std::unique_ptr<CompactMerkleTree>(
+      new CompactMerkleTree(cert_tree_, hasher));
+}
 
 template <class Logged>
 int64_t LogLookup<Logged>::GetIndexInternal(

--- a/cpp/log/log_lookup.h
+++ b/cpp/log/log_lookup.h
@@ -9,6 +9,7 @@
 
 #include "base/macros.h"
 #include "log/database.h"
+#include "merkletree/compact_merkle_tree.h"
 #include "merkletree/merkle_tree.h"
 #include "proto/ct.pb.h"
 
@@ -55,6 +56,11 @@ class LogLookup {
   }
 
   std::string LeafHash(const Logged& logged) const;
+
+  // Creates a CompactMerkleTree based on the current state of our MerkleTree.
+  // Takes ownership of |hasher|.
+  std::unique_ptr<CompactMerkleTree> GetCompactMerkleTree(
+      SerialHasher* hasher);
 
  private:
   void UpdateFromSTH(const ct::SignedTreeHead& sth);

--- a/cpp/log/log_lookup_test.cc
+++ b/cpp/log/log_lookup_test.cc
@@ -39,6 +39,7 @@ using ct::SequenceMapping;
 using std::make_shared;
 using std::string;
 using std::shared_ptr;
+using std::unique_ptr;
 using testing::NiceMock;
 
 typedef Database<LoggedCertificate> DB;
@@ -57,8 +58,10 @@ class LogLookupTest : public ::testing::Test {
         pool_(2),
         store_(base_.get(), &pool_, &etcd_client_, &election_, "/root", "id"),
         test_signer_(),
-        tree_signer_(std::chrono::duration<double>(0), db(), &store_,
-                     TestSigner::DefaultLogSigner()),
+        tree_signer_(std::chrono::duration<double>(0), db(),
+                     unique_ptr<CompactMerkleTree>(
+                         new CompactMerkleTree(new Sha256Hasher)),
+                     &store_, TestSigner::DefaultLogSigner()),
         verifier_(TestSigner::DefaultLogSigVerifier(),
                   new MerkleVerifier(new Sha256Hasher())) {
     // Set some noddy STH so that we can call UpdateTree on the Tree Signer.

--- a/cpp/merkletree/compact_merkle_tree.cc
+++ b/cpp/merkletree/compact_merkle_tree.cc
@@ -92,6 +92,17 @@ CompactMerkleTree::CompactMerkleTree(MerkleTree& model, SerialHasher* hasher)
   CHECK_EQ(model.LevelCount(), LevelCount());
 }
 
+
+CompactMerkleTree::CompactMerkleTree(const CompactMerkleTree& other,
+                                     SerialHasher* hasher)
+    : tree_(other.tree_),
+      treehasher_(hasher),
+      leaf_count_(other.leaf_count_),
+      leaves_processed_(other.leaves_processed_),
+      level_count_(other.level_count_),
+      root_(other.root_) {
+}
+
 CompactMerkleTree::~CompactMerkleTree() {
 }
 

--- a/cpp/merkletree/compact_merkle_tree.h
+++ b/cpp/merkletree/compact_merkle_tree.h
@@ -22,6 +22,9 @@ class CompactMerkleTree : public cert_trans::MerkleTreeInterface {
   // instantiation of the SerialHasher abstract class.
   // Takes ownership of the hasher.
   explicit CompactMerkleTree(SerialHasher* hasher);
+  CompactMerkleTree(const CompactMerkleTree& other, SerialHasher* hasher);
+
+  explicit CompactMerkleTree(CompactMerkleTree&& other) = default;
 
   // Creates a new CompactMerkleTree based on the data present in the
   // (non-compact) MerkleTree |model|.

--- a/cpp/server/ct-server.cc
+++ b/cpp/server/ct-server.cc
@@ -516,10 +516,10 @@ int main(int argc, char* argv[]) {
   }
 
   LogLookup<LoggedCertificate> log_lookup(db);
-  TreeSigner<LoggedCertificate> tree_signer(std::chrono::duration<double>(
-                                                FLAGS_guard_window_seconds),
-                                            db, &consistent_store,
-                                            &log_signer);
+  TreeSigner<LoggedCertificate> tree_signer(
+      std::chrono::duration<double>(FLAGS_guard_window_seconds), db,
+      log_lookup.GetCompactMerkleTree(new Sha256Hasher), &consistent_store,
+      &log_signer);
 
   if (stand_alone_mode) {
     // Set up a simple single-node environment.

--- a/cpp/tools/clustertool_main.cc
+++ b/cpp/tools/clustertool_main.cc
@@ -85,6 +85,9 @@ unique_ptr<TreeSigner<LoggedCertificate>> BuildTreeSigner(
     LogSigner* log_signer) {
   return unique_ptr<TreeSigner<LoggedCertificate>>(
       new TreeSigner<LoggedCertificate>(std::chrono::duration<double>(0), db,
+                                        unique_ptr<CompactMerkleTree>(
+                                            new CompactMerkleTree(
+                                                new Sha256Hasher)),
                                         consistent_store, log_signer));
 }
 


### PR DESCRIPTION
Lets the `TreeSigner` be initialised with a pre-built `CompactMerkleTree`, and provides a mechanism for getting one from the `LogLookup` instance which has already built a full tree at boot time.
 
Addresses #428. 