### PR TITLE
Improve error reporting for SSL_CTX_new.

### DIFF
--- a/cpp/net/connection_pool.cc
+++ b/cpp/net/connection_pool.cc
@@ -138,8 +138,9 @@ void ConnectionPool::Connection::ReleaseConnection() {
 ConnectionPool::ConnectionPool(libevent::Base* base)
     : base_(CHECK_NOTNULL(base)),
       cleanup_scheduled_(false),
-      ssl_ctx_(CHECK_NOTNULL(SSL_CTX_new(TLSv1_client_method())),
-               SSL_CTX_free) {
+      ssl_ctx_(SSL_CTX_new(TLSv1_client_method()), SSL_CTX_free) {
+  CHECK(ssl_ctx_) << "could not build SSL context: " << DumpOpenSSLErrorStack();
+
   // Try to load trusted root certificates.
   // TODO(alcutter): This is probably Linux specific, we'll need other sections
   // for OSX etc.


### PR DESCRIPTION
Attempting clarify error messages, but it's only getting me this anyway, so it's only of limited help... :stuck_out_tongue: 

```
F0623 16:16:08.862726  8713 connection_pool.cc:142] Check failed: ssl_ctx_ could not build SSL context: OpenSSL errors left on stack:
        error:140A90A1:SSL routines:func(169):reason(161)
```