### PR TITLE
Improve Portability, Specifically for OSX

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -678,6 +678,8 @@ cpp_util_masterelection_test_SOURCES = \
 	cpp/util/periodic_closure.cc \
 	cpp/util/protobuf_util.cc \
 	cpp/util/thread_pool.cc
+EXTRA_cpp_util_masterelection_test_DEPENDENCIES = \
+	test/testdata/urlfetcher_test_certs/localhost.pem
 
 cpp_merkletree_merkle_tree_test_LDADD = \
 	cpp/libcore.a \

--- a/Makefile.am
+++ b/Makefile.am
@@ -644,6 +644,8 @@ cpp_util_fake_etcd_test_SOURCES = \
 	cpp/util/json_wrapper.cc \
 	cpp/util/libevent_wrapper.cc \
 	cpp/util/thread_pool.cc
+EXTRA_cpp_util_fake_etcd_test_DEPENDENCIES = \
+	test/testdata/urlfetcher_test_certs/localhost.pem
 
 cpp_util_json_wrapper_test_LDADD = \
 	cpp/libtest.a \

--- a/configure.ac
+++ b/configure.ac
@@ -109,6 +109,21 @@ AC_DEFUN([CT_CHECK_TLS],
      fi
    fi])
 
+AC_DEFUN([CT_CHECK_INADDR_LOOPBACK],
+  [AC_CACHE_CHECK(
+     [whether the platform defines INADDR_LOOPBACK],
+     [ct_cv_inaddr_loopback],
+     [AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM([ #include <netinet/in.h>
+           static int var = INADDR_LOOPBACK;], [return var;])],
+        [ct_cv_inaddr_loopback=yes],
+        [ct_cv_inaddr_loopback=no])])
+   if test $ct_cv_inaddr_loopback = yes; then
+     AC_DEFINE([HAVE_INADDR_LOOPBACK], [1],
+               [Define to 1 if the platform defines INADDR_LOOPBACK constant
+                in <netinet/in.h>.])
+   fi])
+
 AC_MSG_CHECKING([checking for gflags library])
 LIBS="-lgflags $LIBS"
 AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <gflags/gflags.h>], [google::ParseCommandLineFlags(NULL, NULL, true)])], [have_gflags=yes], [have_gflags=no])
@@ -173,6 +188,7 @@ AC_TYPE_UINT64_T
 AC_TYPE_UINT8_T
 
 CT_CHECK_TLS
+CT_CHECK_INADDR_LOOPBACK
 
 AC_MSG_CHECKING([whether pthread_t is a pointer])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([

--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,43 @@ AC_SEARCH_LIBS([SSL_CTX_new], [ssl],, [missing_openssl=1], [$save_LIBS])
 AS_IF([test -n "$missing_openssl"],
       [AC_MSG_ERROR([could not find the OpenSSL libraries])])
 
+dnl Checks for thread-local storage support.
+dnl
+dnl Taken from the openvswitch config code (Apache 2.0 License)
+dnl with some local modifications. Does not include <threads.h>
+dnl as this does not currently exist on GCC.
+dnl Checks whether the compiler and linker support the C11
+dnl thread_local macro from <threads.h>, and if so defines
+dnl HAVE_THREAD_LOCAL.  If not, checks whether the compiler and linker
+dnl support the GCC __thread extension, and if so defines
+dnl HAVE___THREAD.
+AC_DEFUN([CT_CHECK_TLS],
+  [AC_CACHE_CHECK(
+     [whether $CC has <threads.h> that supports thread_local],
+     [ct_cv_thread_local],
+     [AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM([ static thread_local int var;], [return var;])],
+        [ct_cv_thread_local=yes],
+        [ct_cv_thread_local=no])])
+   if test $ct_cv_thread_local = yes; then
+     AC_DEFINE([HAVE_THREAD_LOCAL], [1],
+               [Define to 1 if the C compiler and linker supports the C11
+                thread_local macro defined in <threads.h>.])
+   else
+     AC_CACHE_CHECK(
+       [whether $CC supports __thread],
+       [ct_cv___thread],
+       [AC_LINK_IFELSE(
+          [AC_LANG_PROGRAM([static __thread int var;], [return var;])],
+          [ct_cv___thread=yes],
+          [ct_cv___thread=no])])
+     if test $ct_cv___thread = yes; then
+       AC_DEFINE([HAVE___THREAD], [1],
+                 [Define to 1 if the C compiler and linker supports the
+                  GCC __thread extensions.])
+     fi
+   fi])
+
 AC_MSG_CHECKING([checking for gflags library])
 LIBS="-lgflags $LIBS"
 AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <gflags/gflags.h>], [google::ParseCommandLineFlags(NULL, NULL, true)])], [have_gflags=yes], [have_gflags=no])
@@ -134,6 +171,8 @@ AC_TYPE_UINT16_T
 AC_TYPE_UINT32_T
 AC_TYPE_UINT64_T
 AC_TYPE_UINT8_T
+
+CT_CHECK_TLS
 
 AC_MSG_CHECKING([whether pthread_t is a pointer])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([

--- a/configure.ac
+++ b/configure.ac
@@ -72,58 +72,6 @@ AC_SEARCH_LIBS([SSL_CTX_new], [ssl],, [missing_openssl=1], [$save_LIBS])
 AS_IF([test -n "$missing_openssl"],
       [AC_MSG_ERROR([could not find the OpenSSL libraries])])
 
-dnl Checks for thread-local storage support.
-dnl
-dnl Taken from the openvswitch config code (Apache 2.0 License)
-dnl with some local modifications. Does not include <threads.h>
-dnl as this does not currently exist on GCC.
-dnl Checks whether the compiler and linker support the C11
-dnl thread_local macro from <threads.h>, and if so defines
-dnl HAVE_THREAD_LOCAL.  If not, checks whether the compiler and linker
-dnl support the GCC __thread extension, and if so defines
-dnl HAVE___THREAD.
-AC_DEFUN([CT_CHECK_TLS],
-  [AC_CACHE_CHECK(
-     [whether $CC has <threads.h> that supports thread_local],
-     [ct_cv_thread_local],
-     [AC_LINK_IFELSE(
-        [AC_LANG_PROGRAM([ static thread_local int var;], [return var;])],
-        [ct_cv_thread_local=yes],
-        [ct_cv_thread_local=no])])
-   if test $ct_cv_thread_local = yes; then
-     AC_DEFINE([HAVE_THREAD_LOCAL], [1],
-               [Define to 1 if the C compiler and linker supports the C11
-                thread_local macro defined in <threads.h>.])
-   else
-     AC_CACHE_CHECK(
-       [whether $CC supports __thread],
-       [ct_cv___thread],
-       [AC_LINK_IFELSE(
-          [AC_LANG_PROGRAM([static __thread int var;], [return var;])],
-          [ct_cv___thread=yes],
-          [ct_cv___thread=no])])
-     if test $ct_cv___thread = yes; then
-       AC_DEFINE([HAVE___THREAD], [1],
-                 [Define to 1 if the C compiler and linker supports the
-                  GCC __thread extensions.])
-     fi
-   fi])
-
-AC_DEFUN([CT_CHECK_INADDR_LOOPBACK],
-  [AC_CACHE_CHECK(
-     [whether the platform defines INADDR_LOOPBACK],
-     [ct_cv_inaddr_loopback],
-     [AC_LINK_IFELSE(
-        [AC_LANG_PROGRAM([ #include <netinet/in.h>
-           static int var = INADDR_LOOPBACK;], [return var;])],
-        [ct_cv_inaddr_loopback=yes],
-        [ct_cv_inaddr_loopback=no])])
-   if test $ct_cv_inaddr_loopback = yes; then
-     AC_DEFINE([HAVE_INADDR_LOOPBACK], [1],
-               [Define to 1 if the platform defines INADDR_LOOPBACK constant
-                in <netinet/in.h>.])
-   fi])
-
 AC_MSG_CHECKING([checking for gflags library])
 LIBS="-lgflags $LIBS"
 AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <gflags/gflags.h>], [google::ParseCommandLineFlags(NULL, NULL, true)])], [have_gflags=yes], [have_gflags=no])
@@ -188,7 +136,7 @@ AC_TYPE_UINT64_T
 AC_TYPE_UINT8_T
 
 CT_CHECK_TLS
-CT_CHECK_INADDR_LOOPBACK
+AC_CHECK_DECLS([INADDR_LOOPBACK], [], [], [#include <netinet/in.h>])
 
 AC_MSG_CHECKING([whether pthread_t is a pointer])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([

--- a/cpp/log/database_test.cc
+++ b/cpp/log/database_test.cc
@@ -47,7 +47,12 @@ typedef testing::Types<FileDB<cert_trans::LoggedCertificate>,
 
 typedef Database<cert_trans::LoggedCertificate> DB;
 
+template <class T>
+class DBTestDeathTest : public DBTest<T> {
+};
+
 TYPED_TEST_CASE(DBTest, Databases);
+TYPED_TEST_CASE(DBTestDeathTest, Databases);
 
 
 TYPED_TEST(DBTest, CreateSequenced) {
@@ -362,14 +367,14 @@ TYPED_TEST(DBTest, NoNodeIdSet) {
 }
 
 
-TYPED_TEST(DBTest, CannotOverwriteNodeIdDeathTest) {
+TYPED_TEST(DBTestDeathTest, CannotOverwriteNodeId) {
   const string kNodeId("some_node_id");
   this->db()->InitializeNode(kNodeId);
   EXPECT_DEATH(this->db()->InitializeNode("something_else"), kNodeId);
 }
 
 
-TYPED_TEST(DBTest, CannotHaveEmptyNodeIdDeathTest) {
+TYPED_TEST(DBTestDeathTest, CannotHaveEmptyNodeId) {
   EXPECT_DEATH(this->db()->InitializeNode(""), "empty");
 }
 

--- a/cpp/log/database_test.cc
+++ b/cpp/log/database_test.cc
@@ -362,14 +362,14 @@ TYPED_TEST(DBTest, NoNodeIdSet) {
 }
 
 
-TYPED_TEST(DBTest, CannotOverwriteNodeId) {
+TYPED_TEST(DBTest, CannotOverwriteNodeIdDeathTest) {
   const string kNodeId("some_node_id");
   this->db()->InitializeNode(kNodeId);
   EXPECT_DEATH(this->db()->InitializeNode("something_else"), kNodeId);
 }
 
 
-TYPED_TEST(DBTest, CannotHaveEmptyNodeId) {
+TYPED_TEST(DBTest, CannotHaveEmptyNodeIdDeathTest) {
   EXPECT_DEATH(this->db()->InitializeNode(""), "empty");
 }
 

--- a/cpp/log/etcd_consistent_store_test.cc
+++ b/cpp/log/etcd_consistent_store_test.cc
@@ -497,8 +497,7 @@ TEST_F(EtcdConsistentStoreDeathTest,
                "sequence_number\\(\\) < mapping");
 }
 
-TEST_F(
-    EtcdConsistentStoreDeathTest,
+TEST_F(EtcdConsistentStoreDeathTest,
     TestUpdateSequenceMappingBarfsMappingNonContiguousToServingTreeDeathTest) {
   SignedTreeHead sth;
   sth.set_timestamp(123);

--- a/cpp/log/etcd_consistent_store_test.cc
+++ b/cpp/log/etcd_consistent_store_test.cc
@@ -290,7 +290,7 @@ TEST_F(EtcdConsistentStoreTest, TestSetServingSTHWontOverwriteWithOlder) {
 }
 
 TEST_F(EtcdConsistentStoreDeathTest,
-       TestSetServingSTHChecksInconsistentSizeDeathTest) {
+       TestSetServingSTHChecksInconsistentSize) {
   ct::SignedTreeHead sth;
   sth.set_timestamp(234);
   sth.set_tree_size(10);
@@ -338,7 +338,7 @@ TEST_F(EtcdConsistentStoreTest,
 
 
 TEST_F(EtcdConsistentStoreDeathTest,
-       TestAddPendingEntryForExistingNonIdenticalEntryDeathTest) {
+       TestAddPendingEntryForExistingNonIdenticalEntry) {
   LoggedCertificate cert(DefaultCert());
   LoggedCertificate other_cert(MakeCert(2342, "something else"));
 
@@ -353,7 +353,7 @@ TEST_F(EtcdConsistentStoreDeathTest,
 
 
 TEST_F(EtcdConsistentStoreDeathTest,
-       TestAddPendingEntryDoesNotAcceptSequencedEntryDeathTest) {
+       TestAddPendingEntryDoesNotAcceptSequencedEntry) {
   LoggedCertificate cert(DefaultCert());
   cert.set_sequence_number(76);
   EXPECT_DEATH(store_->AddPendingEntry(&cert),
@@ -402,7 +402,7 @@ TEST_F(EtcdConsistentStoreTest, TestGetPendingEntries) {
 
 
 TEST_F(EtcdConsistentStoreDeathTest,
-       TestGetPendingEntriesBarfsWithSequencedEntryDeathTest) {
+       TestGetPendingEntriesBarfsWithSequencedEntry) {
   const string kPath(string(kRoot) + "/entries/");
   LoggedCertificate one(MakeSequencedCert(123, "one", 666));
   InsertEntry(kPath + "one", one);
@@ -442,7 +442,7 @@ TEST_F(EtcdConsistentStoreTest,
 
 
 TEST_F(EtcdConsistentStoreDeathTest,
-       TestGetSequenceMappingBarfsOnGapsAboveTreeSizeDeathTest) {
+       TestGetSequenceMappingBarfsOnGapsAboveTreeSize) {
   SignedTreeHead sth;
   sth.set_tree_size(0);
   store_->SetServingSTH(sth);
@@ -482,7 +482,7 @@ TEST_F(EtcdConsistentStoreTest, TestUpdateSequenceMapping) {
 
 
 TEST_F(EtcdConsistentStoreDeathTest,
-       TestUpdateSequenceMappingBarfsWithOutOfOrderSequenceNumberDeathTest) {
+       TestUpdateSequenceMappingBarfsWithOutOfOrderSequenceNumber) {
   EntryHandle<SequenceMapping> mapping;
   Status status(store_->GetSequenceMapping(&mapping));
   EXPECT_EQ(Status::OK, status);
@@ -498,7 +498,7 @@ TEST_F(EtcdConsistentStoreDeathTest,
 }
 
 TEST_F(EtcdConsistentStoreDeathTest,
-    TestUpdateSequenceMappingBarfsMappingNonContiguousToServingTreeDeathTest) {
+    TestUpdateSequenceMappingBarfsMappingNonContiguousToServingTree) {
   SignedTreeHead sth;
   sth.set_timestamp(123);
   sth.set_tree_size(1000);

--- a/cpp/log/etcd_consistent_store_test.cc
+++ b/cpp/log/etcd_consistent_store_test.cc
@@ -289,8 +289,8 @@ TEST_F(EtcdConsistentStoreTest, TestSetServingSTHWontOverwriteWithOlder) {
   EXPECT_EQ(util::error::OUT_OF_RANGE, status.CanonicalCode()) << status;
 }
 
-
-TEST_F(EtcdConsistentStoreDeathTest, TestSetServingSTHChecksInconsistentSize) {
+TEST_F(EtcdConsistentStoreDeathTest,
+       TestSetServingSTHChecksInconsistentSizeDeathTest) {
   ct::SignedTreeHead sth;
   sth.set_timestamp(234);
   sth.set_tree_size(10);
@@ -338,7 +338,7 @@ TEST_F(EtcdConsistentStoreTest,
 
 
 TEST_F(EtcdConsistentStoreDeathTest,
-       TestAddPendingEntryForExistingNonIdenticalEntry) {
+       TestAddPendingEntryForExistingNonIdenticalEntryDeathTest) {
   LoggedCertificate cert(DefaultCert());
   LoggedCertificate other_cert(MakeCert(2342, "something else"));
 
@@ -353,7 +353,7 @@ TEST_F(EtcdConsistentStoreDeathTest,
 
 
 TEST_F(EtcdConsistentStoreDeathTest,
-       TestAddPendingEntryDoesNotAcceptSequencedEntry) {
+       TestAddPendingEntryDoesNotAcceptSequencedEntryDeathTest) {
   LoggedCertificate cert(DefaultCert());
   cert.set_sequence_number(76);
   EXPECT_DEATH(store_->AddPendingEntry(&cert),
@@ -402,7 +402,7 @@ TEST_F(EtcdConsistentStoreTest, TestGetPendingEntries) {
 
 
 TEST_F(EtcdConsistentStoreDeathTest,
-       TestGetPendingEntriesBarfsWithSequencedEntry) {
+       TestGetPendingEntriesBarfsWithSequencedEntryDeathTest) {
   const string kPath(string(kRoot) + "/entries/");
   LoggedCertificate one(MakeSequencedCert(123, "one", 666));
   InsertEntry(kPath + "one", one);
@@ -442,7 +442,7 @@ TEST_F(EtcdConsistentStoreTest,
 
 
 TEST_F(EtcdConsistentStoreDeathTest,
-       TestGetSequenceMappingBarfsOnGapsAboveTreeSize) {
+       TestGetSequenceMappingBarfsOnGapsAboveTreeSizeDeathTest) {
   SignedTreeHead sth;
   sth.set_tree_size(0);
   store_->SetServingSTH(sth);
@@ -482,7 +482,7 @@ TEST_F(EtcdConsistentStoreTest, TestUpdateSequenceMapping) {
 
 
 TEST_F(EtcdConsistentStoreDeathTest,
-       TestUpdateSequenceMappingBarfsWithOutOfOrderSequenceNumber) {
+       TestUpdateSequenceMappingBarfsWithOutOfOrderSequenceNumberDeathTest) {
   EntryHandle<SequenceMapping> mapping;
   Status status(store_->GetSequenceMapping(&mapping));
   EXPECT_EQ(Status::OK, status);
@@ -497,9 +497,9 @@ TEST_F(EtcdConsistentStoreDeathTest,
                "sequence_number\\(\\) < mapping");
 }
 
-
-TEST_F(EtcdConsistentStoreDeathTest,
-       TestUpdateSequenceMappingBarfsWithMappingNonContiguousToServingTree) {
+TEST_F(
+    EtcdConsistentStoreDeathTest,
+    TestUpdateSequenceMappingBarfsMappingNonContiguousToServingTreeDeathTest) {
   SignedTreeHead sth;
   sth.set_timestamp(123);
   sth.set_tree_size(1000);

--- a/cpp/merkletree/compact_merkle_tree.cc
+++ b/cpp/merkletree/compact_merkle_tree.cc
@@ -21,7 +21,7 @@ CompactMerkleTree::CompactMerkleTree(SerialHasher* hasher)
 
 CompactMerkleTree::CompactMerkleTree(MerkleTree& model, SerialHasher* hasher)
     : MerkleTreeInterface(),
-      tree_(std::max(0L, int64_t(model.LevelCount()) - 1)),
+      tree_(std::max(int64_t(0), int64_t(model.LevelCount()) - 1)),
       treehasher_(hasher),
       leaf_count_(model.LeafCount()),
       leaves_processed_(0),

--- a/cpp/net/url_fetcher_test.cc
+++ b/cpp/net/url_fetcher_test.cc
@@ -325,9 +325,13 @@ int main(int argc, char** argv) {
   struct sockaddr_in hang_addr;
   bzero((char*)&hang_addr, sizeof(hang_addr));
   hang_addr.sin_family = AF_INET;
-  // Using LOOPBACK avoids triggering the firewall on some platforms. All
-  // our connections are to localhost
+  // Prefer to use INADDR_LOOPBACK if available as it avoids the firewall
+  // triggering on some platforms if we bind a non-local address.
+#ifdef HAVE_INADDR_LOOPBACK
   hang_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+#else
+  hang_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+#endif
   hang_addr.sin_port = htons(cert_trans::kHangPort);
   CHECK_EQ(0, bind(hang_fd, reinterpret_cast<struct sockaddr*>(&hang_addr),
                    sizeof(hang_addr)));

--- a/cpp/net/url_fetcher_test.cc
+++ b/cpp/net/url_fetcher_test.cc
@@ -317,7 +317,7 @@ int main(int argc, char** argv) {
   hang_addr.sin_family = AF_INET;
   // Using LOOPBACK avoids triggering the firewall on some platforms. All
   // our connections are to localhost
-  hang_addr.sin_addr.s_addr = INADDR_LOOPBACK;
+  hang_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
   hang_addr.sin_port = htons(cert_trans::kHangPort);
   CHECK_EQ(0, bind(hang_fd, reinterpret_cast<struct sockaddr*>(&hang_addr),
                    sizeof(hang_addr)));

--- a/cpp/net/url_fetcher_test.cc
+++ b/cpp/net/url_fetcher_test.cc
@@ -315,7 +315,9 @@ int main(int argc, char** argv) {
   struct sockaddr_in hang_addr;
   bzero((char*)&hang_addr, sizeof(hang_addr));
   hang_addr.sin_family = AF_INET;
-  hang_addr.sin_addr.s_addr = INADDR_ANY;
+  // Using LOOPBACK avoids triggering the firewall on some platforms. All
+  // our connections are to localhost
+  hang_addr.sin_addr.s_addr = INADDR_LOOPBACK;
   hang_addr.sin_port = htons(cert_trans::kHangPort);
   CHECK_EQ(0, bind(hang_fd, reinterpret_cast<struct sockaddr*>(&hang_addr),
                    sizeof(hang_addr)));

--- a/cpp/net/url_fetcher_test.cc
+++ b/cpp/net/url_fetcher_test.cc
@@ -1,3 +1,5 @@
+#include "config.h"
+
 #include <csignal>
 #include <fcntl.h>
 #include <gflags/gflags.h>
@@ -7,6 +9,9 @@
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#ifdef HAVE_VFORK_H
+#include <vfork.h>
+#endif
 
 #include "net/connection_pool.h"
 #include "net/url_fetcher.h"
@@ -57,7 +62,12 @@ class LocalhostResolver : public libevent::Base::Resolver {
 pid_t RunOpenSSLServer(uint16_t port, const std::string& cert_file,
                        const std::string& key_file,
                        const std::string& mode = "-www") {
+#ifdef HAVE_WORKING_VFORK
+  pid_t pid(vfork());
+#else
   pid_t pid(fork());
+#endif
+
   if (pid == -1) {
     LOG(INFO) << "fork() failed: " << pid;
   } else if (pid == 0) {

--- a/cpp/server/event.cc
+++ b/cpp/server/event.cc
@@ -251,7 +251,7 @@ bool Services::InitServer(int* sock, int port, const char* ip, int type) {
   server.sin_family = AF_INET;
   server.sin_port = htons((unsigned short)port);
   if (ip == NULL)
-    server.sin_addr.s_addr = INADDR_ANY;
+    server.sin_addr.s_addr = htonl(INADDR_ANY);
   else
     memcpy(&server.sin_addr.s_addr, ip, 4);
 

--- a/cpp/server/server.h
+++ b/cpp/server/server.h
@@ -36,6 +36,8 @@
 #include "util/thread_pool.h"
 #include "util/uuid.h"
 
+using std::bind;
+
 DEFINE_int32(node_state_refresh_seconds, 10,
              "How often to refresh the ClusterNodeState entry for this node.");
 DEFINE_int32(watchdog_seconds, 120,

--- a/cpp/util/fake_etcd_test.cc
+++ b/cpp/util/fake_etcd_test.cc
@@ -19,6 +19,10 @@
 #include "util/testing.h"
 #include "util/thread_pool.h"
 
+DECLARE_string(trusted_root_certs);
+DEFINE_string(cert_dir, "test/testdata/urlfetcher_test_certs",
+              "Directory containing the test certs.");
+
 namespace cert_trans {
 
 using std::bind;
@@ -960,6 +964,9 @@ int main(int argc, char** argv) {
   ERR_load_crypto_strings();
   SSL_load_error_strings();
   SSL_library_init();
+
+  // Default value of trusted root certs may not be correct on all platforms
+  FLAGS_trusted_root_certs = FLAGS_cert_dir + "/ca-cert.pem";
 
   return RUN_ALL_TESTS();
 }

--- a/cpp/util/libevent_wrapper.cc
+++ b/cpp/util/libevent_wrapper.cc
@@ -1,3 +1,4 @@
+#include "config.h"
 #include "util/libevent_wrapper.h"
 
 #include <arpa/inet.h>
@@ -61,7 +62,13 @@ void DelayDispatch(evutil_socket_t, short, void* userdata) {
 }
 
 
+#ifdef HAVE_THREAD_LOCAL
 thread_local bool on_event_thread = false;
+#elif HAVE___THREAD
+__thread bool on_event_thread = false;
+#else
+#error No suitable thread local storage available
+#endif
 
 
 }  // namespace

--- a/cpp/util/libevent_wrapper_test.cc
+++ b/cpp/util/libevent_wrapper_test.cc
@@ -43,7 +43,7 @@ TEST_F(LibEventWrapperTest, TestTurtlesAllTheWayDown) {
 }
 
 
-TEST_F(LibEventWrapperDeathTest, TestCheckNotOnEventThreadDeathTest) {
+TEST_F(LibEventWrapperDeathTest, TestCheckNotOnEventThread) {
   // Should be fine:
   Base::CheckNotOnEventThread();
   // But...

--- a/cpp/util/libevent_wrapper_test.cc
+++ b/cpp/util/libevent_wrapper_test.cc
@@ -43,7 +43,7 @@ TEST_F(LibEventWrapperTest, TestTurtlesAllTheWayDown) {
 }
 
 
-TEST_F(LibEventWrapperDeathTest, TestCheckNotOnEventThread) {
+TEST_F(LibEventWrapperDeathTest, TestCheckNotOnEventThreadDeathTest) {
   // Should be fine:
   Base::CheckNotOnEventThread();
   // But...

--- a/cpp/util/masterelection_test.cc
+++ b/cpp/util/masterelection_test.cc
@@ -17,6 +17,9 @@
 #include "util/thread_pool.h"
 #include "util/testing.h"
 
+DECLARE_string(trusted_root_certs);
+DEFINE_string(cert_dir, "test/testdata/urlfetcher_test_certs",
+              "Directory containing the test certs.");
 
 namespace cert_trans {
 
@@ -323,5 +326,7 @@ TEST_F(ElectionTest, ElectionMania) {
 
 int main(int argc, char** argv) {
   cert_trans::test::InitTesting(argv[0], &argc, &argv, true);
+  // Default value of trusted root certs may not be correct on all platforms
+  FLAGS_trusted_root_certs = FLAGS_cert_dir + "/ca-cert.pem";
   return RUN_ALL_TESTS();
 }

--- a/cpp/util/thread_pool_test.cc
+++ b/cpp/util/thread_pool_test.cc
@@ -36,7 +36,7 @@ TEST_F(ThreadPoolTest, Delay) {
 }
 
 
-TEST_F(ThreadPoolDeathTest, AddingMoreTasksAfterClosedGoesBang) {
+TEST_F(ThreadPoolDeathTest, AddingMoreTasksAfterClosedGoesBangDeathTest) {
   unique_ptr<ThreadPool> my_pool_of_one(new ThreadPool(1));
   SyncTask task(my_pool_of_one.get());
   my_pool_of_one->Delay(milliseconds(200), task.task());
@@ -94,5 +94,6 @@ TEST_F(ThreadPoolTest, CancelsDelayTasks) {
 
 int main(int argc, char** argv) {
   cert_trans::test::InitTesting(argv[0], &argc, &argv, true);
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   return RUN_ALL_TESTS();
 }

--- a/cpp/util/thread_pool_test.cc
+++ b/cpp/util/thread_pool_test.cc
@@ -36,7 +36,7 @@ TEST_F(ThreadPoolTest, Delay) {
 }
 
 
-TEST_F(ThreadPoolDeathTest, AddingMoreTasksAfterClosedGoesBangDeathTest) {
+TEST_F(ThreadPoolDeathTest, AddingMoreTasksAfterClosedGoesBang) {
   unique_ptr<ThreadPool> my_pool_of_one(new ThreadPool(1));
   SyncTask task(my_pool_of_one.get());
   my_pool_of_one->Delay(milliseconds(200), task.task());

--- a/m4/ct_check_tls.m4
+++ b/m4/ct_check_tls.m4
@@ -1,0 +1,37 @@
+dnl Checks for thread-local storage support.
+dnl
+dnl Taken from the openvswitch config code (Apache 2.0 License)
+dnl with some local modifications. Does not include <threads.h>
+dnl as this does not currently exist on GCC.
+dnl Checks whether the compiler and linker support the C11
+dnl thread_local macro from <threads.h>, and if so defines
+dnl HAVE_THREAD_LOCAL.  If not, checks whether the compiler and linker
+dnl support the GCC __thread extension, and if so defines
+dnl HAVE___THREAD.
+AC_DEFUN([CT_CHECK_TLS],
+  [AC_CACHE_CHECK(
+     [whether $CC has <threads.h> that supports thread_local],
+     [ct_cv_thread_local],
+     [AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM([ static thread_local int var;], [return var;])],
+        [ct_cv_thread_local=yes],
+        [ct_cv_thread_local=no])])
+   if test $ct_cv_thread_local = yes; then
+     AC_DEFINE([HAVE_THREAD_LOCAL], [1],
+               [Define to 1 if the C compiler and linker supports the C11
+                thread_local macro defined in <threads.h>.])
+   else
+     AC_CACHE_CHECK(
+       [whether $CC supports __thread],
+       [ct_cv___thread],
+       [AC_LINK_IFELSE(
+          [AC_LANG_PROGRAM([static __thread int var;], [return var;])],
+          [ct_cv___thread=yes],
+          [ct_cv___thread=no])])
+     if test $ct_cv___thread = yes; then
+       AC_DEFINE([HAVE___THREAD], [1],
+                 [Define to 1 if the C compiler and linker supports the
+                  GCC __thread extensions.])
+     fi
+   fi])
+


### PR DESCRIPTION
Fixes a number of issues on OSX and addresses test failures. Includes renaming death tests so they run first, network byte ordering, assumptions that /etc/certs exists, use of thread_local qualifier. Added new checks to configure.ac to support test fixes.