### PR TITLE
Fixes bug in ct.client.db.cert_desc when local timezone is not UTC

### DIFF
--- a/python/ct/cert_analysis/algorithm.py
+++ b/python/ct/cert_analysis/algorithm.py
@@ -1,3 +1,4 @@
+import calendar
 import time
 
 from ct.crypto import cert
@@ -19,7 +20,8 @@ class AlgorithmMismatch(AlgorithmObservation):
 
 class SHA1Observation(AlgorithmObservation):
     def _format_details(self):
-        return time.strftime("%Y-%m-%dT%H:%M:%S%Z", self.details)
+        # Times are in UTC, so use "UTC" instead of %Z (which gives local TZ)
+        return time.strftime("%Y-%m-%dT%H:%M:%SUTC", self.details)
 
 
 class RsaSHA1(SHA1Observation):
@@ -57,7 +59,7 @@ class CheckSignatureAlgorithmsMismatch(object):
 def check_sha1_after_2017(not_after, algorithm):
     invalid_after = time.strptime("2017-01-01T00:00:00UTC",
                                   "%Y-%m-%dT%H:%M:%S%Z")
-    if time.mktime(not_after) - time.mktime(invalid_after) >= 0:
+    if calendar.timegm(not_after) - calendar.timegm(invalid_after) >= 0:
         if algorithm == oid.SHA1_WITH_RSA_ENCRYPTION:
             return RsaSHA1(not_after)
         elif algorithm == oid.ID_DSA_WITH_SHA1:

--- a/python/ct/cert_analysis/validity.py
+++ b/python/ct/cert_analysis/validity.py
@@ -1,3 +1,4 @@
+import calendar
 import datetime
 import time
 
@@ -45,9 +46,8 @@ class CheckValidityNotBeforeFuture(object):
         try:
             not_before = certificate.not_before()
             now = datetime.datetime.utcnow()
-            # time.mktime assumes localtime, but because both dates are in utc
-            # comparision will be valid
-            if time.mktime(not_before) - time.mktime(now.utctimetuple()) > 0:
+
+            if calendar.timegm(not_before) - calendar.timegm(now.utctimetuple()) > 0:
                 return [NotBeforeInFuture(details=not_before)]
         except cert.CertificateError:
             pass

--- a/python/ct/client/db/cert_desc.py
+++ b/python/ct/client/db/cert_desc.py
@@ -1,6 +1,6 @@
 import re
 import hashlib
-import time
+import calendar
 from ct.crypto import cert
 from ct.crypto.asn1 import x509_common
 from ct.proto import certificate_pb2
@@ -75,8 +75,8 @@ def from_cert(certificate, observations=[]):
 
     try:
         proto.validity.not_before, proto.validity.not_after = (
-            1000 * int(time.mktime(certificate.not_before())),
-            1000 * int(time.mktime(certificate.not_after())))
+            1000 * int(calendar.timegm(certificate.not_before())),
+            1000 * int(calendar.timegm(certificate.not_after())))
     except cert.CertificateError:
         pass
 

--- a/python/ct/client/db/cert_desc.py
+++ b/python/ct/client/db/cert_desc.py
@@ -1,6 +1,6 @@
-import re
-import hashlib
 import calendar
+import hashlib
+import re
 from ct.crypto import cert
 from ct.crypto.asn1 import x509_common
 from ct.proto import certificate_pb2

--- a/python/ct/client/db/cert_desc_test.py
+++ b/python/ct/client/db/cert_desc_test.py
@@ -116,8 +116,11 @@ class CertificateDescriptionTest(unittest.TestCase):
         with time_utils.timezone("UTC"):
             self.assert_description_matches_source(cert, is_ca_cert)
 
-        # Test in a non-UTC timezone, to detect timezone issues
+        # Test in non-UTC timezones, to detect timezone issues
         with time_utils.timezone("America/Los_Angeles"):
+            self.assert_description_matches_source(cert, is_ca_cert)
+
+        with time_utils.timezone("Asia/Shanghai"):
             self.assert_description_matches_source(cert, is_ca_cert)
 
     def test_from_cert_with_dsa_sha256_cert(self):
@@ -127,8 +130,11 @@ class CertificateDescriptionTest(unittest.TestCase):
         with time_utils.timezone("UTC"):
             self.assert_description_matches_source(cert, is_ca_cert)
 
-        # Test in a non-UTC timezone, to detect timezone issues
+        # Test in non-UTC timezones, to detect timezone issues
         with time_utils.timezone("America/Los_Angeles"):
+            self.assert_description_matches_source(cert, is_ca_cert)
+
+        with time_utils.timezone("Asia/Shanghai"):
             self.assert_description_matches_source(cert, is_ca_cert)
 
     def test_from_cert_with_ca_cert(self):
@@ -138,8 +144,11 @@ class CertificateDescriptionTest(unittest.TestCase):
         with time_utils.timezone("UTC"):
             self.assert_description_matches_source(cert, is_ca_cert)
 
-        # Test in a non-UTC timezone, to detect timezone issues
+        # Test in non-UTC timezones, to detect timezone issues
         with time_utils.timezone("America/Los_Angeles"):
+            self.assert_description_matches_source(cert, is_ca_cert)
+
+        with time_utils.timezone("Asia/Shanghai"):
             self.assert_description_matches_source(cert, is_ca_cert)
 
     def test_process_value(self):

--- a/python/ct/client/db/cert_desc_test.py
+++ b/python/ct/client/db/cert_desc_test.py
@@ -13,87 +13,97 @@ CA_CERT = cert.Certificate.from_pem_file("ct/crypto/testdata/verisign_intermedia
 DSA_SHA256_CERT = cert.Certificate.from_der_file("ct/crypto/testdata/dsa_with_sha256.der")
 
 class CertificateDescriptionTest(unittest.TestCase):
+    def assert_description_matches_source(self, source, expect_ca_true):
+        observations = []
+        for check in all_checks.ALL_CHECKS:
+            observations += check.check(source) or []
+        observations.append(observation.Observation(
+            "AE", u'ćę©ß→æ→ćąßę-ß©ąńśþa©ęńć←', (u'əę”ąłęµ', u'…łą↓ð→↓ś→ę')))
+
+        proto = cert_desc.from_cert(source, observations)
+
+        self.assertEqual(proto.der, source.to_der())
+
+        subject = [(att.type, att.value) for att in proto.subject]
+        cert_subject = [(type_.short_name,
+                     cert_desc.to_unicode('.'.join(
+                             cert_desc.process_name(value.human_readable()))))
+                    for type_, value in source.subject()]
+        self.assertItemsEqual(cert_subject, subject)
+
+        issuer = [(att.type, att.value) for att in proto.issuer]
+        cert_issuer = [(type_.short_name,
+                     cert_desc.to_unicode('.'.join(
+                             cert_desc.process_name(value.human_readable()))))
+                    for type_, value in source.issuer()]
+        self.assertItemsEqual(cert_issuer, issuer)
+
+        subject_alternative_names = [(att.type, att.value)
+                                     for att in proto.subject_alternative_names]
+        cert_subject_alternative_names = [(san.component_key(),
+                                           cert_desc.to_unicode('.'.join(
+                                            cert_desc.process_name(
+                                     san.component_value().human_readable()))))
+                    for san in source.subject_alternative_names()]
+        self.assertItemsEqual(cert_subject_alternative_names,
+                              subject_alternative_names)
+
+        self.assertEqual(proto.version, str(source.version().value))
+        self.assertEqual(proto.serial_number,
+                         str(source.serial_number().human_readable()
+                             .upper().replace(':', '')))
+
+        self.assertEqual(time.gmtime(proto.validity.not_before / 1000),
+                         source.not_before())
+        self.assertEqual(time.gmtime(proto.validity.not_after / 1000),
+                         source.not_after())
+
+        observations_tuples = [(unicode(obs.description),
+                                unicode(obs.reason) if obs.reason else u'',
+                                obs.details_to_proto())
+                               for obs in observations]
+        proto_obs = [(obs.description, obs.reason, obs.details)
+                     for obs in proto.observations]
+        self.assertItemsEqual(proto_obs, observations_tuples)
+
+        self.assertEqual(proto.tbs_signature.algorithm_id,
+                         source.signature()["algorithm"].long_name)
+        self.assertEqual(proto.cert_signature.algorithm_id,
+                         source.signature_algorithm()["algorithm"].long_name)
+        self.assertEqual(proto.tbs_signature.algorithm_id,
+                         proto.cert_signature.algorithm_id)
+
+        if source.signature()["parameters"]:
+            self.assertEqual(proto.tbs_signature.parameters,
+                             source.signature()["parameters"])
+        else:
+            self.assertFalse(proto.tbs_signature.HasField('parameters'))
+
+        if source.signature_algorithm()["parameters"]:
+            self.assertEqual(proto.cert_signature.parameters,
+                             source.signature_algorithm()["parameters"])
+        else:
+            self.assertFalse(proto.cert_signature.HasField('parameters'))
+
+        self.assertEqual(proto.tbs_signature.parameters,
+                         proto.cert_signature.parameters)
+
+        self.assertEqual(proto.basic_constraint_ca, expect_ca_true)
+
     def test_from_cert(self):
         # Test in a non-UTC timezone, to detect timezone issues
         with time_utils.timezone("America/Los_Angeles"):
-            for test_case in [(CERT, False), (DSA_SHA256_CERT, False), (CA_CERT, True)]:
-                (source, expect_ca_true) = test_case
+            self.assert_description_matches_source(CERT, False)
 
-                observations = []
-                for check in all_checks.ALL_CHECKS:
-                    observations += check.check(source) or []
-                observations.append(observation.Observation(
-                    "AE", u'ćę©ß→æ→ćąßę-ß©ąńśþa©ęńć←', (u'əę”ąłęµ', u'…łą↓ð→↓ś→ę')))
+    def test_from_cert_with_dsa_sha256_cert(self):
+        # Test in a non-UTC timezone, to detect timezone issues
+        with time_utils.timezone("America/Los_Angeles"):
+            self.assert_description_matches_source(DSA_SHA256_CERT, False)
 
-                proto = cert_desc.from_cert(source, observations)
-
-                self.assertEqual(proto.der, source.to_der())
-
-                subject = [(att.type, att.value) for att in proto.subject]
-                cert_subject = [(type_.short_name,
-                             cert_desc.to_unicode('.'.join(
-                                     cert_desc.process_name(value.human_readable()))))
-                            for type_, value in source.subject()]
-                self.assertItemsEqual(cert_subject, subject)
-
-                issuer = [(att.type, att.value) for att in proto.issuer]
-                cert_issuer = [(type_.short_name,
-                             cert_desc.to_unicode('.'.join(
-                                     cert_desc.process_name(value.human_readable()))))
-                            for type_, value in source.issuer()]
-                self.assertItemsEqual(cert_issuer, issuer)
-
-                subject_alternative_names = [(att.type, att.value)
-                                             for att in proto.subject_alternative_names]
-                cert_subject_alternative_names = [(san.component_key(),
-                                                   cert_desc.to_unicode('.'.join(
-                                                    cert_desc.process_name(
-                                             san.component_value().human_readable()))))
-                            for san in source.subject_alternative_names()]
-                self.assertItemsEqual(cert_subject_alternative_names,
-                                      subject_alternative_names)
-
-                self.assertEqual(proto.version, str(source.version().value))
-                self.assertEqual(proto.serial_number,
-                                 str(source.serial_number().human_readable()
-                                     .upper().replace(':', '')))
-
-                self.assertEqual(time.gmtime(proto.validity.not_before / 1000),
-                                 source.not_before())
-                self.assertEqual(time.gmtime(proto.validity.not_after / 1000),
-                                 source.not_after())
-
-                observations_tuples = [(unicode(obs.description),
-                                        unicode(obs.reason) if obs.reason else u'',
-                                        obs.details_to_proto())
-                                       for obs in observations]
-                proto_obs = [(obs.description, obs.reason, obs.details)
-                             for obs in proto.observations]
-                self.assertItemsEqual(proto_obs, observations_tuples)
-
-                self.assertEqual(proto.tbs_signature.algorithm_id,
-                                 source.signature()["algorithm"].long_name)
-                self.assertEqual(proto.cert_signature.algorithm_id,
-                                 source.signature_algorithm()["algorithm"].long_name)
-                self.assertEqual(proto.tbs_signature.algorithm_id,
-                                 proto.cert_signature.algorithm_id)
-
-                if source.signature()["parameters"]:
-                    self.assertEqual(proto.tbs_signature.parameters,
-                                     source.signature()["parameters"])
-                else:
-                    self.assertFalse(proto.tbs_signature.HasField('parameters'))
-
-                if source.signature_algorithm()["parameters"]:
-                    self.assertEqual(proto.cert_signature.parameters,
-                                     source.signature_algorithm()["parameters"])
-                else:
-                    self.assertFalse(proto.cert_signature.HasField('parameters'))
-
-                self.assertEqual(proto.tbs_signature.parameters,
-                                 proto.cert_signature.parameters)
-
-                self.assertEqual(proto.basic_constraint_ca, expect_ca_true)
+    def test_from_cert_with_ca_cert(self):
+        # Test in a non-UTC timezone, to detect timezone issues
+        with time_utils.timezone("America/Los_Angeles"):
+            self.assert_description_matches_source(CA_CERT, True)
 
     def test_process_value(self):
         self.assertEqual(["London"], cert_desc.process_name("London"))

--- a/python/ct/client/db/cert_desc_test.py
+++ b/python/ct/client/db/cert_desc_test.py
@@ -91,19 +91,37 @@ class CertificateDescriptionTest(unittest.TestCase):
         self.assertEqual(proto.basic_constraint_ca, expect_ca_true)
 
     def test_from_cert(self):
+        cert = CERT
+        is_ca_cert = False
+
+        with time_utils.timezone("UTC"):
+            self.assert_description_matches_source(cert, is_ca_cert)
+
         # Test in a non-UTC timezone, to detect timezone issues
         with time_utils.timezone("America/Los_Angeles"):
-            self.assert_description_matches_source(CERT, False)
+            self.assert_description_matches_source(cert, is_ca_cert)
 
     def test_from_cert_with_dsa_sha256_cert(self):
+        cert = DSA_SHA256_CERT
+        is_ca_cert = False
+
+        with time_utils.timezone("UTC"):
+            self.assert_description_matches_source(cert, is_ca_cert)
+
         # Test in a non-UTC timezone, to detect timezone issues
         with time_utils.timezone("America/Los_Angeles"):
-            self.assert_description_matches_source(DSA_SHA256_CERT, False)
+            self.assert_description_matches_source(cert, is_ca_cert)
 
     def test_from_cert_with_ca_cert(self):
+        cert = CA_CERT
+        is_ca_cert = True
+
+        with time_utils.timezone("UTC"):
+            self.assert_description_matches_source(cert, is_ca_cert)
+
         # Test in a non-UTC timezone, to detect timezone issues
         with time_utils.timezone("America/Los_Angeles"):
-            self.assert_description_matches_source(CA_CERT, True)
+            self.assert_description_matches_source(cert, is_ca_cert)
 
     def test_process_value(self):
         self.assertEqual(["London"], cert_desc.process_name("London"))

--- a/python/ct/client/db/cert_desc_test.py
+++ b/python/ct/client/db/cert_desc_test.py
@@ -6,6 +6,7 @@ from ct.client.db import cert_desc
 from ct.crypto import cert
 from ct.cert_analysis import all_checks
 from ct.cert_analysis import observation
+from ct.test import time_utils
 
 CERT = cert.Certificate.from_der_file("ct/crypto/testdata/google_cert.der")
 CA_CERT = cert.Certificate.from_pem_file("ct/crypto/testdata/verisign_intermediate.pem")
@@ -13,81 +14,86 @@ DSA_SHA256_CERT = cert.Certificate.from_der_file("ct/crypto/testdata/dsa_with_sh
 
 class CertificateDescriptionTest(unittest.TestCase):
     def test_from_cert(self):
-        for test_case in [(CERT, False), (DSA_SHA256_CERT, False), (CA_CERT, True)]:
-            (source, expect_ca_true) = test_case
+        # Test in a non-UTC timezone, to detect timezone issues
+        with time_utils.timezone("America/Los_Angeles"):
+            for test_case in [(CERT, False), (DSA_SHA256_CERT, False), (CA_CERT, True)]:
+                (source, expect_ca_true) = test_case
 
-            observations = []
-            for check in all_checks.ALL_CHECKS:
-                observations += check.check(source) or []
-            observations.append(observation.Observation(
-                "AE", u'ćę©ß→æ→ćąßę-ß©ąńśþa©ęńć←', (u'əę”ąłęµ', u'…łą↓ð→↓ś→ę')))
-            proto = cert_desc.from_cert(source, observations)
-            self.assertEqual(proto.der, source.to_der())
+                observations = []
+                for check in all_checks.ALL_CHECKS:
+                    observations += check.check(source) or []
+                observations.append(observation.Observation(
+                    "AE", u'ćę©ß→æ→ćąßę-ß©ąńśþa©ęńć←', (u'əę”ąłęµ', u'…łą↓ð→↓ś→ę')))
 
-            subject = [(att.type, att.value) for att in proto.subject]
-            cert_subject = [(type_.short_name,
-                         cert_desc.to_unicode('.'.join(
-                                 cert_desc.process_name(value.human_readable()))))
-                        for type_, value in source.subject()]
-            self.assertItemsEqual(cert_subject, subject)
+                proto = cert_desc.from_cert(source, observations)
 
-            issuer = [(att.type, att.value) for att in proto.issuer]
-            cert_issuer = [(type_.short_name,
-                         cert_desc.to_unicode('.'.join(
-                                 cert_desc.process_name(value.human_readable()))))
-                        for type_, value in source.issuer()]
-            self.assertItemsEqual(cert_issuer, issuer)
+                self.assertEqual(proto.der, source.to_der())
 
-            subject_alternative_names = [(att.type, att.value)
-                                         for att in proto.subject_alternative_names]
-            cert_subject_alternative_names = [(san.component_key(),
-                                               cert_desc.to_unicode('.'.join(
-                                                cert_desc.process_name(
-                                         san.component_value().human_readable()))))
-                        for san in source.subject_alternative_names()]
-            self.assertItemsEqual(cert_subject_alternative_names,
-                                  subject_alternative_names)
+                subject = [(att.type, att.value) for att in proto.subject]
+                cert_subject = [(type_.short_name,
+                             cert_desc.to_unicode('.'.join(
+                                     cert_desc.process_name(value.human_readable()))))
+                            for type_, value in source.subject()]
+                self.assertItemsEqual(cert_subject, subject)
 
-            self.assertEqual(proto.version, str(source.version().value))
-            self.assertEqual(proto.serial_number,
-                             str(source.serial_number().human_readable()
-                                 .upper().replace(':', '')))
-            self.assertEqual(time.gmtime(proto.validity.not_before / 1000),
-                             source.not_before())
-            self.assertEqual(time.gmtime(proto.validity.not_after / 1000),
-                             source.not_after())
+                issuer = [(att.type, att.value) for att in proto.issuer]
+                cert_issuer = [(type_.short_name,
+                             cert_desc.to_unicode('.'.join(
+                                     cert_desc.process_name(value.human_readable()))))
+                            for type_, value in source.issuer()]
+                self.assertItemsEqual(cert_issuer, issuer)
 
-            observations_tuples = [(unicode(obs.description),
-                                    unicode(obs.reason) if obs.reason else u'',
-                                    obs.details_to_proto())
-                                   for obs in observations]
-            proto_obs = [(obs.description, obs.reason, obs.details)
-                         for obs in proto.observations]
-            self.assertItemsEqual(proto_obs, observations_tuples)
+                subject_alternative_names = [(att.type, att.value)
+                                             for att in proto.subject_alternative_names]
+                cert_subject_alternative_names = [(san.component_key(),
+                                                   cert_desc.to_unicode('.'.join(
+                                                    cert_desc.process_name(
+                                             san.component_value().human_readable()))))
+                            for san in source.subject_alternative_names()]
+                self.assertItemsEqual(cert_subject_alternative_names,
+                                      subject_alternative_names)
 
-            self.assertEqual(proto.tbs_signature.algorithm_id,
-                             source.signature()["algorithm"].long_name)
-            self.assertEqual(proto.cert_signature.algorithm_id,
-                             source.signature_algorithm()["algorithm"].long_name)
-            self.assertEqual(proto.tbs_signature.algorithm_id,
-                             proto.cert_signature.algorithm_id)
+                self.assertEqual(proto.version, str(source.version().value))
+                self.assertEqual(proto.serial_number,
+                                 str(source.serial_number().human_readable()
+                                     .upper().replace(':', '')))
 
-            if source.signature()["parameters"]:
+                self.assertEqual(time.gmtime(proto.validity.not_before / 1000),
+                                 source.not_before())
+                self.assertEqual(time.gmtime(proto.validity.not_after / 1000),
+                                 source.not_after())
+
+                observations_tuples = [(unicode(obs.description),
+                                        unicode(obs.reason) if obs.reason else u'',
+                                        obs.details_to_proto())
+                                       for obs in observations]
+                proto_obs = [(obs.description, obs.reason, obs.details)
+                             for obs in proto.observations]
+                self.assertItemsEqual(proto_obs, observations_tuples)
+
+                self.assertEqual(proto.tbs_signature.algorithm_id,
+                                 source.signature()["algorithm"].long_name)
+                self.assertEqual(proto.cert_signature.algorithm_id,
+                                 source.signature_algorithm()["algorithm"].long_name)
+                self.assertEqual(proto.tbs_signature.algorithm_id,
+                                 proto.cert_signature.algorithm_id)
+
+                if source.signature()["parameters"]:
+                    self.assertEqual(proto.tbs_signature.parameters,
+                                     source.signature()["parameters"])
+                else:
+                    self.assertFalse(proto.tbs_signature.HasField('parameters'))
+
+                if source.signature_algorithm()["parameters"]:
+                    self.assertEqual(proto.cert_signature.parameters,
+                                     source.signature_algorithm()["parameters"])
+                else:
+                    self.assertFalse(proto.cert_signature.HasField('parameters'))
+
                 self.assertEqual(proto.tbs_signature.parameters,
-                                 source.signature()["parameters"])
-            else:
-                self.assertFalse(proto.tbs_signature.HasField('parameters'))
+                                 proto.cert_signature.parameters)
 
-            if source.signature_algorithm()["parameters"]:
-                self.assertEqual(proto.cert_signature.parameters,
-                                 source.signature_algorithm()["parameters"])
-            else:
-                self.assertFalse(proto.cert_signature.HasField('parameters'))
-
-            self.assertEqual(proto.tbs_signature.parameters,
-                             proto.cert_signature.parameters)
-
-            self.assertEqual(proto.basic_constraint_ca, expect_ca_true)
+                self.assertEqual(proto.basic_constraint_ca, expect_ca_true)
 
     def test_process_value(self):
         self.assertEqual(["London"], cert_desc.process_name("London"))

--- a/python/ct/test/__init__.py
+++ b/python/ct/test/__init__.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python

--- a/python/ct/test/time_utils.py
+++ b/python/ct/test/time_utils.py
@@ -1,0 +1,27 @@
+"""Utilities for testing time-sensitive code."""
+
+import contextlib
+import os
+import time
+
+
+def get_timezone_environ():
+    return os.environ.get("TZ", '')
+
+def set_timezone_environ(new_timezone):
+    os.environ["TZ"] = new_timezone
+    time.tzset()
+
+@contextlib.contextmanager
+def timezone(temp_tz):
+    """Sets the timezone, yields, then resets the timezone.
+
+    Args:
+        temp_tz: See https://docs.python.org/2/library/time.html#time.tzset
+    """
+    original_tz = get_timezone_environ()
+    set_timezone_environ(temp_tz)
+    try:
+        yield
+    finally:
+        set_timezone_environ(original_tz)


### PR DESCRIPTION
Fixes #765. This also modifies a test to use a non-UTC timezone, which then fails without the
included fix.