### PR TITLE
Populate TBS and Cert Signature fields in X509Description.

### DIFF
--- a/python/ct/client/db/cert_desc_test.py
+++ b/python/ct/client/db/cert_desc_test.py
@@ -8,57 +8,77 @@ from ct.cert_analysis import all_checks
 from ct.cert_analysis import observation
 
 CERT = cert.Certificate.from_der_file("ct/crypto/testdata/google_cert.der")
+CA_CERT = cert.Certificate.from_pem_file("ct/crypto/testdata/verisign_intermediate.pem")
 
 class CertificateDescriptionTest(unittest.TestCase):
     def test_from_cert(self):
-        observations = []
-        for check in all_checks.ALL_CHECKS:
-            observations += check.check(CERT) or []
-        observations.append(observation.Observation(
-            "AE", u'ćę©ß→æ→ćąßę-ß©ąńśþa©ęńć←', (u'əę”ąłęµ', u'…łą↓ð→↓ś→ę')))
-        proto = cert_desc.from_cert(CERT, observations)
-        self.assertEqual(proto.der, CERT.to_der())
+        for test_case in [(CERT, False), (CA_CERT, True)]:
+            (source, expect_ca_true) = test_case
 
-        subject = [(att.type, att.value) for att in proto.subject]
-        cert_subject = [(type_.short_name,
-                     cert_desc.to_unicode('.'.join(
-                             cert_desc.process_name(value.human_readable()))))
-                    for type_, value in CERT.subject()]
-        self.assertItemsEqual(cert_subject, subject)
+            observations = []
+            for check in all_checks.ALL_CHECKS:
+                observations += check.check(source) or []
+            observations.append(observation.Observation(
+                "AE", u'ćę©ß→æ→ćąßę-ß©ąńśþa©ęńć←', (u'əę”ąłęµ', u'…łą↓ð→↓ś→ę')))
+            proto = cert_desc.from_cert(source, observations)
+            self.assertEqual(proto.der, source.to_der())
 
-        issuer = [(att.type, att.value) for att in proto.issuer]
-        cert_issuer = [(type_.short_name,
-                     cert_desc.to_unicode('.'.join(
-                             cert_desc.process_name(value.human_readable()))))
-                    for type_, value in CERT.issuer()]
-        self.assertItemsEqual(cert_issuer, issuer)
+            subject = [(att.type, att.value) for att in proto.subject]
+            cert_subject = [(type_.short_name,
+                         cert_desc.to_unicode('.'.join(
+                                 cert_desc.process_name(value.human_readable()))))
+                        for type_, value in source.subject()]
+            self.assertItemsEqual(cert_subject, subject)
 
-        subject_alternative_names = [(att.type, att.value)
-                                     for att in proto.subject_alternative_names]
-        cert_subject_alternative_names = [(san.component_key(),
-                                           cert_desc.to_unicode('.'.join(
-                                            cert_desc.process_name(
-                                     san.component_value().human_readable()))))
-                    for san in CERT.subject_alternative_names()]
-        self.assertItemsEqual(cert_subject_alternative_names,
-                              subject_alternative_names)
+            issuer = [(att.type, att.value) for att in proto.issuer]
+            cert_issuer = [(type_.short_name,
+                         cert_desc.to_unicode('.'.join(
+                                 cert_desc.process_name(value.human_readable()))))
+                        for type_, value in source.issuer()]
+            self.assertItemsEqual(cert_issuer, issuer)
 
-        self.assertEqual(proto.version, str(CERT.version().value))
-        self.assertEqual(proto.serial_number,
-                         str(CERT.serial_number().human_readable()
-                             .upper().replace(':', '')))
-        self.assertEqual(time.gmtime(proto.validity.not_before / 1000),
-                         CERT.not_before())
-        self.assertEqual(time.gmtime(proto.validity.not_after / 1000),
-                         CERT.not_after())
+            subject_alternative_names = [(att.type, att.value)
+                                         for att in proto.subject_alternative_names]
+            cert_subject_alternative_names = [(san.component_key(),
+                                               cert_desc.to_unicode('.'.join(
+                                                cert_desc.process_name(
+                                         san.component_value().human_readable()))))
+                        for san in source.subject_alternative_names()]
+            self.assertItemsEqual(cert_subject_alternative_names,
+                                  subject_alternative_names)
 
-        observations_tuples = [(unicode(obs.description),
-                                unicode(obs.reason) if obs.reason else u'',
-                                obs.details_to_proto())
-                               for obs in observations]
-        proto_obs = [(obs.description, obs.reason, obs.details)
-                     for obs in proto.observations]
-        self.assertItemsEqual(proto_obs, observations_tuples)
+            self.assertEqual(proto.version, str(source.version().value))
+            self.assertEqual(proto.serial_number,
+                             str(source.serial_number().human_readable()
+                                 .upper().replace(':', '')))
+            self.assertEqual(time.gmtime(proto.validity.not_before / 1000),
+                             source.not_before())
+            self.assertEqual(time.gmtime(proto.validity.not_after / 1000),
+                             source.not_after())
+
+            observations_tuples = [(unicode(obs.description),
+                                    unicode(obs.reason) if obs.reason else u'',
+                                    obs.details_to_proto())
+                                   for obs in observations]
+            proto_obs = [(obs.description, obs.reason, obs.details)
+                         for obs in proto.observations]
+            self.assertItemsEqual(proto_obs, observations_tuples)
+
+            self.assertEqual(proto.tbs_signature.algorithm_id,
+                             source.signature()["algorithm"].long_name)
+            self.assertEqual(proto.cert_signature.algorithm_id,
+                             source.signature_algorithm()["algorithm"].long_name)
+            self.assertEqual(proto.tbs_signature.algorithm_id,
+                             proto.cert_signature.algorithm_id)
+
+            self.assertEqual(proto.tbs_signature.parameters,
+                             source.signature()["parameters"])
+            self.assertEqual(proto.cert_signature.parameters,
+                             source.signature_algorithm()["parameters"])
+            self.assertEqual(proto.tbs_signature.parameters,
+                             proto.cert_signature.parameters)
+
+            self.assertEqual(proto.basic_constraint_ca, expect_ca_true)
 
     def test_process_value(self):
         self.assertEqual(["London"], cert_desc.process_name("London"))

--- a/python/ct/proto/certificate.proto
+++ b/python/ct/proto/certificate.proto
@@ -61,5 +61,9 @@ message X509Description {
 
   repeated DNAttribute root_issuer = 12;
 
+  // Type of Log Entry this cert came from: X509 or PRECERT.
   optional LogEntryType entry_type = 13;
+
+  // True if this cert has the Basic Constraint CA=TRUE.
+  optional bool basic_constraint_ca = 14;
 }


### PR DESCRIPTION
These fields were already defined but not being populated.
Add 'basic_constraint_ca' field to the X509Description proto as well.