### PR TITLE
Allows python.ct.crypto.cert.Certificate to be used in a set

### DIFF
--- a/python/ct/crypto/cert.py
+++ b/python/ct/crypto/cert.py
@@ -56,6 +56,23 @@ class Certificate(object):
     def __str__(self):
         return self._asn1_cert.human_readable(label=self.__class__.__name__)
 
+    def __eq__(self, other):
+        if isinstance(other, type(self)):
+            return self.is_identical_to(other)
+        else:
+            return NotImplemented
+
+    def __ne__(self, other):
+        are_equal = self.__eq__(other)
+
+        if are_equal is NotImplemented:
+            return NotImplemented
+        else:
+            return not are_equal
+
+    def __hash__(self):
+        return hash(self.fingerprint())
+
     @classmethod
     def from_pem(cls, pem_string, strict_der=True):
         """Read a single PEM-encoded certificate from a string.

--- a/python/ct/crypto/cert_test.py
+++ b/python/ct/crypto/cert_test.py
@@ -184,17 +184,21 @@ class CertificateTest(unittest.TestCase):
     def test_identical_to_self(self):
         c = self.cert_from_pem_file(self._PEM_FILE)
         self.assertTrue(c.is_identical_to(c))
+        self.assertEqual(c, c)
 
     def test_identical(self):
         c = self.cert_from_pem_file(self._PEM_FILE)
         c2 = self.cert_from_pem_file(self._PEM_FILE)
         self.assertTrue(c.is_identical_to(c2))
         self.assertTrue(c2.is_identical_to(c))
+        self.assertEqual(c2, c)
 
     def test_not_identical(self):
         c = self.cert_from_pem_file(self._PEM_FILE)
         c2 = self.cert_from_pem_file(self._V1_PEM_FILE)
         self.assertFalse(c2.is_identical_to(c))
+        self.assertNotEqual(c2, c)
+        self.assertNotEqual(c2, "foo")
 
     def test_parse_matrixssl(self):
         """Test parsing of old MatrixSSL.org sample certificate

--- a/python/ct/crypto/cert_test.py
+++ b/python/ct/crypto/cert_test.py
@@ -200,6 +200,12 @@ class CertificateTest(unittest.TestCase):
         self.assertNotEqual(c2, c)
         self.assertNotEqual(c2, "foo")
 
+    def test_hash(self):
+        c = self.cert_from_pem_file(self._PEM_FILE)
+        c2 = self.cert_from_pem_file(self._PEM_FILE)
+        self.assertEqual(hash(c), hash(c))
+        self.assertEqual(hash(c), hash(c2))
+
     def test_parse_matrixssl(self):
         """Test parsing of old MatrixSSL.org sample certificate
 


### PR DESCRIPTION
Implements magic methods that allow Certificate instances to be tested
for equality and hashed - the two requirements for putting them in a set.
This makes it trivial to eliminate duplicate certificates.

This makes Certificate.is_identical_to redundant, but it remains for
backwards compatibility.