### PR TITLE
Avoid trying to read flags when a module is imported

### DIFF
--- a/python/ct/cert_analysis/tld_list.py
+++ b/python/ct/cert_analysis/tld_list.py
@@ -13,7 +13,10 @@ TLD_LIST_ADDR = "https://publicsuffix.org/list/effective_tld_names.dat"
 class TLDList(object):
     """Contains list of top-level domains"""
     NOT_ADDRESS_REGEX = re.compile('[^a-z0-9\-.*]')
-    def __init__(self, tld_dir=FLAGS.tld_list_dir, tld_file_name="tld_list"):
+    def __init__(self, tld_dir=None, tld_file_name='tld_list'):
+        if tld_dir is None:
+            tld_dir = FLAGS.tld_list_dir
+
         tld_file = '/'.join((tld_dir, tld_file_name))
         try:
             with open(tld_file, 'r') as f:

--- a/python/ct/client/reporter.py
+++ b/python/ct/client/reporter.py
@@ -104,11 +104,10 @@ class CertificateReport(object):
     __metaclass__ = abc.ABCMeta
 
     def __init__(self, checks=all_checks.ALL_CHECKS,
-                 pool_size=FLAGS.reporter_workers,
-                 queue_size=FLAGS.reporter_queue_size):
+                 queue_size=None):
         self.reset()
         self.checks = checks
-        self._jobs = Queue(queue_size)
+        self._jobs = Queue(queue_size or FLAGS.reporter_queue_size)
         self._pool = None
         self._writing_handler = None
 


### PR DESCRIPTION
Using a command-line flag as the default value for a parameter will not work, as these values are evaluated when the module is imported. This is almost always prior to the flags being parsed.

Also removes one such parameter that was not being used (pool_size).