### PR TITLE
Log etcd version(s)

### DIFF
--- a/cpp/server/ct-mirror.cc
+++ b/cpp/server/ct-mirror.cc
@@ -354,7 +354,8 @@ int main(int argc, char* argv[]) {
   const std::unique_ptr<EtcdClient> etcd_client(
       stand_alone_mode
           ? new FakeEtcdClient(event_base.get())
-          : new EtcdClient(&url_fetcher, SplitHosts(FLAGS_etcd_servers)));
+          : new EtcdClient(&internal_pool, &url_fetcher,
+                           SplitHosts(FLAGS_etcd_servers)));
 
   Server<LoggedCertificate>::Options options;
   options.server = FLAGS_server;

--- a/cpp/server/ct-server.cc
+++ b/cpp/server/ct-server.cc
@@ -382,7 +382,8 @@ int main(int argc, char* argv[]) {
   std::unique_ptr<EtcdClient> etcd_client(
       stand_alone_mode
           ? new FakeEtcdClient(event_base.get())
-          : new EtcdClient(&url_fetcher, SplitHosts(FLAGS_etcd_servers)));
+          : new EtcdClient(&internal_pool, &url_fetcher,
+                           SplitHosts(FLAGS_etcd_servers)));
 
   Server<LoggedCertificate>::Options options;
   options.server = FLAGS_server;

--- a/cpp/tools/clustertool_main.cc
+++ b/cpp/tools/clustertool_main.cc
@@ -149,7 +149,7 @@ int main(int argc, char* argv[]) {
   ThreadPool pool;
   UrlFetcher fetcher(event_base.get(), &pool);
 
-  EtcdClient etcd_client(&fetcher, SplitHosts(FLAGS_etcd_servers));
+  EtcdClient etcd_client(&pool, &fetcher, SplitHosts(FLAGS_etcd_servers));
 
   const string node_id("clustertool");
   unique_ptr<MasterElection> election(

--- a/cpp/tools/etcd_watch.cc
+++ b/cpp/tools/etcd_watch.cc
@@ -41,7 +41,7 @@ int main(int argc, char* argv[]) {
   libevent::Base event_base;
   ThreadPool pool;
   UrlFetcher fetcher(&event_base, &pool);
-  EtcdClient etcd(&fetcher, FLAGS_etcd, FLAGS_etcd_port);
+  EtcdClient etcd(&pool, &fetcher, FLAGS_etcd, FLAGS_etcd_port);
 
   SyncTask task(&event_base);
   etcd.Watch(FLAGS_key, Notify, task.task());

--- a/cpp/util/bench_etcd.cc
+++ b/cpp/util/bench_etcd.cc
@@ -88,7 +88,7 @@ void test_etcd(int thread_num) {
   libevent::EventPumpThread pump(event_base);
   ThreadPool pool;
   UrlFetcher fetcher(event_base.get(), &pool);
-  EtcdClient etcd(&fetcher, FLAGS_etcd, FLAGS_etcd_port);
+  EtcdClient etcd(&pool, &fetcher, FLAGS_etcd, FLAGS_etcd_port);
   SyncTask task(event_base.get());
   State state(&etcd, thread_num, task.task());
 

--- a/cpp/util/etcd.h
+++ b/cpp/util/etcd.h
@@ -14,6 +14,7 @@
 #include "base/macros.h"
 #include "net/url_fetcher.h"
 #include "util/status.h"
+#include "util/sync_task.h"
 #include "util/task.h"
 #include "util/util.h"
 
@@ -81,9 +82,9 @@ class EtcdClient {
 
   typedef std::function<void(const std::vector<Node>& updates)> WatchCallback;
 
-  EtcdClient(UrlFetcher* fetcher, const std::string& host, uint16_t port);
+  EtcdClient(util::Executor* executor, UrlFetcher* fetcher, const std::string& host, uint16_t port);
 
-  EtcdClient(UrlFetcher* fetcher, const std::list<HostPortPair>& etcds);
+  EtcdClient(util::Executor* executir, UrlFetcher* fetcher, const std::list<HostPortPair>& etcds);
 
   virtual ~EtcdClient();
 
@@ -150,10 +151,15 @@ class EtcdClient {
   void WatchRequestDone(WatchState* state, GetResponse* gen_resp,
                         util::Task* child_task);
 
+  void MaybeLogEtcdVersion();
+
+  util::Executor* const executor_;
+  std::unique_ptr<util::SyncTask> log_version_task_;
   UrlFetcher* const fetcher_;
 
   mutable std::mutex lock_;
   std::list<HostPortPair> etcds_;
+  bool logged_version_;
 
   DISALLOW_COPY_AND_ASSIGN(EtcdClient);
 };

--- a/cpp/util/etcd_masterelection.cc
+++ b/cpp/util/etcd_masterelection.cc
@@ -33,7 +33,7 @@ int main(int argc, char* argv[]) {
   ThreadPool pool;
   UrlFetcher fetcher(event_base.get(), &pool);
 
-  EtcdClient etcd(&fetcher, FLAGS_etcd, FLAGS_etcd_port);
+  EtcdClient etcd(&pool, &fetcher, FLAGS_etcd, FLAGS_etcd_port);
   MasterElection election(event_base, &etcd, FLAGS_proposal_dir,
                           FLAGS_node_id);
   election.StartElection();

--- a/cpp/util/fake_etcd_test.cc
+++ b/cpp/util/fake_etcd_test.cc
@@ -66,7 +66,8 @@ class FakeEtcdTest : public ::testing::Test {
         fetcher_(base_.get(), &pool_),
         client_(FLAGS_etcd.empty()
                     ? new FakeEtcdClient(base_.get())
-                    : new EtcdClient(&fetcher_, FLAGS_etcd, FLAGS_etcd_port)),
+                    : new EtcdClient(&pool_, &fetcher_, FLAGS_etcd,
+                                     FLAGS_etcd_port)),
         key_prefix_(BuildKeyPrefix()) {
   }
 

--- a/cpp/util/masterelection_test.cc
+++ b/cpp/util/masterelection_test.cc
@@ -153,9 +153,10 @@ class ElectionTest : public ::testing::Test {
         event_pump_(base_),
         pool_(),
         url_fetcher_(base_.get(), &pool_),
-        client_(FLAGS_etcd.empty() ? new FakeEtcdClient(base_.get())
-                                   : new EtcdClient(&url_fetcher_, FLAGS_etcd,
-                                                    FLAGS_etcd_port)) {
+        client_(FLAGS_etcd.empty()
+                    ? new FakeEtcdClient(base_.get())
+                    : new EtcdClient(&pool_, &url_fetcher_, FLAGS_etcd,
+                                     FLAGS_etcd_port)) {
   }
 
 


### PR DESCRIPTION
Logs the version of the etcd server we're currently talking to.
Does the reporting lazily - i.e. waits for the first "real" request before requesting the version.
If we get redirected to another etcd it'll log the version string from there too.