### PR TITLE
Update tests that relied on /etc/ssl/certs to use our test certs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -644,6 +644,8 @@ cpp_util_fake_etcd_test_SOURCES = \
 	cpp/util/json_wrapper.cc \
 	cpp/util/libevent_wrapper.cc \
 	cpp/util/thread_pool.cc
+EXTRA_cpp_util_fake_etcd_test_DEPENDENCIES = \
+	test/testdata/urlfetcher_test_certs/localhost.pem
 
 cpp_util_json_wrapper_test_LDADD = \
 	cpp/libtest.a \
@@ -676,6 +678,8 @@ cpp_util_masterelection_test_SOURCES = \
 	cpp/util/periodic_closure.cc \
 	cpp/util/protobuf_util.cc \
 	cpp/util/thread_pool.cc
+EXTRA_cpp_util_masterelection_test_DEPENDENCIES = \
+	test/testdata/urlfetcher_test_certs/localhost.pem
 
 cpp_merkletree_merkle_tree_test_LDADD = \
 	cpp/libcore.a \

--- a/cpp/util/fake_etcd_test.cc
+++ b/cpp/util/fake_etcd_test.cc
@@ -19,6 +19,10 @@
 #include "util/testing.h"
 #include "util/thread_pool.h"
 
+DECLARE_string(trusted_root_certs);
+DEFINE_string(cert_dir, "test/testdata/urlfetcher_test_certs",
+              "Directory containing the test certs.");
+
 namespace cert_trans {
 
 using std::bind;
@@ -960,6 +964,9 @@ int main(int argc, char** argv) {
   ERR_load_crypto_strings();
   SSL_load_error_strings();
   SSL_library_init();
+
+  // Default value of trusted root certs may not be correct on all platforms
+  FLAGS_trusted_root_certs = FLAGS_cert_dir + "/ca-cert.pem";
 
   return RUN_ALL_TESTS();
 }

--- a/cpp/util/masterelection_test.cc
+++ b/cpp/util/masterelection_test.cc
@@ -17,6 +17,9 @@
 #include "util/thread_pool.h"
 #include "util/testing.h"
 
+DECLARE_string(trusted_root_certs);
+DEFINE_string(cert_dir, "test/testdata/urlfetcher_test_certs",
+              "Directory containing the test certs.");
 
 namespace cert_trans {
 
@@ -323,5 +326,7 @@ TEST_F(ElectionTest, ElectionMania) {
 
 int main(int argc, char** argv) {
   cert_trans::test::InitTesting(argv[0], &argc, &argv, true);
+  // Default value of trusted root certs may not be correct on all platforms
+  FLAGS_trusted_root_certs = FLAGS_cert_dir + "/ca-cert.pem";
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
These tests don't need particular ones but fail if we can't initialize the store so they now use our generated test certs instead.