### PR TITLE
Some portability improvements, mostly for tests but also thread local

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -135,6 +135,9 @@ AC_TYPE_UINT32_T
 AC_TYPE_UINT64_T
 AC_TYPE_UINT8_T
 
+CT_CHECK_TLS
+AC_CHECK_DECLS([INADDR_LOOPBACK], [], [], [#include <netinet/in.h>])
+
 AC_MSG_CHECKING([whether pthread_t is a pointer])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 #include <pthread.h>

--- a/cpp/server/event.cc
+++ b/cpp/server/event.cc
@@ -251,7 +251,7 @@ bool Services::InitServer(int* sock, int port, const char* ip, int type) {
   server.sin_family = AF_INET;
   server.sin_port = htons((unsigned short)port);
   if (ip == NULL)
-    server.sin_addr.s_addr = INADDR_ANY;
+    server.sin_addr.s_addr = htonl(INADDR_ANY);
   else
     memcpy(&server.sin_addr.s_addr, ip, 4);
 

--- a/cpp/server/server.h
+++ b/cpp/server/server.h
@@ -36,6 +36,8 @@
 #include "util/thread_pool.h"
 #include "util/uuid.h"
 
+using std::bind;
+
 DEFINE_int32(node_state_refresh_seconds, 10,
              "How often to refresh the ClusterNodeState entry for this node.");
 DEFINE_int32(watchdog_seconds, 120,

--- a/cpp/util/libevent_wrapper.cc
+++ b/cpp/util/libevent_wrapper.cc
@@ -1,3 +1,4 @@
+#include "config.h"
 #include "util/libevent_wrapper.h"
 
 #include <arpa/inet.h>
@@ -61,7 +62,13 @@ void DelayDispatch(evutil_socket_t, short, void* userdata) {
 }
 
 
+#ifdef HAVE_THREAD_LOCAL
 thread_local bool on_event_thread = false;
+#elif HAVE___THREAD
+__thread bool on_event_thread = false;
+#else
+#error No suitable thread local storage available
+#endif
 
 
 }  // namespace

--- a/m4/ct_check_tls.m4
+++ b/m4/ct_check_tls.m4
@@ -1,0 +1,37 @@
+dnl Checks for thread-local storage support.
+dnl
+dnl Taken from the openvswitch config code (Apache 2.0 License)
+dnl with some local modifications. Does not include <threads.h>
+dnl as this does not currently exist on GCC.
+dnl Checks whether the compiler and linker support the C11
+dnl thread_local macro from <threads.h>, and if so defines
+dnl HAVE_THREAD_LOCAL.  If not, checks whether the compiler and linker
+dnl support the GCC __thread extension, and if so defines
+dnl HAVE___THREAD.
+AC_DEFUN([CT_CHECK_TLS],
+  [AC_CACHE_CHECK(
+     [whether $CC has <threads.h> that supports thread_local],
+     [ct_cv_thread_local],
+     [AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM([ static thread_local int var;], [return var;])],
+        [ct_cv_thread_local=yes],
+        [ct_cv_thread_local=no])])
+   if test $ct_cv_thread_local = yes; then
+     AC_DEFINE([HAVE_THREAD_LOCAL], [1],
+               [Define to 1 if the C compiler and linker supports the C11
+                thread_local macro defined in <threads.h>.])
+   else
+     AC_CACHE_CHECK(
+       [whether $CC supports __thread],
+       [ct_cv___thread],
+       [AC_LINK_IFELSE(
+          [AC_LANG_PROGRAM([static __thread int var;], [return var;])],
+          [ct_cv___thread=yes],
+          [ct_cv___thread=no])])
+     if test $ct_cv___thread = yes; then
+       AC_DEFINE([HAVE___THREAD], [1],
+                 [Define to 1 if the C compiler and linker supports the
+                  GCC __thread extensions.])
+     fi
+   fi])
+


### PR DESCRIPTION
Add support to configure.ac for checking thread local support
and also check IPADDR_LOOPBACK is defined. In test use
loopback if we can to prevent firewall issues and use correct
thread local qualifier in sever. Plus ensure server.h qualifies
calls to std::bind to prevent clash with C socket API.