### PR TITLE
Portability tweak to compact merkle tree code.

### DIFF
--- a/cpp/merkletree/compact_merkle_tree.cc
+++ b/cpp/merkletree/compact_merkle_tree.cc
@@ -21,7 +21,7 @@ CompactMerkleTree::CompactMerkleTree(SerialHasher* hasher)
 
 CompactMerkleTree::CompactMerkleTree(MerkleTree& model, SerialHasher* hasher)
     : MerkleTreeInterface(),
-      tree_(std::max(int64_t(0), int64_t(model.LevelCount()) - 1)),
+      tree_(std::max<int64_t>(0, model.LevelCount() - 1)),
       treehasher_(hasher),
       leaf_count_(model.LeafCount()),
       leaves_processed_(0),

--- a/cpp/merkletree/compact_merkle_tree.cc
+++ b/cpp/merkletree/compact_merkle_tree.cc
@@ -21,7 +21,7 @@ CompactMerkleTree::CompactMerkleTree(SerialHasher* hasher)
 
 CompactMerkleTree::CompactMerkleTree(MerkleTree& model, SerialHasher* hasher)
     : MerkleTreeInterface(),
-      tree_(std::max(0L, int64_t(model.LevelCount()) - 1)),
+      tree_(std::max(int64_t(0), int64_t(model.LevelCount()) - 1)),
       treehasher_(hasher),
       leaf_count_(model.LeafCount()),
       leaves_processed_(0),


### PR DESCRIPTION
Constructor tweak to CompactMerkleTree. Alternatives tried either did not compile or caused tests to fail at runtime with std::bad_alloc.