### PR TITLE
Catch manifests up with latest GCE/Kubernetes requirements.

### DIFF
--- a/cloud/google/etcd_container.yaml
+++ b/cloud/google/etcd_container.yaml
@@ -1,5 +1,7 @@
 version: v1
 kind: Pod
+metadata:
+  name: "@@CONTAINER_HOST@@"
 spec:
   containers:
     - name: etcd
@@ -29,7 +31,7 @@ spec:
       image: google/cadvisor:latest
       imagePullPolicy: Always
       ports:
-        - name: cadvisor-monitor
+        - name: cadvisor-mon
           containerPort: 8080
           hostPort: 8080
           protocol: TCP

--- a/cloud/google/log_container.yaml
+++ b/cloud/google/log_container.yaml
@@ -1,5 +1,7 @@
 version: v1
 kind: Pod
+metadata:
+  name: "@@CONTAINER_HOST@@"
 spec:
   containers:
     - name: super-duper
@@ -24,11 +26,11 @@ spec:
       volumeMounts:
         - name: logdata
           mountPath: /mnt/ctlog
-    - name: cadvisor-monitor
+    - name: cadvisor-mon
       image: google/cadvisor:latest
       imagePullPolicy: Always
       ports:
-        - name: cadvisor-monitor
+        - name: cadvisor-mon
           containerPort: 8080
           hostPort: 8080
           protocol: TCP

--- a/cloud/google/mirror_container.yaml
+++ b/cloud/google/mirror_container.yaml
@@ -1,5 +1,7 @@
 version: v1
 kind: Pod
+metadata:
+  name: "@@CONTAINER_HOST@@"
 spec:
   containers:
     - name: super-mirror
@@ -32,7 +34,7 @@ spec:
       image: google/cadvisor:latest
       imagePullPolicy: Always
       ports:
-        - name: cadvisor-monitor
+        - name: cadvisor-mon
           containerPort: 8080
           hostPort: 8080
           protocol: TCP


### PR DESCRIPTION
+ Add a `metadata.name` field
+ Shorten port names to 15 chars or less.