### PR TITLE
Migrate from 'requests' for an HTTP client to 'httplib2'

### DIFF
--- a/python/README
+++ b/python/README
@@ -3,7 +3,7 @@ To run the python scripts
 1. Install the following additional packages
 gflags (python_gflags if using easy_install)
 gviz-api-py (easy_install 'https://google-visualization-python.googlecode.com/files/gviz_api_py-1.8.2.tar.gz')
-requests (at least version 1.0)
+httplib2
 protobuf
 ecdsa
 mock

--- a/python/ct/client/log_client_test.py
+++ b/python/ct/client/log_client_test.py
@@ -337,6 +337,19 @@ class LogClientTest(unittest.TestCase):
         self.assertRaises(log_client.InvalidResponseError,
                           client._parse_sct, json_sct_response)
 
+    def test_uri_with_params(self):
+        self.assertEqual(
+            'http://www.google.com',
+            log_client.RequestHandler._uri_with_params('http://www.google.com',
+                                                      {}))
+        self.assertEqual(
+            'http://www.google.com?a=1&b=2',
+            log_client.RequestHandler._uri_with_params('http://www.google.com',
+                                                      {'a': 1, 'b': 2}))
+        self.assertEqual(
+            'http://www.google.com/?a=1&b=foo+bar',
+            log_client.RequestHandler._uri_with_params('http://www.google.com/',
+                                                      {'a': 1, 'b': 'foo bar'}))
 
 if __name__ == "__main__":
     sys.argv = FLAGS(sys.argv)

--- a/python/ct/client/scanner.py
+++ b/python/ct/client/scanner.py
@@ -105,11 +105,11 @@ def _scan(entry_queue, log_url, range_description):
         entries = client.get_entries(range_start, range_end)
         scanned = range_start
         for entry in entries:
-            scanned += 1
             # Can't pickle protocol buffers with protobuf module version < 2.5.0
             # (https://code.google.com/p/protobuf/issues/detail?id=418)
             # so send serialized entry.
             entry_queue.put((scanned, entry.SerializeToString()))
+            scanned += 1
     except Exception as e:
         print "Exception when fetching range %d to %d:\n%s" % (
             range_start, range_end, e)

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -4,5 +4,6 @@ https://google-visualization-python.googlecode.com/files/gviz_api_py-1.8.2.tar.g
 mock>=1.0
 protobuf
 python-gflags
-requests>=1.0
 Twisted>=12.1
+httplib2>0.9
+bitstring


### PR DESCRIPTION
This is being done because 'requests' depends on 'urllib3' which is thought to have security issues.