### PR TITLE
Add SSL support to UrlFetcher.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -69,6 +69,7 @@ TESTS = \
 	cpp/monitoring/prometheus/counter_test \
 	cpp/monitoring/prometheus/gauge_test \
 	cpp/monitoring/registry_test \
+	cpp/net/url_fetcher_test \
 	cpp/proto/serializer_test \
 	cpp/server/proxy_test \
 	cpp/util/etcd_delete_test \
@@ -98,6 +99,9 @@ cpp/gtest-all.cc: $(GTEST_DIR)/src/gtest-all.cc
 
 cpp/gmock-all.cc: $(GMOCK_DIR)/src/gmock-all.cc
 	$(AM_V_at)cp $^ $@
+
+test/testdata/urlfetcher_test_certs/localhost.pem: test/create_url_fetcher_test_certs.sh
+	$(AM_V_GEN)test/create_url_fetcher_test_certs.sh
 
 cpp_libcore_a_SOURCES = \
 	cpp/base/notification.cc \
@@ -137,12 +141,15 @@ cpp_libcore_a_SOURCES = \
 	cpp/monitoring/prometheus/metrics.pb.h \
 	cpp/monitoring/registry.cc \
 	cpp/net/connection_pool.cc \
+	cpp/third_party/curl/hostcheck.c \
+	cpp/third_party/isec_partners/openssl_hostname_validation.c \
 	cpp/net/url.cc \
 	cpp/net/url_fetcher.cc \
 	cpp/util/etcd.cc \
 	cpp/util/etcd_delete.cc \
 	cpp/util/fake_etcd.cc \
 	cpp/util/masterelection.cc \
+	cpp/util/openssl_util.cc \
 	cpp/util/status.cc \
 	cpp/util/sync_task.cc \
 	cpp/util/task.cc \
@@ -175,7 +182,6 @@ cpp_server_ct_mirror_SOURCES = \
 	cpp/server/proxy.cc \
 	cpp/util/json_wrapper.cc \
 	cpp/util/libevent_wrapper.cc \
-	cpp/util/openssl_util.cc \
 	cpp/util/periodic_closure.cc \
 	cpp/util/protobuf_util.cc \
 	cpp/util/protobuf_util.h \
@@ -200,7 +206,6 @@ cpp_server_ct_server_SOURCES = \
 	cpp/server/proxy.cc \
 	cpp/util/json_wrapper.cc \
 	cpp/util/libevent_wrapper.cc \
-	cpp/util/openssl_util.cc \
 	cpp/util/periodic_closure.cc \
 	cpp/util/protobuf_util.cc \
 	cpp/util/protobuf_util.h \
@@ -242,7 +247,6 @@ cpp_client_ct_SOURCES = \
 	cpp/proto/serializer.cc \
 	cpp/util/json_wrapper.cc \
 	cpp/util/libevent_wrapper.cc \
-	cpp/util/openssl_util.cc \
 	cpp/util/read_key.cc \
 	cpp/util/util.cc
 
@@ -319,7 +323,6 @@ cpp_log_cluster_state_controller_test_SOURCES = \
 	cpp/proto/serializer.cc \
 	cpp/util/json_wrapper.cc \
 	cpp/util/libevent_wrapper.cc \
-	cpp/util/openssl_util.cc \
 	cpp/util/periodic_closure.cc \
 	cpp/util/protobuf_util.cc \
 	cpp/util/thread_pool.cc \
@@ -507,6 +510,19 @@ cpp_monitoring_registry_test_SOURCES = \
 	cpp/monitoring/registry_test.cc \
 	cpp/util/protobuf_util.cc
 
+cpp_net_url_fetcher_test_LDADD = \
+	cpp/libcore.a \
+	cpp/libtest.a \
+	$(libevent_LIBS) \
+	-lprotobuf
+cpp_net_url_fetcher_test_SOURCES = \
+	cpp/net/url_fetcher_test.cc \
+	cpp/util/libevent_wrapper.cc \
+	cpp/util/protobuf_util.cc \
+	cpp/util/thread_pool.cc
+EXTRA_cpp_net_url_fetcher_test_DEPENDENCIES = \
+	test/testdata/urlfetcher_test_certs/localhost.pem
+
 cpp_proto_serializer_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
@@ -648,7 +664,6 @@ cpp_log_cert_checker_test_LDADD = \
 	$(libevent_LIBS)
 cpp_log_cert_checker_test_SOURCES = \
 	cpp/log/cert_checker_test.cc \
-	cpp/util/openssl_util.cc \
 	cpp/util/util.cc
 
 cpp_log_cert_submission_handler_test_LDADD = \
@@ -658,7 +673,6 @@ cpp_log_cert_submission_handler_test_LDADD = \
 	-lprotobuf
 cpp_log_cert_submission_handler_test_SOURCES = \
 	cpp/log/cert_submission_handler_test.cc \
-	cpp/util/openssl_util.cc \
 	cpp/util/util.cc
 
 cpp_log_cert_test_LDADD = \
@@ -667,7 +681,6 @@ cpp_log_cert_test_LDADD = \
 	$(libevent_LIBS)
 cpp_log_cert_test_SOURCES = \
 	cpp/log/cert_test.cc \
-	cpp/util/openssl_util.cc \
 	cpp/util/util.cc
 
 cpp_log_ct_extensions_test_LDADD = \
@@ -676,7 +689,6 @@ cpp_log_ct_extensions_test_LDADD = \
 	$(libevent_LIBS)
 cpp_log_ct_extensions_test_SOURCES = \
 	cpp/log/ct_extensions_test.cc \
-	cpp/util/openssl_util.cc \
 	cpp/util/util.cc
 
 cpp_log_database_large_test_LDADD = \
@@ -705,7 +717,6 @@ cpp_log_frontend_test_SOURCES = \
 	cpp/proto/serializer.cc \
 	cpp/util/json_wrapper.cc \
 	cpp/util/libevent_wrapper.cc \
-	cpp/util/openssl_util.cc \
 	cpp/util/periodic_closure.cc \
 	cpp/util/protobuf_util.cc \
 	cpp/util/thread_pool.cc \

--- a/cloud/google/mirror-config.sh
+++ b/cloud/google/mirror-config.sh
@@ -16,7 +16,7 @@ for i in $(seq ${ETCD_NUM_REPLICAS}); do
 done
 
 
-export MIRROR_TARGET_URL="http://ct.googleapis.com/pilot"
+export MIRROR_TARGET_URL="https://ct.googleapis.com/pilot"
 # Public key relative to the cloud/keys directory:
 export MIRROR_TARGET_PUBLIC_KEY=pilot.pem
 export MIRROR_NUM_REPLICAS=3

--- a/cpp/net/url_fetcher_test.cc
+++ b/cpp/net/url_fetcher_test.cc
@@ -1,0 +1,318 @@
+#include <csignal>
+#include <fcntl.h>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "net/connection_pool.h"
+#include "net/url_fetcher.h"
+#include "util/libevent_wrapper.h"
+#include "util/status_test_util.h"
+#include "util/sync_task.h"
+#include "util/testing.h"
+#include "util/thread_pool.h"
+
+DECLARE_string(trusted_root_certs);
+
+namespace cert_trans {
+
+using std::make_shared;
+using std::shared_ptr;
+using std::string;
+using std::to_string;
+using std::unique_ptr;
+using util::SyncTask;
+using util::testing::StatusIs;
+
+DEFINE_string(cert_dir, "test/testdata/urlfetcher_test_certs",
+              "Directory containing the test certs.");
+
+
+const uint16_t kLocalHostPort = 4433;
+const uint16_t kNonLocalHostPort = 4434;
+const uint16_t kStarExampleComPort = 4435;
+const uint16_t kBinkyExampleComPort = 4436;
+const uint16_t kExampleComPort = 4437;
+const uint16_t k127_0_0_1Port = 4438;
+
+
+namespace {
+
+
+class LocalhostResolver : public libevent::Base::Resolver {
+ public:
+  string Resolve(const std::string& name) override {
+    return "127.0.0.1";
+  }
+};
+
+
+pid_t RunOpenSSLServer(uint16_t port, const std::string& cert_file,
+                       const std::string& key_file) {
+  pid_t pid(fork());
+  if (pid == -1) {
+    LOG(INFO) << "fork() failed: " << pid;
+  } else if (pid == 0) {
+    const string port_str(to_string(port));
+    const string cert_str(FLAGS_cert_dir + "/" + cert_file);
+    const string key_str(FLAGS_cert_dir + "/" + key_file);
+    const char* argv[]{"openssl", "s_server",
+                       "-accept", port_str.c_str(),
+                       "-cert",   cert_str.c_str(),
+                       "-key",    key_str.c_str(),
+                       "-www",    0L};
+    execvp(argv[0], const_cast<char**>(argv));
+  }
+  return pid;
+}
+
+
+}  // namespace
+
+
+class UrlFetcherTest : public ::testing::Test {
+ public:
+  UrlFetcherTest()
+      : base_(make_shared<libevent::Base>(
+            unique_ptr<libevent::Base::Resolver>(new LocalhostResolver))),
+        event_pump_(base_),
+        pool_(1) {
+    FLAGS_trusted_root_certs = FLAGS_cert_dir + "/ca-cert.pem";
+    fetcher_.reset(new UrlFetcher(base_.get()));
+  }
+
+ protected:
+  shared_ptr<libevent::Base> base_;
+  shared_ptr<UrlFetcher> fetcher_;
+  libevent::EventPumpThread event_pump_;
+  ThreadPool pool_;
+};
+
+
+TEST_F(UrlFetcherTest, TestCertMatchesHost) {
+  UrlFetcher::Request req(
+      URL("https://localhost:" + to_string(kLocalHostPort)));
+  UrlFetcher::Response resp;
+
+  SyncTask task(&pool_);
+  fetcher_->Fetch(req, &resp, task.task());
+  task.Wait();
+  EXPECT_EQ(util::Status::OK, task.status());
+  EXPECT_EQ(200, resp.status_code);
+}
+
+
+TEST_F(UrlFetcherTest, TestCertDoesNotMatchHost) {
+  UrlFetcher::Request req(
+      URL("https://localhost:" + to_string(kNonLocalHostPort)));
+  UrlFetcher::Response resp;
+
+  SyncTask task(&pool_);
+  fetcher_->Fetch(req, &resp, task.task());
+  task.Wait();
+  EXPECT_THAT(task.status(), StatusIs(util::error::FAILED_PRECONDITION));
+  EXPECT_EQ(kSSLErrorStatus, resp.status_code);
+}
+
+
+TEST_F(UrlFetcherTest, TestNotListening) {
+  UrlFetcher::Request req(URL("https://localhost:63544"));
+  UrlFetcher::Response resp;
+
+  SyncTask task(&pool_);
+  fetcher_->Fetch(req, &resp, task.task());
+  task.Wait();
+  EXPECT_THAT(task.status(), StatusIs(util::error::FAILED_PRECONDITION));
+  EXPECT_EQ(kUnknownErrorStatus, resp.status_code);
+}
+
+
+TEST_F(UrlFetcherTest, TestStarMatchesSubdomain) {
+  UrlFetcher::Request req(
+      URL("https://donkey.example.com:" + to_string(kStarExampleComPort)));
+  UrlFetcher::Response resp;
+
+  SyncTask task(&pool_);
+  fetcher_->Fetch(req, &resp, task.task());
+  task.Wait();
+  EXPECT_EQ(util::Status::OK, task.status());
+  EXPECT_EQ(200, resp.status_code);
+}
+
+
+TEST_F(UrlFetcherTest, TestStarDoesNotMatcheIncorrectParentDomain) {
+  UrlFetcher::Request req(
+      URL("https://donkey.9600.org:" + to_string(kStarExampleComPort)));
+  UrlFetcher::Response resp;
+
+  SyncTask task(&pool_);
+  fetcher_->Fetch(req, &resp, task.task());
+  task.Wait();
+  EXPECT_THAT(task.status(), StatusIs(util::error::FAILED_PRECONDITION));
+  EXPECT_EQ(kSSLErrorStatus, resp.status_code);
+}
+
+
+TEST_F(UrlFetcherTest, TestSubdomainMatches) {
+  UrlFetcher::Request req(
+      URL("https://binky.example.com:" + to_string(kBinkyExampleComPort)));
+  UrlFetcher::Response resp;
+
+  SyncTask task(&pool_);
+  fetcher_->Fetch(req, &resp, task.task());
+  task.Wait();
+  EXPECT_EQ(util::Status::OK, task.status());
+  EXPECT_EQ(200, resp.status_code);
+}
+
+
+TEST_F(UrlFetcherTest, TestSubdomainDoesNotMatchIncorrectParentDomain) {
+  UrlFetcher::Request req(
+      URL("https://binky.9600.org:" + to_string(kBinkyExampleComPort)));
+  UrlFetcher::Response resp;
+
+  SyncTask task(&pool_);
+  fetcher_->Fetch(req, &resp, task.task());
+  task.Wait();
+  EXPECT_THAT(task.status(), StatusIs(util::error::FAILED_PRECONDITION));
+  EXPECT_EQ(kSSLErrorStatus, resp.status_code);
+}
+
+
+TEST_F(UrlFetcherTest, TestSubstringSubjectDoesNotMatch) {
+  UrlFetcher::Request req(
+      URL("https://superexample.com:" + to_string(kExampleComPort)));
+  UrlFetcher::Response resp;
+
+  SyncTask task(&pool_);
+  fetcher_->Fetch(req, &resp, task.task());
+  task.Wait();
+  EXPECT_THAT(task.status(), StatusIs(util::error::FAILED_PRECONDITION));
+  EXPECT_EQ(kSSLErrorStatus, resp.status_code);
+}
+
+
+TEST_F(UrlFetcherTest, TestSuperstringSubjectDoesNotMatch) {
+  UrlFetcher::Request req(
+      URL("https://xample.com:" + to_string(kExampleComPort)));
+  UrlFetcher::Response resp;
+
+  SyncTask task(&pool_);
+  fetcher_->Fetch(req, &resp, task.task());
+  task.Wait();
+  EXPECT_THAT(task.status(), StatusIs(util::error::FAILED_PRECONDITION));
+  EXPECT_EQ(kSSLErrorStatus, resp.status_code);
+}
+
+
+TEST_F(UrlFetcherTest, TestSubstringHostDoesNotMatch) {
+  UrlFetcher::Request req(URL("https://exampl:" + to_string(kExampleComPort)));
+  UrlFetcher::Response resp;
+
+  SyncTask task(&pool_);
+  fetcher_->Fetch(req, &resp, task.task());
+  task.Wait();
+  EXPECT_THAT(task.status(), StatusIs(util::error::FAILED_PRECONDITION));
+  EXPECT_EQ(kSSLErrorStatus, resp.status_code);
+}
+
+
+TEST_F(UrlFetcherTest, TestIpMatches) {
+  UrlFetcher::Request req(
+      URL("https://127.0.0.1:" + to_string(k127_0_0_1Port)));
+  UrlFetcher::Response resp;
+
+  SyncTask task(&pool_);
+  fetcher_->Fetch(req, &resp, task.task());
+  task.Wait();
+  EXPECT_EQ(util::Status::OK, task.status());
+  EXPECT_EQ(200, resp.status_code);
+}
+
+
+TEST_F(UrlFetcherTest, TestWrongIpDoesNotMatch) {
+  UrlFetcher::Request req(URL("https://1.2.3.4:" + to_string(k127_0_0_1Port)));
+  UrlFetcher::Response resp;
+
+  SyncTask task(&pool_);
+  fetcher_->Fetch(req, &resp, task.task());
+  task.Wait();
+  EXPECT_THAT(task.status(), StatusIs(util::error::FAILED_PRECONDITION));
+  EXPECT_EQ(kSSLErrorStatus, resp.status_code);
+}
+
+
+}  // namespace cert_trans
+
+
+namespace {
+
+
+pid_t localhost_pid(0);
+pid_t nonlocalhost_pid(0);
+pid_t star_example_com_pid(0);
+pid_t binky_example_com_pid(0);
+pid_t example_com_pid(0);
+pid_t ip_address_pid(0);
+
+
+void KillAllOpenSSLServers() {
+  kill(localhost_pid, SIGTERM);
+  kill(nonlocalhost_pid, SIGTERM);
+  kill(star_example_com_pid, SIGTERM);
+  kill(binky_example_com_pid, SIGTERM);
+  kill(example_com_pid, SIGTERM);
+  kill(ip_address_pid, SIGTERM);
+  waitpid(localhost_pid, nullptr, 0);
+  waitpid(nonlocalhost_pid, nullptr, 0);
+  waitpid(star_example_com_pid, nullptr, 0);
+  waitpid(binky_example_com_pid, nullptr, 0);
+  waitpid(example_com_pid, nullptr, 0);
+  waitpid(ip_address_pid, nullptr, 0);
+}
+
+
+}  // namespace
+
+
+int main(int argc, char** argv) {
+  cert_trans::test::InitTesting(argv[0], &argc, &argv, true);
+  OpenSSL_add_all_algorithms();
+  ERR_load_BIO_strings();
+  ERR_load_crypto_strings();
+  SSL_load_error_strings();
+  SSL_library_init();
+
+  signal(SIGPIPE, SIG_IGN);
+
+  localhost_pid =
+      cert_trans::RunOpenSSLServer(cert_trans::kLocalHostPort,
+                                   "localhost-cert.pem", "localhost-key.pem");
+  nonlocalhost_pid =
+      cert_trans::RunOpenSSLServer(cert_trans::kNonLocalHostPort,
+                                   "not-localhost-cert.pem",
+                                   "not-localhost-key.pem");
+  star_example_com_pid =
+      cert_trans::RunOpenSSLServer(cert_trans::kStarExampleComPort,
+                                   "star_example_com-cert.pem",
+                                   "star_example_com-key.pem");
+  binky_example_com_pid =
+      cert_trans::RunOpenSSLServer(cert_trans::kBinkyExampleComPort,
+                                   "binky_example_com-cert.pem",
+                                   "binky_example_com-key.pem");
+  example_com_pid = cert_trans::RunOpenSSLServer(cert_trans::kExampleComPort,
+                                                 "example_com-cert.pem",
+                                                 "example_com-key.pem");
+  ip_address_pid =
+      cert_trans::RunOpenSSLServer(cert_trans::k127_0_0_1Port,
+                                   "127_0_0_1-cert.pem", "127_0_0_1-key.pem");
+  sleep(1);
+
+  const int ret(RUN_ALL_TESTS());
+  KillAllOpenSSLServers();
+  return ret;
+}

--- a/cpp/third_party/curl/hostcheck.c
+++ b/cpp/third_party/curl/hostcheck.c
@@ -1,0 +1,214 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2012, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at http://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+/* This file is an amalgamation of hostcheck.c and most of rawstr.c
+   from cURL.  The contents of the COPYING file mentioned above are:
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright (c) 1996 - 2013, Daniel Stenberg, <daniel@haxx.se>.
+
+All rights reserved.
+
+Permission to use, copy, modify, and distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright
+notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS. IN
+NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall not
+be used in advertising or otherwise to promote the sale, use or other dealings
+in this Software without prior written authorization of the copyright holder.
+*/
+
+#include "hostcheck.h"
+#include <string.h>
+
+/* Portable, consistent toupper (remember EBCDIC). Do not use toupper() because
+   its behavior is altered by the current locale. */
+static char Curl_raw_toupper(char in) {
+  switch (in) {
+    case 'a':
+      return 'A';
+    case 'b':
+      return 'B';
+    case 'c':
+      return 'C';
+    case 'd':
+      return 'D';
+    case 'e':
+      return 'E';
+    case 'f':
+      return 'F';
+    case 'g':
+      return 'G';
+    case 'h':
+      return 'H';
+    case 'i':
+      return 'I';
+    case 'j':
+      return 'J';
+    case 'k':
+      return 'K';
+    case 'l':
+      return 'L';
+    case 'm':
+      return 'M';
+    case 'n':
+      return 'N';
+    case 'o':
+      return 'O';
+    case 'p':
+      return 'P';
+    case 'q':
+      return 'Q';
+    case 'r':
+      return 'R';
+    case 's':
+      return 'S';
+    case 't':
+      return 'T';
+    case 'u':
+      return 'U';
+    case 'v':
+      return 'V';
+    case 'w':
+      return 'W';
+    case 'x':
+      return 'X';
+    case 'y':
+      return 'Y';
+    case 'z':
+      return 'Z';
+  }
+  return in;
+}
+
+/*
+ * Curl_raw_equal() is for doing "raw" case insensitive strings. This is meant
+ * to be locale independent and only compare strings we know are safe for
+ * this.  See http://daniel.haxx.se/blog/2008/10/15/strcasecmp-in-turkish/ for
+ * some further explanation to why this function is necessary.
+ *
+ * The function is capable of comparing a-z case insensitively even for
+ * non-ascii.
+ */
+
+static int Curl_raw_equal(const char *first, const char *second) {
+  while (*first && *second) {
+    if (Curl_raw_toupper(*first) != Curl_raw_toupper(*second))
+      /* get out of the loop as soon as they don't match */
+      break;
+    first++;
+    second++;
+  }
+  /* we do the comparison here (possibly again), just to make sure that if the
+     loop above is skipped because one of the strings reached zero, we must not
+     return this as a successful match */
+  return (Curl_raw_toupper(*first) == Curl_raw_toupper(*second));
+}
+
+static int Curl_raw_nequal(const char *first, const char *second, size_t max) {
+  while (*first && *second && max) {
+    if (Curl_raw_toupper(*first) != Curl_raw_toupper(*second)) {
+      break;
+    }
+    max--;
+    first++;
+    second++;
+  }
+  if (0 == max)
+    return 1; /* they are equal this far */
+
+  return Curl_raw_toupper(*first) == Curl_raw_toupper(*second);
+}
+
+/*
+ * Match a hostname against a wildcard pattern.
+ * E.g.
+ *  "foo.host.com" matches "*.host.com".
+ *
+ * We use the matching rule described in RFC6125, section 6.4.3.
+ * http://tools.ietf.org/html/rfc6125#section-6.4.3
+ */
+
+static int hostmatch(const char *hostname, const char *pattern) {
+  const char *pattern_label_end, *pattern_wildcard, *hostname_label_end;
+  int wildcard_enabled;
+  size_t prefixlen, suffixlen;
+  pattern_wildcard = strchr(pattern, '*');
+  if (pattern_wildcard == NULL)
+    return Curl_raw_equal(pattern, hostname) ? CURL_HOST_MATCH
+                                             : CURL_HOST_NOMATCH;
+
+  /* We require at least 2 dots in pattern to avoid too wide wildcard
+     match. */
+  wildcard_enabled = 1;
+  pattern_label_end = strchr(pattern, '.');
+  if (pattern_label_end == NULL ||
+      strchr(pattern_label_end + 1, '.') == NULL ||
+      pattern_wildcard > pattern_label_end ||
+      Curl_raw_nequal(pattern, "xn--", 4)) {
+    wildcard_enabled = 0;
+  }
+  if (!wildcard_enabled)
+    return Curl_raw_equal(pattern, hostname) ? CURL_HOST_MATCH
+                                             : CURL_HOST_NOMATCH;
+
+  hostname_label_end = strchr(hostname, '.');
+  if (hostname_label_end == NULL ||
+      !Curl_raw_equal(pattern_label_end, hostname_label_end))
+    return CURL_HOST_NOMATCH;
+
+  /* The wildcard must match at least one character, so the left-most
+     label of the hostname is at least as large as the left-most label
+     of the pattern. */
+  if (hostname_label_end - hostname < pattern_label_end - pattern)
+    return CURL_HOST_NOMATCH;
+
+  prefixlen = pattern_wildcard - pattern;
+  suffixlen = pattern_label_end - (pattern_wildcard + 1);
+  return Curl_raw_nequal(pattern, hostname, prefixlen) &&
+                 Curl_raw_nequal(pattern_wildcard + 1,
+                                 hostname_label_end - suffixlen, suffixlen)
+             ? CURL_HOST_MATCH
+             : CURL_HOST_NOMATCH;
+}
+
+int Curl_cert_hostcheck(const char *match_pattern, const char *hostname) {
+  if (!match_pattern || !*match_pattern || !hostname ||
+      !*hostname) /* sanity check */
+    return 0;
+
+  if (Curl_raw_equal(hostname, match_pattern)) /* trivial case */
+    return 1;
+
+  if (hostmatch(hostname, match_pattern) == CURL_HOST_MATCH)
+    return 1;
+  return 0;
+}

--- a/cpp/third_party/curl/hostcheck.h
+++ b/cpp/third_party/curl/hostcheck.h
@@ -1,0 +1,29 @@
+#ifndef HEADER_CURL_HOSTCHECK_H
+#define HEADER_CURL_HOSTCHECK_H
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2012, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at http://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+#define CURL_HOST_NOMATCH 0
+#define CURL_HOST_MATCH 1
+int Curl_cert_hostcheck(const char *match_pattern, const char *hostname);
+
+#endif /* HEADER_CURL_HOSTCHECK_H */

--- a/cpp/third_party/isec_partners/openssl_hostname_validation.c
+++ b/cpp/third_party/isec_partners/openssl_hostname_validation.c
@@ -1,0 +1,180 @@
+/* Obtained from: https://github.com/iSECPartners/ssl-conservatory */
+
+/*
+Copyright (C) 2012, iSEC Partners.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+/*
+ * Helper functions to perform basic hostname validation using OpenSSL.
+ *
+ * Please read "everything-you-wanted-to-know-about-openssl.pdf" before
+ * attempting to use this code. This whitepaper describes how the code works,
+ * how it should be used, and what its limitations are.
+ *
+ * Author:  Alban Diquet
+ * License: See LICENSE
+ *
+ */
+
+
+#include <openssl/x509v3.h>
+#include <openssl/ssl.h>
+
+#include "third_party/curl/hostcheck.h"
+#include "third_party/isec_partners/openssl_hostname_validation.h"
+
+#define HOSTNAME_MAX_SIZE 255
+
+/**
+* Tries to find a match for hostname in the certificate's Common Name field.
+*
+* Returns MatchFound if a match was found.
+* Returns MatchNotFound if no matches were found.
+* Returns MalformedCertificate if the Common Name had a NUL character embedded
+* in it.
+* Returns Error if the Common Name could not be extracted.
+*/
+static HostnameValidationResult matches_common_name(const char *hostname,
+                                                    const X509 *server_cert) {
+  int common_name_loc = -1;
+  X509_NAME_ENTRY *common_name_entry = NULL;
+  ASN1_STRING *common_name_asn1 = NULL;
+  char *common_name_str = NULL;
+
+  // Find the position of the CN field in the Subject field of the certificate
+  common_name_loc =
+      X509_NAME_get_index_by_NID(X509_get_subject_name((X509 *)server_cert),
+                                 NID_commonName, -1);
+  if (common_name_loc < 0) {
+    return Error;
+  }
+
+  // Extract the CN field
+  common_name_entry =
+      X509_NAME_get_entry(X509_get_subject_name((X509 *)server_cert),
+                          common_name_loc);
+  if (common_name_entry == NULL) {
+    return Error;
+  }
+
+  // Convert the CN field to a C string
+  common_name_asn1 = X509_NAME_ENTRY_get_data(common_name_entry);
+  if (common_name_asn1 == NULL) {
+    return Error;
+  }
+  common_name_str = (char *)ASN1_STRING_data(common_name_asn1);
+
+  // Make sure there isn't an embedded NUL character in the CN
+  if ((size_t)ASN1_STRING_length(common_name_asn1) !=
+      strlen(common_name_str)) {
+    return MalformedCertificate;
+  }
+
+  // Compare expected hostname with the CN
+  if (Curl_cert_hostcheck(common_name_str, hostname) == CURL_HOST_MATCH) {
+    return MatchFound;
+  } else {
+    return MatchNotFound;
+  }
+}
+
+
+/**
+* Tries to find a match for hostname in the certificate's Subject Alternative
+* Name extension.
+*
+* Returns MatchFound if a match was found.
+* Returns MatchNotFound if no matches were found.
+* Returns MalformedCertificate if any of the hostnames had a NUL character
+* embedded in it.
+* Returns NoSANPresent if the SAN extension was not present in the certificate.
+*/
+static HostnameValidationResult matches_subject_alternative_name(
+    const char *hostname, const X509 *server_cert) {
+  HostnameValidationResult result = MatchNotFound;
+  int i;
+  int san_names_nb = -1;
+  STACK_OF(GENERAL_NAME) *san_names = NULL;
+
+  // Try to extract the names within the SAN extension from the certificate
+  san_names =
+      X509_get_ext_d2i((X509 *)server_cert, NID_subject_alt_name, NULL, NULL);
+  if (san_names == NULL) {
+    return NoSANPresent;
+  }
+  san_names_nb = sk_GENERAL_NAME_num(san_names);
+
+  // Check each name within the extension
+  for (i = 0; i < san_names_nb; i++) {
+    const GENERAL_NAME *current_name = sk_GENERAL_NAME_value(san_names, i);
+
+    if (current_name->type == GEN_DNS) {
+      // Current name is a DNS name, let's check it
+      char *dns_name = (char *)ASN1_STRING_data(current_name->d.dNSName);
+
+      // Make sure there isn't an embedded NUL character in the DNS name
+      if ((size_t)ASN1_STRING_length(current_name->d.dNSName) !=
+          strlen(dns_name)) {
+        result = MalformedCertificate;
+        break;
+      } else {  // Compare expected hostname with the DNS name
+        if (Curl_cert_hostcheck(dns_name, hostname) == CURL_HOST_MATCH) {
+          result = MatchFound;
+          break;
+        }
+      }
+    }
+  }
+  sk_GENERAL_NAME_pop_free(san_names, GENERAL_NAME_free);
+
+  return result;
+}
+
+
+/**
+* Validates the server's identity by looking for the expected hostname in the
+* server's certificate. As described in RFC 6125, it first tries to find a
+* match
+* in the Subject Alternative Name extension. If the extension is not present in
+* the certificate, it checks the Common Name instead.
+*
+* Returns MatchFound if a match was found.
+* Returns MatchNotFound if no matches were found.
+* Returns MalformedCertificate if any of the hostnames had a NUL character
+* embedded in it.
+* Returns Error if there was an error.
+*/
+HostnameValidationResult validate_hostname(const char *hostname,
+                                           const X509 *server_cert) {
+  HostnameValidationResult result;
+
+  if ((hostname == NULL) || (server_cert == NULL))
+    return Error;
+
+  // First try the Subject Alternative Names extension
+  result = matches_subject_alternative_name(hostname, server_cert);
+  if (result == NoSANPresent) {
+    // Extension was not found: try the Common Name
+    result = matches_common_name(hostname, server_cert);
+  }
+
+  return result;
+}

--- a/cpp/third_party/isec_partners/openssl_hostname_validation.h
+++ b/cpp/third_party/isec_partners/openssl_hostname_validation.h
@@ -1,0 +1,59 @@
+/* Obtained from: https://github.com/iSECPartners/ssl-conservatory */
+
+/*
+Copyright (C) 2012, iSEC Partners.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+/*
+ * Helper functions to perform basic hostname validation using OpenSSL.
+ *
+ * Please read "everything-you-wanted-to-know-about-openssl.pdf" before
+ * attempting to use this code. This whitepaper describes how the code works,
+ * how it should be used, and what its limitations are.
+ *
+ * Author:  Alban Diquet
+ * License: See LICENSE
+ *
+ */
+
+typedef enum {
+  MatchFound,
+  MatchNotFound,
+  NoSANPresent,
+  MalformedCertificate,
+  Error
+} HostnameValidationResult;
+
+/**
+* Validates the server's identity by looking for the expected hostname in the
+* server's certificate. As described in RFC 6125, it first tries to find a
+* match
+* in the Subject Alternative Name extension. If the extension is not present in
+* the certificate, it checks the Common Name instead.
+*
+* Returns MatchFound if a match was found.
+* Returns MatchNotFound if no matches were found.
+* Returns MalformedCertificate if any of the hostnames had a NUL character
+* embedded in it.
+* Returns Error if there was an error.
+*/
+HostnameValidationResult validate_hostname(const char *hostname,
+                                           const X509 *server_cert);

--- a/cpp/util/fake_etcd_test.cc
+++ b/cpp/util/fake_etcd_test.cc
@@ -951,5 +951,12 @@ TEST_F(FakeEtcdTest, GetWaitRecursive) {
 
 int main(int argc, char** argv) {
   cert_trans::test::InitTesting(argv[0], &argc, &argv, true);
+
+  OpenSSL_add_all_algorithms();
+  ERR_load_BIO_strings();
+  ERR_load_crypto_strings();
+  SSL_load_error_strings();
+  SSL_library_init();
+
   return RUN_ALL_TESTS();
 }

--- a/cpp/util/testing.cc
+++ b/cpp/util/testing.cc
@@ -1,6 +1,7 @@
 #include "util/testing.h"
 
 #include <event2/thread.h>
+#include <evhtp.h>
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
@@ -18,6 +19,15 @@ void InitTesting(const char* name, int* argc, char*** argv,
   google::InitGoogleLogging(name);
   google::InstallFailureSignalHandler();
   evthread_use_pthreads();
+
+  // Set-up OpenSSL for multithreaded use:
+  evhtp_ssl_use_threads();
+
+  OpenSSL_add_all_algorithms();
+  ERR_load_BIO_strings();
+  ERR_load_crypto_strings();
+  SSL_load_error_strings();
+  SSL_library_init();
 }
 
 }  // namespace test

--- a/test/create_url_fetcher_test_certs.sh
+++ b/test/create_url_fetcher_test_certs.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+. ${DIR}/generate_certs.sh
+
+set -e
+
+TARGET="${DIR}/testdata/urlfetcher_test_certs"
+mkdir -p ${TARGET}
+
+# TODO(alcutter): fix the cert/ca scripts to work if called from a different
+# directory
+cd ${DIR}
+
+echo "Generating CA certs in ${TARGET}"
+mkdir -p ${TARGET}/ca-hashes
+ca_setup ${TARGET} ca false
+make_ca_certs ${TARGET} ${TARGET}/ca-hashes ca openssl
+cp ${TARGET}/01.pem ${TARGET}/ca-cert.pem
+
+sed -e "/0.organizationName=Certificate/ a commonName=localhost" ${DIR}/precert.conf > ${TARGET}/localhost.conf
+sed -e "/0.organizationName=Certificate/ a commonName=not-localhost" ${DIR}/precert.conf > ${TARGET}/not-localhost.conf
+sed -e "/0.organizationName=Certificate/ a commonName=binky.example.com" ${DIR}/precert.conf > ${TARGET}/binky_example_com.conf
+sed -e "/0.organizationName=Certificate/ a commonName=*.example.com" ${DIR}/precert.conf > ${TARGET}/star_example_com.conf
+sed -e "/0.organizationName=Certificate/ a commonName=example.com" ${DIR}/precert.conf > ${TARGET}/example_com.conf
+sed -e "/0.organizationName=Certificate/ a commonName=127.0.0.1" ${DIR}/precert.conf > ${TARGET}/127_0_0_1.conf
+
+request_cert ${TARGET} "not-localhost" ${TARGET}/not-localhost.conf true
+issue_cert ${TARGET} ca "not-localhost" ${TARGET}/not-localhost.conf simple false "not-localhost"
+
+request_cert ${TARGET} "localhost" ${TARGET}/localhost.conf true
+issue_cert ${TARGET} ca "localhost" ${TARGET}/localhost.conf simple false "localhost"
+
+request_cert ${TARGET} "binky_example_com" ${TARGET}/binky_example_com.conf true
+issue_cert ${TARGET} ca "binky_example_com" ${TARGET}/binky_example_com.conf simple false "binky_example_com"
+
+request_cert ${TARGET} "star_example_com" ${TARGET}/star_example_com.conf true
+issue_cert ${TARGET} ca "star_example_com" ${TARGET}/star_example_com.conf simple false "star_example_com"
+
+request_cert ${TARGET} "example_com" ${TARGET}/example_com.conf true
+issue_cert ${TARGET} ca "example_com" ${TARGET}/example_com.conf simple false "example_com"
+
+request_cert ${TARGET} "127_0_0_1" ${TARGET}/127_0_0_1.conf true
+issue_cert ${TARGET} ca "127_0_0_1" ${TARGET}/127_0_0_1.conf simple false "127_0_0_1"
+


### PR DESCRIPTION
In an attempt to avoid blindly falling into the many OpenSSL gotchas, most of the hostname checking stuff is glommed from https://wiki.openssl.org/index.php/Hostname_validation and https://github.com/iSECPartners/ssl-conservatory/tree/master/openssl, and re-uses the cURL hostname checking routines referenced there.

By way of simple sanity checking, ct-mirror happily works over SSL with this against Pilot (etc.) and verifies the *.googleapis.com cert ok, it also correctly rejects the cert served at https://tv.eurosport.com (since that doesn't contain a matching CN/SAN.)
 