### PR TITLE
Write STHs to LevelDB synchronously.

### DIFF
--- a/cpp/log/leveldb_db-inl.h
+++ b/cpp/log/leveldb_db-inl.h
@@ -274,8 +274,9 @@ typename Database<Logged>::WriteResult LevelDB<Logged>::WriteTreeHead_(
     return this->DUPLICATE_TREE_HEAD_TIMESTAMP;
   }
 
-  status =
-      db_->Put(leveldb::WriteOptions(), kTreeHeadPrefix + timestamp_key, data);
+  leveldb::WriteOptions opts;
+  opts.sync = true;
+  status = db_->Put(opts, kTreeHeadPrefix + timestamp_key, data);
   CHECK(status.ok()) << "Failed to write tree head (" << timestamp_key
                      << "): " << status.ToString();
 


### PR DESCRIPTION
#770 
Docs at https://github.com/google/leveldb/blob/master/doc/index.html suggest that this "hybrid" approach as they call it is fine.  (Otherwise there's always the synchronous "WriteBatch" approach.)