### PR TITLE
Store SHA256 of issuing cert's public key in X509Description proto.

### DIFF
--- a/python/ct/client/reporter.py
+++ b/python/ct/client/reporter.py
@@ -68,6 +68,13 @@ def _scan_der_cert(der_certs, checks):
 
             if der_chain:
                 try:
+                    issuer = cert.Certificate(der_chain[0], strict_der=False)
+                except error.Error:
+                     pass
+                else:
+                    desc.issuer_pk_sha256_hash = issuer.key_hash(hashfunc="sha256")
+
+                try:
                     root = cert.Certificate(der_chain[-1], strict_der=False)
                 except error.Error:
                     pass

--- a/python/ct/client/reporter_test.py
+++ b/python/ct/client/reporter_test.py
@@ -137,7 +137,11 @@ class CertificateReportTest(base_check_test.BaseCheckTest):
         self.assertEquals(certs[0].entry_type, client_pb2.X509_ENTRY)
 
     def test_issuer_public_key_populated_from_chain(self):
+        # Verify the test data is what is expected for this unit test.
         self.assertEqual(3, len(CHAIN_DERS))
+        self.assertEqual(
+            cert.Certificate(CHAIN_DERS[1]).key_hash(hashfunc="sha256").encode('hex'),
+            'b6b95432abae57fe020cb2b74f4f9f9173c8c708afc9e732ace23279047c6d05')
 
         report = self.CertificateReportBase([])
         report.scan_der_certs([(0, CHAIN_DERS[0], CHAIN_DERS[1:],
@@ -147,11 +151,8 @@ class CertificateReportTest(base_check_test.BaseCheckTest):
 
         certs = report.certs()
         self.assertEqual(len(certs), 1)
-
-        issuer_cert = cert.Certificate(CHAIN_DERS[1])
-        issuer_pk_sha256 = issuer_cert.key_hash(hashfunc="sha256")
-
-        self.assertEqual(certs[0].issuer_pk_sha256_hash, issuer_pk_sha256)
+        self.assertEqual(certs[0].issuer_pk_sha256_hash.encode('hex'),
+            'b6b95432abae57fe020cb2b74f4f9f9173c8c708afc9e732ace23279047c6d05')
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/ct/client/reporter_test.py
+++ b/python/ct/client/reporter_test.py
@@ -136,5 +136,22 @@ class CertificateReportTest(base_check_test.BaseCheckTest):
         self.assertEqual(len(certs), 1)
         self.assertEquals(certs[0].entry_type, client_pb2.X509_ENTRY)
 
+    def test_issuer_public_key_populated_from_chain(self):
+        self.assertEqual(3, len(CHAIN_DERS))
+
+        report = self.CertificateReportBase([])
+        report.scan_der_certs([(0, CHAIN_DERS[0], CHAIN_DERS[1:],
+                                client_pb2.X509_ENTRY)])
+        result = report.report()
+        self.assertEqual(len(sum(result.values(), [])), 0)
+
+        certs = report.certs()
+        self.assertEqual(len(certs), 1)
+
+        issuer_cert = cert.Certificate(CHAIN_DERS[1])
+        issuer_pk_sha256 = issuer_cert.key_hash(hashfunc="sha256")
+
+        self.assertEqual(certs[0].issuer_pk_sha256_hash, issuer_pk_sha256)
+
 if __name__ == '__main__':
     unittest.main()

--- a/python/ct/proto/certificate.proto
+++ b/python/ct/proto/certificate.proto
@@ -66,4 +66,7 @@ message X509Description {
 
   // True if this cert has the Basic Constraint CA=TRUE.
   optional bool basic_constraint_ca = 14;
+
+  // SHA256 hash of issuer's public key.
+  optional bytes issuer_pk_sha256_hash = 15;
 }


### PR DESCRIPTION
Preparatory work for being able to group certs by issuer's PK in the CT Monitor.