### PR TITLE
Some fixes to tests, flakiness improvement and test ordering

### DIFF
--- a/cpp/log/database_test.cc
+++ b/cpp/log/database_test.cc
@@ -47,7 +47,12 @@ typedef testing::Types<FileDB<cert_trans::LoggedCertificate>,
 
 typedef Database<cert_trans::LoggedCertificate> DB;
 
+template <class T>
+class DBTestDeathTest : public DBTest<T> {
+};
+
 TYPED_TEST_CASE(DBTest, Databases);
+TYPED_TEST_CASE(DBTestDeathTest, Databases);
 
 
 TYPED_TEST(DBTest, CreateSequenced) {
@@ -362,14 +367,14 @@ TYPED_TEST(DBTest, NoNodeIdSet) {
 }
 
 
-TYPED_TEST(DBTest, CannotOverwriteNodeId) {
+TYPED_TEST(DBTestDeathTest, CannotOverwriteNodeId) {
   const string kNodeId("some_node_id");
   this->db()->InitializeNode(kNodeId);
   EXPECT_DEATH(this->db()->InitializeNode("something_else"), kNodeId);
 }
 
 
-TYPED_TEST(DBTest, CannotHaveEmptyNodeId) {
+TYPED_TEST(DBTestDeathTest, CannotHaveEmptyNodeId) {
   EXPECT_DEATH(this->db()->InitializeNode(""), "empty");
 }
 

--- a/cpp/log/etcd_consistent_store_test.cc
+++ b/cpp/log/etcd_consistent_store_test.cc
@@ -289,8 +289,8 @@ TEST_F(EtcdConsistentStoreTest, TestSetServingSTHWontOverwriteWithOlder) {
   EXPECT_EQ(util::error::OUT_OF_RANGE, status.CanonicalCode()) << status;
 }
 
-
-TEST_F(EtcdConsistentStoreDeathTest, TestSetServingSTHChecksInconsistentSize) {
+TEST_F(EtcdConsistentStoreDeathTest,
+       TestSetServingSTHChecksInconsistentSize) {
   ct::SignedTreeHead sth;
   sth.set_timestamp(234);
   sth.set_tree_size(10);
@@ -497,9 +497,8 @@ TEST_F(EtcdConsistentStoreDeathTest,
                "sequence_number\\(\\) < mapping");
 }
 
-
 TEST_F(EtcdConsistentStoreDeathTest,
-       TestUpdateSequenceMappingBarfsWithMappingNonContiguousToServingTree) {
+    TestUpdateSequenceMappingBarfsMappingNonContiguousToServingTree) {
   SignedTreeHead sth;
   sth.set_timestamp(123);
   sth.set_tree_size(1000);

--- a/cpp/util/thread_pool_test.cc
+++ b/cpp/util/thread_pool_test.cc
@@ -94,5 +94,6 @@ TEST_F(ThreadPoolTest, CancelsDelayTasks) {
 
 int main(int argc, char** argv) {
   cert_trans::test::InitTesting(argv[0], &argc, &argv, true);
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Trying to reduce cluster state test flakiness and making sure death tests are in the correctly
named test suite.