### PR TITLE
Add support for precertificate verification.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -39,6 +39,7 @@ Nicholas Galbreath <nickg@client9.com>
 Oliver Weidner <Oliver.Weidner@gmail.com>
 Pascal Leroy <phl@google.com>
 Paul Hadfield <hadfieldp@google.com> <paul@phad.org.uk>
+Paul Lietar <lietar@google.com>
 Pierre Phaneuf <pphaneuf@google.com>
 Rob Stradling <rob@comodo.com>
 Ruslan Kovalov <ruslan.kovalyov@gmail.com>

--- a/python/ct/crypto/error.py
+++ b/python/ct/crypto/error.py
@@ -113,6 +113,10 @@ class ASN1IllegalCharacter(ASN1Error):
                                                                     self.index],
                                                               self.index)
 
+class IncompleteChainError(VerifyError):
+    """A certificate is missing from the chain"""
+    pass
+
 class SignatureError(VerifyError):
     """A public-key signature does not verify."""
     pass


### PR DESCRIPTION
In addition to the already supported plain X.509 certificate,
precertificates and certificates embedding an SCT list can be verified.
PreCertificates signed with special purpose CA certificates are also
supported.