### PR TITLE
Refactoring to support multiple handler versions + server binaries

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -194,7 +194,7 @@ cpp_libtest_a_SOURCES = \
 	cpp/util/testing.cc
 
 cpp_libserver_a_LIBDADD = \
-  cpp/libcore.a
+        cpp/libcore.a
 
 cpp_libserver_a_SOURCES = \
 	cpp/client/async_log_client.cc \

--- a/Makefile.am
+++ b/Makefile.am
@@ -202,6 +202,8 @@ cpp_server_ct_mirror_SOURCES = \
 	cpp/proto/serializer.cc \
 	cpp/server/ct-mirror.cc \
 	cpp/server/handler.cc \
+	cpp/server/handler_v1.cc \
+	cpp/server/handler_v2.cc \
 	cpp/server/json_output.cc \
 	cpp/server/metrics.cc \
 	cpp/server/proxy.cc \
@@ -215,6 +217,15 @@ cpp_server_ct_mirror_SOURCES = \
 	cpp/util/util.cc \
 	cpp/util/uuid.cc \
 	cpp/version.cc
+EXTRA_cpp_server_ct_mirror_SOURCES = \
+        cpp/server/handler_factory_v1.cc \
+        cpp/server/handler_factory_v2.cc
+if CT_VERSION_1
+cpp_server_ct_mirror_SOURCES += cpp/server/handler_factory_v1.cc
+endif
+if CT_VERSION_2
+cpp_server_ct_mirror_SOURCES += cpp/server/handler_factory_v2.cc
+endif
 
 cpp_server_ct_server_LDADD = \
 	cpp/libcore.a \
@@ -222,11 +233,16 @@ cpp_server_ct_server_LDADD = \
 	$(libevent_LIBS) \
 	$(leveldb_LIBS) \
 	-lprotobuf -lsqlite3
+EXTRA_cpp_server_ct_server_SOURCES = \
+        cpp/server/handler_v1.cc \
+        cpp/server/handler_v2.cc
 cpp_server_ct_server_SOURCES = \
 	cpp/client/async_log_client.cc \
 	cpp/proto/serializer.cc \
 	cpp/server/ct-server.cc \
 	cpp/server/handler.cc \
+	cpp/server/handler_v1.cc \
+	cpp/server/handler_v2.cc \
 	cpp/server/json_output.cc \
 	cpp/server/metrics.cc \
 	cpp/server/proxy.cc \
@@ -240,6 +256,12 @@ cpp_server_ct_server_SOURCES = \
 	cpp/util/util.cc \
 	cpp/util/uuid.cc \
 	cpp/version.cc
+if CT_VERSION_1
+cpp_server_ct_server_SOURCES += cpp/server/handler_factory_v1.cc
+endif
+if CT_VERSION_2
+cpp_server_ct_server_SOURCES += cpp/server/handler_factory_v2.cc
+endif
 
 cpp_tools_ct_clustertool_LDADD = \
 	cpp/libcore.a \

--- a/Makefile.am
+++ b/Makefile.am
@@ -32,7 +32,9 @@ cpp/version.o: \
 bin_PROGRAMS = \
 	cpp/client/ct \
 	cpp/server/ct-mirror \
+	cpp/server/ct-mirror-v2 \
 	cpp/server/ct-server \
+	cpp/server/ct-server-v2 \
 	cpp/tools/ct-clustertool
 
 noinst_PROGRAMS = \
@@ -50,6 +52,7 @@ endif
 
 noinst_LIBRARIES = \
 	cpp/libcore.a \
+	cpp/libserver.a \
 	cpp/libtest.a
 
 check_PROGRAMS = \
@@ -190,23 +193,20 @@ cpp_libtest_a_SOURCES = \
 	cpp/gtest-all.cc \
 	cpp/util/testing.cc
 
-cpp_server_ct_mirror_LDADD = \
-	cpp/libcore.a \
-	$(json_c_LIBS) \
-	$(libevent_LIBS) \
-	$(leveldb_LIBS) \
-	-lprotobuf -lsqlite3
-cpp_server_ct_mirror_SOURCES = \
+cpp_libserver_a_LIBDADD = \
+  cpp/libcore.a
+
+cpp_libserver_a_SOURCES = \
 	cpp/client/async_log_client.cc \
-	cpp/fetcher/remote_peer.cc \
-	cpp/proto/serializer.cc \
-	cpp/server/ct-mirror.cc \
 	cpp/server/handler.cc \
-	cpp/server/handler_v1.cc \
-	cpp/server/handler_v2.cc \
 	cpp/server/json_output.cc \
 	cpp/server/metrics.cc \
 	cpp/server/proxy.cc \
+	cpp/fetcher/remote_peer.cc \
+	cpp/monitoring/prometheus/exporter.cc \
+	cpp/monitoring/prometheus/metrics.pb.cc \
+	cpp/monitoring/prometheus/metrics.pb.h \
+	cpp/proto/serializer.cc \
 	cpp/util/init.cc \
 	cpp/util/json_wrapper.cc \
 	cpp/util/libevent_wrapper.cc \
@@ -217,51 +217,58 @@ cpp_server_ct_mirror_SOURCES = \
 	cpp/util/util.cc \
 	cpp/util/uuid.cc \
 	cpp/version.cc
-EXTRA_cpp_server_ct_mirror_SOURCES = \
-        cpp/server/handler_factory_v1.cc \
-        cpp/server/handler_factory_v2.cc
-if CT_VERSION_1
-cpp_server_ct_mirror_SOURCES += cpp/server/handler_factory_v1.cc
-endif
-if CT_VERSION_2
-cpp_server_ct_mirror_SOURCES += cpp/server/handler_factory_v2.cc
-endif
+
+cpp_server_ct_mirror_LDADD = \
+	cpp/libcore.a \
+	cpp/libserver.a \
+	$(json_c_LIBS) \
+	$(libevent_LIBS) \
+	$(leveldb_LIBS) \
+	-lprotobuf -lsqlite3
+
+cpp_server_ct_mirror_SOURCES = \
+	cpp/server/ct-mirror.cc \
+	cpp/server/handler_factory_v1.cc \
+	cpp/server/handler_v1.cc
+
+cpp_server_ct_mirror_v2_LDADD = \
+	cpp/libcore.a \
+	cpp/libserver.a \
+	$(json_c_LIBS) \
+	$(libevent_LIBS) \
+	$(leveldb_LIBS) \
+	-lprotobuf -lsqlite3
+
+cpp_server_ct_mirror_v2_SOURCES = \
+	cpp/server/ct-mirror.cc \
+	cpp/server/handler_factory_v2.cc \
+	cpp/server/handler_v2.cc
 
 cpp_server_ct_server_LDADD = \
 	cpp/libcore.a \
+	cpp/libserver.a \
 	$(json_c_LIBS) \
 	$(libevent_LIBS) \
 	$(leveldb_LIBS) \
 	-lprotobuf -lsqlite3
-EXTRA_cpp_server_ct_server_SOURCES = \
-        cpp/server/handler_v1.cc \
-        cpp/server/handler_v2.cc
+
 cpp_server_ct_server_SOURCES = \
-	cpp/client/async_log_client.cc \
-	cpp/proto/serializer.cc \
 	cpp/server/ct-server.cc \
-	cpp/server/handler.cc \
-	cpp/server/handler_v1.cc \
-	cpp/server/handler_v2.cc \
-	cpp/server/json_output.cc \
-	cpp/server/metrics.cc \
-	cpp/server/proxy.cc \
-	cpp/util/init.cc \
-	cpp/util/json_wrapper.cc \
-	cpp/util/libevent_wrapper.cc \
-	cpp/util/periodic_closure.cc \
-	cpp/util/protobuf_util.cc \
-	cpp/util/protobuf_util.h \
-	cpp/util/read_key.cc \
-	cpp/util/util.cc \
-	cpp/util/uuid.cc \
-	cpp/version.cc
-if CT_VERSION_1
-cpp_server_ct_server_SOURCES += cpp/server/handler_factory_v1.cc
-endif
-if CT_VERSION_2
-cpp_server_ct_server_SOURCES += cpp/server/handler_factory_v2.cc
-endif
+	cpp/server/handler_factory_v1.cc \
+	cpp/server/handler_v1.cc
+	
+cpp_server_ct_server_v2_LDADD = \
+	cpp/libcore.a \
+	cpp/libserver.a \
+	$(json_c_LIBS) \
+	$(libevent_LIBS) \
+	$(leveldb_LIBS) \
+	-lprotobuf -lsqlite3
+
+cpp_server_ct_server_v2_SOURCES = \
+	cpp/server/ct-server.cc \
+	cpp/server/handler_factory_v2.cc \
+	cpp/server/handler_v2.cc
 
 cpp_tools_ct_clustertool_LDADD = \
 	cpp/libcore.a \

--- a/configure.ac
+++ b/configure.ac
@@ -155,6 +155,20 @@ AS_IF([test -n "$missing_libevhtp"],
       [AC_MSG_ERROR([could not find the evhtp library])])
 LIBS="$save_LIBS"
 
+# CT protocol version support. Only one version may be enabled
+# at compile time. Defaults to v1 support (RFC 6962).
+AC_ARG_WITH(
+  ctversion,
+  AS_HELP_STRING([--with-ctversion=1 or 2],
+                 [ 1 (default) for rfc6962, 2 for rfc6962-bis]),
+                 AS_CASE([$withval],
+                 [1], [ctversion=1],
+                 [2], [ctversion=2],
+                 [*], [AC_MSG_FAILURE([ctversion must be 1 or 2])]),
+                 [ctversion=1])
+AM_CONDITIONAL([CT_VERSION_1], [test x$ctversion = x1])
+AM_CONDITIONAL([CT_VERSION_2], [test x$ctversion = x2])
+
 # TCMalloc gubbins
 AC_ARG_WITH([tcmalloc],
             [AS_HELP_STRING([--without-tcmalloc],

--- a/cpp/server/ct-mirror.cc
+++ b/cpp/server/ct-mirror.cc
@@ -36,7 +36,7 @@
 #include "monitoring/latency.h"
 #include "monitoring/monitoring.h"
 #include "monitoring/registry.h"
-#include "server/handler.h"
+#include "server/handler_factory.h"
 #include "server/json_output.h"
 #include "server/metrics.h"
 #include "server/proxy.h"

--- a/cpp/server/handler.cc
+++ b/cpp/server/handler.cc
@@ -71,81 +71,6 @@ static Latency<milliseconds, string> http_server_request_latency_ms(
     "Total request latency in ms broken down by path");
 
 
-multimap<string, string> ParseQuery(evhttp_request* req) {
-  evkeyvalq keyval;
-  multimap<string, string> retval;
-
-  // We return an empty result in case of a parsing error.
-  if (evhttp_parse_query_str(evhttp_uri_get_query(
-                                 evhttp_request_get_evhttp_uri(req)),
-                             &keyval) == 0) {
-    for (evkeyval* i = keyval.tqh_first; i; i = i->next.tqe_next) {
-      retval.insert(make_pair(i->key, i->value));
-    }
-  }
-
-  return retval;
-}
-
-
-bool GetParam(const multimap<string, string>& query, const string& param,
-              string* value) {
-  CHECK_NOTNULL(value);
-
-  multimap<string, string>::const_iterator it = query.find(param);
-  if (it == query.end()) {
-    return false;
-  }
-
-  const string possible_value(it->second);
-  ++it;
-
-  // Flag duplicate query parameters as invalid.
-  const bool retval(it == query.end() || it->first != param);
-  if (retval) {
-    *value = possible_value;
-  }
-
-  return retval;
-}
-
-
-// Returns -1 on error, and on success too if the parameter contains
-// -1 (so it's advised to only use it when expecting unsigned
-// parameters).
-int64_t GetIntParam(const multimap<string, string>& query,
-                    const string& param) {
-  int retval(-1);
-  string value;
-  if (GetParam(query, param, &value)) {
-    errno = 0;
-    const long num(strtol(value.c_str(), /*endptr*/ NULL, 10));
-    // Detect strtol() errors or overflow/underflow when casting to
-    // retval's type clips the value. We do the following by doing it,
-    // and checking that they're still equal afterward (this will
-    // still work if we change retval's type later on).
-    retval = num;
-    if (errno || static_cast<long>(retval) != num) {
-      VLOG(1) << "over/underflow getting \"" << param << "\": " << retval
-              << ", " << num << " (" << strerror(errno) << ")";
-      retval = -1;
-    }
-  }
-
-  return retval;
-}
-
-
-bool GetBoolParam(const multimap<string, string>& query, const string& param) {
-  string value;
-  if (GetParam(query, param, &value)) {
-    return (value == "true");
-  } else {
-    return false;
-  }
-}
-
-
 }  // namespace
 
 
@@ -177,6 +102,82 @@ HttpHandler::~HttpHandler() {
   task_.Wait();
 }
 
+int HttpHandler::GetMaxLeafEntriesPerResponse() const {
+  return FLAGS_max_leaf_entries_per_response;
+}
+
+multimap<string, string> HttpHandler::ParseQuery(evhttp_request* req) const {
+  evkeyvalq keyval;
+  multimap<string, string> retval;
+
+  // We return an empty result in case of a parsing error.
+  if (evhttp_parse_query_str(evhttp_uri_get_query(
+                                 evhttp_request_get_evhttp_uri(req)),
+                             &keyval) == 0) {
+    for (evkeyval* i = keyval.tqh_first; i; i = i->next.tqe_next) {
+      retval.insert(make_pair(i->key, i->value));
+    }
+  }
+
+  return retval;
+}
+
+bool HttpHandler::GetParam(const multimap<string, string>& query,
+                           const string& param, string* value) const {
+  CHECK_NOTNULL(value);
+
+  multimap<string, string>::const_iterator it = query.find(param);
+  if (it == query.end()) {
+    return false;
+  }
+
+  const string possible_value(it->second);
+  ++it;
+
+  // Flag duplicate query parameters as invalid.
+  const bool retval(it == query.end() || it->first != param);
+  if (retval) {
+    *value = possible_value;
+  }
+
+  return retval;
+}
+
+
+// Returns -1 on error, and on success too if the parameter contains
+// -1 (so it's advised to only use it when expecting unsigned
+// parameters).
+int64_t HttpHandler::GetIntParam(const multimap<string, string>& query,
+                                 const string& param) const {
+  int retval(-1);
+  string value;
+  if (GetParam(query, param, &value)) {
+    errno = 0;
+    const long num(strtol(value.c_str(), /*endptr*/ NULL, 10));
+    // Detect strtol() errors or overflow/underflow when casting to
+    // retval's type clips the value. We do the following by doing it,
+    // and checking that they're still equal afterward (this will
+    // still work if we change retval's type later on).
+    retval = num;
+    if (errno || static_cast<long>(retval) != num) {
+      VLOG(1) << "over/underflow getting \"" << param << "\": " << retval
+              << ", " << num << " (" << strerror(errno) << ")";
+      retval = -1;
+    }
+  }
+
+  return retval;
+}
+
+bool HttpHandler::GetBoolParam(const multimap<string, string>& query,
+                               const string& param) const {
+  string value;
+  if (GetParam(query, param, &value)) {
+    return (value == "true");
+  } else {
+    return false;
+  }
+}
 
 void StatsHandlerInterceptor(const string& path,
                              const libevent::HttpServer::HandlerCallback& cb,
@@ -282,227 +283,6 @@ void HttpHandler::AddChainReply(JsonOutput* output, evhttp_request* req,
   output->SendJsonReply(req, HTTP_OK, json_reply);
 }
 
-
-void HttpHandler::GetEntries(evhttp_request* req) const {
-  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
-    return output_->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
-  }
-
-  const multimap<string, string> query(ParseQuery(req));
-
-  const int64_t start(GetIntParam(query, "start"));
-  if (start < 0) {
-    return output_->SendError(req, HTTP_BADREQUEST,
-                              "Missing or invalid \"start\" parameter.");
-  }
-
-  int64_t end(GetIntParam(query, "end"));
-  if (end < start) {
-    return output_->SendError(req, HTTP_BADREQUEST,
-                              "Missing or invalid \"end\" parameter.");
-  }
-
-  // Limit the number of entries returned in a single request.
-  end = std::min(end, start + FLAGS_max_leaf_entries_per_response);
-
-  // Sekrit parameter to indicate that SCTs should be included too.
-  // This is non-standard, and is only used internally by other log nodes when
-  // "following" nodes with more data.
-  const bool include_scts(GetBoolParam(query, "include_scts"));
-
-  BlockingGetEntries(req, start, end, include_scts);
-}
-
-void HttpHandler::GetRoots(evhttp_request* req) const {
-  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
-    return output_->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
-  }
-
-  JsonArray roots;
-  multimap<string, const Cert*>::const_iterator it;
-  for (it = cert_checker_->GetTrustedCertificates().begin();
-       it != cert_checker_->GetTrustedCertificates().end(); ++it) {
-    string cert;
-    if (it->second->DerEncoding(&cert) != util::Status::OK) {
-      LOG(ERROR) << "Cert encoding failed";
-      return output_->SendError(req, HTTP_INTERNAL, "Serialisation failed.");
-    }
-    roots.AddBase64(cert);
-  }
-
-  JsonObject json_reply;
-  json_reply.Add("certificates", roots);
-
-  output_->SendJsonReply(req, HTTP_OK, json_reply);
-}
-
-
-void HttpHandler::GetProof(evhttp_request* req) const {
-  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
-    return output_->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
-  }
-
-  const multimap<string, string> query(ParseQuery(req));
-
-  string b64_hash;
-  if (!GetParam(query, "hash", &b64_hash)) {
-    return output_->SendError(req, HTTP_BADREQUEST,
-                              "Missing or invalid \"hash\" parameter.");
-  }
-
-  const string hash(util::FromBase64(b64_hash.c_str()));
-  if (hash.empty()) {
-    return output_->SendError(req, HTTP_BADREQUEST,
-                              "Invalid \"hash\" parameter.");
-  }
-
-  const int64_t tree_size(GetIntParam(query, "tree_size"));
-  if (tree_size < 0 ||
-      static_cast<int64_t>(tree_size) > log_lookup_->GetSTH().tree_size()) {
-    return output_->SendError(req, HTTP_BADREQUEST,
-                              "Missing or invalid \"tree_size\" parameter.");
-  }
-
-  ShortMerkleAuditProof proof;
-  if (log_lookup_->AuditProof(hash, tree_size, &proof) !=
-      LogLookup<LoggedCertificate>::OK) {
-    return output_->SendError(req, HTTP_BADREQUEST, "Couldn't find hash.");
-  }
-
-  JsonArray json_audit;
-  for (int i = 0; i < proof.path_node_size(); ++i) {
-    json_audit.AddBase64(proof.path_node(i));
-  }
-
-  JsonObject json_reply;
-  json_reply.Add("leaf_index", proof.leaf_index());
-  json_reply.Add("audit_path", json_audit);
-
-  output_->SendJsonReply(req, HTTP_OK, json_reply);
-}
-
-
-void HttpHandler::GetSTH(evhttp_request* req) const {
-  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
-    return output_->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
-  }
-
-  const SignedTreeHead& sth(log_lookup_->GetSTH());
-
-  VLOG(2) << "SignedTreeHead:\n" << sth.DebugString();
-
-  JsonObject json_reply;
-  json_reply.Add("tree_size", sth.tree_size());
-  json_reply.Add("timestamp", sth.timestamp());
-  json_reply.AddBase64("sha256_root_hash", sth.sha256_root_hash());
-  json_reply.Add("tree_head_signature", sth.signature());
-
-  VLOG(2) << "GetSTH:\n" << json_reply.DebugString();
-
-  output_->SendJsonReply(req, HTTP_OK, json_reply);
-}
-
-
-void HttpHandler::GetConsistency(evhttp_request* req) const {
-  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
-    return output_->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
-  }
-
-  const multimap<string, string> query(ParseQuery(req));
-
-  const int64_t first(GetIntParam(query, "first"));
-  if (first < 0) {
-    return output_->SendError(req, HTTP_BADREQUEST,
-                              "Missing or invalid \"first\" parameter.");
-  }
-
-  const int64_t second(GetIntParam(query, "second"));
-  if (second < first) {
-    return output_->SendError(req, HTTP_BADREQUEST,
-                              "Missing or invalid \"second\" parameter.");
-  }
-
-  const vector<string> consistency(
-      log_lookup_->ConsistencyProof(first, second));
-  JsonArray json_cons;
-  for (vector<string>::const_iterator it = consistency.begin();
-       it != consistency.end(); ++it) {
-    json_cons.AddBase64(*it);
-  }
-
-  JsonObject json_reply;
-  json_reply.Add("consistency", json_cons);
-
-  output_->SendJsonReply(req, HTTP_OK, json_reply);
-}
-
-
-void HttpHandler::AddChain(evhttp_request* req) {
-  const shared_ptr<CertChain> chain(make_shared<CertChain>());
-  if (!ExtractChain(output_, req, chain.get())) {
-    return;
-  }
-
-  pool_->Add(bind(&HttpHandler::BlockingAddChain, this, req, chain));
-}
-
-
-void HttpHandler::BlockingGetEntries(evhttp_request* req, int64_t start,
-                                     int64_t end, bool include_scts) const {
-  JsonArray json_entries;
-  auto it(db_->ScanEntries(start));
-  for (int64_t i = start; i <= end; ++i) {
-    LoggedCertificate cert;
-
-    if (!it->GetNextEntry(&cert) || cert.sequence_number() != i) {
-      break;
-    }
-
-    string leaf_input;
-    string extra_data;
-    string sct_data;
-    if (!cert.SerializeForLeaf(&leaf_input) ||
-        !cert.SerializeExtraData(&extra_data) ||
-        (include_scts &&
-         Serializer::SerializeSCT(cert.sct(), &sct_data) != Serializer::OK)) {
-      LOG(WARNING) << "Failed to serialize entry @ " << i << ":\n"
-                   << cert.DebugString();
-      return output_->SendError(req, HTTP_INTERNAL, "Serialization failed.");
-    }
-
-    JsonObject json_entry;
-    json_entry.AddBase64("leaf_input", leaf_input);
-    json_entry.AddBase64("extra_data", extra_data);
-
-    if (include_scts) {
-      // This is non-standard, and currently only used by other SuperDuper log
-      // nodes when "following" to fetch data from each other:
-      json_entry.AddBase64("sct", sct_data);
-    }
-
-    json_entries.Add(&json_entry);
-  }
-
-  if (json_entries.Length() < 1) {
-    return output_->SendError(req, HTTP_BADREQUEST, "Entry not found.");
-  }
-
-  JsonObject json_reply;
-  json_reply.Add("entries", json_entries);
-
-  output_->SendJsonReply(req, HTTP_OK, json_reply);
-}
-
-
-void HttpHandler::BlockingAddChain(evhttp_request* req,
-                                   const shared_ptr<CertChain>& chain) {
-  SignedCertificateTimestamp sct;
-
-  AddChainReply(output_, req,
-                CHECK_NOTNULL(frontend_)
-                    ->QueueX509Entry(CHECK_NOTNULL(chain.get()), &sct),
-                sct);
-}
 
 bool HttpHandler::IsNodeStale() const {
   lock_guard<mutex> lock(mutex_);

--- a/cpp/server/handler.h
+++ b/cpp/server/handler.h
@@ -45,18 +45,20 @@ class HttpHandler {
               Proxy* proxy, ThreadPool* pool, libevent::Base* event_base);
   virtual ~HttpHandler();
 
+  // Register the handler methods with the server
   virtual void Add(libevent::HttpServer* server) = 0;
 
+  // Read requests
   virtual void GetEntries(evhttp_request* req) const = 0;
   virtual void GetRoots(evhttp_request* req) const = 0;
   virtual void GetProof(evhttp_request* req) const = 0;
   virtual void GetSTH(evhttp_request* req) const = 0;
   virtual void GetConsistency(evhttp_request* req) const = 0;
-  virtual void AddChain(evhttp_request* req) = 0;
-  virtual void AddPreChain(evhttp_request* req) = 0;
-
   virtual void BlockingGetEntries(evhttp_request* req, int64_t start,
                                   int64_t end, bool include_scts) const = 0;
+  // Write requests
+  virtual void AddChain(evhttp_request* req) = 0;
+  virtual void AddPreChain(evhttp_request* req) = 0;
   virtual void BlockingAddChain(
       evhttp_request* req, const std::shared_ptr<CertChain>& chain) = 0;
   virtual void BlockingAddPreChain(

--- a/cpp/server/handler.h
+++ b/cpp/server/handler.h
@@ -47,18 +47,18 @@ class HttpHandler {
 
   virtual void Add(libevent::HttpServer* server) = 0;
 
-  void GetEntries(evhttp_request* req) const;
-  void GetRoots(evhttp_request* req) const;
-  void GetProof(evhttp_request* req) const;
-  void GetSTH(evhttp_request* req) const;
-  void GetConsistency(evhttp_request* req) const;
-  void AddChain(evhttp_request* req);
+  virtual void GetEntries(evhttp_request* req) const = 0;
+  virtual void GetRoots(evhttp_request* req) const = 0;
+  virtual void GetProof(evhttp_request* req) const = 0;
+  virtual void GetSTH(evhttp_request* req) const = 0;
+  virtual void GetConsistency(evhttp_request* req) const = 0;
+  virtual void AddChain(evhttp_request* req) = 0;
   virtual void AddPreChain(evhttp_request* req) = 0;
 
-  void BlockingGetEntries(evhttp_request* req, int64_t start,
-                                  int64_t end, bool include_scts) const;
-  void BlockingAddChain(
-      evhttp_request* req, const std::shared_ptr<CertChain>& chain);
+  virtual void BlockingGetEntries(evhttp_request* req, int64_t start,
+                                  int64_t end, bool include_scts) const = 0;
+  virtual void BlockingAddChain(
+      evhttp_request* req, const std::shared_ptr<CertChain>& chain) = 0;
   virtual void BlockingAddPreChain(
       evhttp_request* req,
       const std::shared_ptr<PreCertChain>& chain) = 0;
@@ -74,6 +74,14 @@ class HttpHandler {
   void AddProxyWrappedHandler(
       libevent::HttpServer* server, const std::string& path,
       const libevent::HttpServer::HandlerCallback& local_handler);
+  std::multimap<std::string, std::string> ParseQuery(evhttp_request* req) const;
+  bool GetParam(const std::multimap<std::string, std::string>& query,
+                const std::string& param, std::string* value) const;
+  int64_t GetIntParam(const std::multimap<std::string, std::string>& query,
+                      const std::string& param) const;
+  bool GetBoolParam(const std::multimap<std::string, std::string>& query,
+                    const std::string& param) const;
+  int GetMaxLeafEntriesPerResponse() const;
 
   JsonOutput* const output_;
   LogLookup<LoggedCertificate>* const log_lookup_;

--- a/cpp/server/handler_factory.h
+++ b/cpp/server/handler_factory.h
@@ -1,0 +1,19 @@
+#ifndef CPP_SERVER_HANDLER_FACTORY_H_
+#define CPP_SERVER_HANDLER_FACTORY_H_
+
+#include "server/handler.h"
+
+namespace cert_trans {
+
+class HttpHandlerFactory {
+  public:
+   static HttpHandler* Create(
+       JsonOutput* json_output, LogLookup<LoggedCertificate>* log_lookup,
+       const ReadOnlyDatabase<LoggedCertificate>* db,
+       const ClusterStateController<LoggedCertificate>* controller,
+       const CertChecker* cert_checker, Frontend* frontend, Proxy* proxy,
+       ThreadPool* pool, libevent::Base* event_base);
+};
+} // namespace cert_trans
+
+#endif  // CPP_SERVER_HANDLER_FACTORY_V1_H_

--- a/cpp/server/handler_factory_v1.cc
+++ b/cpp/server/handler_factory_v1.cc
@@ -1,0 +1,38 @@
+#include <functional>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <server/handler_factory.h>
+#include <server/handler_v1.h>
+#include <map>
+#include <memory>
+#include <stdlib.h>
+
+#include "log/cert.h"
+#include "log/cert_checker.h"
+#include "log/cluster_state_controller.h"
+#include "log/frontend.h"
+#include "log/log_lookup.h"
+#include "log/logged_certificate.h"
+#include "monitoring/monitoring.h"
+#include "monitoring/latency.h"
+#include "server/json_output.h"
+#include "server/proxy.h"
+#include "util/json_wrapper.h"
+#include "util/thread_pool.h"
+
+using cert_trans::JsonOutput;
+using cert_trans::HttpHandler;
+using cert_trans::HttpHandlerFactory;
+using cert_trans::HttpHandlerV1;
+using cert_trans::LoggedCertificate;
+
+HttpHandler* HttpHandlerFactory::Create(
+    JsonOutput* json_output, LogLookup<LoggedCertificate>* log_lookup,
+    const ReadOnlyDatabase<LoggedCertificate>* db,
+    const ClusterStateController<LoggedCertificate>* controller,
+    const CertChecker* cert_checker, Frontend* frontend, Proxy* proxy,
+    ThreadPool* pool, libevent::Base* event_base) {
+  return new HttpHandlerV1(json_output, log_lookup, db, controller,
+                           cert_checker, frontend, proxy, pool, event_base);
+
+}

--- a/cpp/server/handler_factory_v2.cc
+++ b/cpp/server/handler_factory_v2.cc
@@ -1,0 +1,37 @@
+#include <functional>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <server/handler_factory.h>
+#include <server/handler_v2.h>
+#include <map>
+#include <memory>
+#include <stdlib.h>
+
+#include "log/cert.h"
+#include "log/cert_checker.h"
+#include "log/cluster_state_controller.h"
+#include "log/frontend.h"
+#include "log/log_lookup.h"
+#include "log/logged_certificate.h"
+#include "monitoring/monitoring.h"
+#include "monitoring/latency.h"
+#include "server/json_output.h"
+#include "server/proxy.h"
+#include "util/json_wrapper.h"
+#include "util/thread_pool.h"
+
+using cert_trans::JsonOutput;
+using cert_trans::HttpHandler;
+using cert_trans::HttpHandlerFactory;
+using cert_trans::HttpHandlerV2;
+using cert_trans::LoggedCertificate;
+
+HttpHandler* HttpHandlerFactory::Create(
+    JsonOutput* json_output, LogLookup<LoggedCertificate>* log_lookup,
+    const ReadOnlyDatabase<LoggedCertificate>* db,
+    const ClusterStateController<LoggedCertificate>* controller,
+    const CertChecker* cert_checker, Frontend* frontend, Proxy* proxy,
+    ThreadPool* pool, libevent::Base* event_base) {
+  return new HttpHandlerV2(json_output, log_lookup, db, controller,
+                           cert_checker, frontend, proxy, pool, event_base);
+}

--- a/cpp/server/handler_v1.cc
+++ b/cpp/server/handler_v1.cc
@@ -54,10 +54,9 @@ HttpHandlerV1::~HttpHandlerV1() {}
 
 void HttpHandlerV1::Add(libevent::HttpServer* server) {
   CHECK_NOTNULL(server);
-  // TODO(pphaneuf): An optional prefix might be nice?
   // TODO(pphaneuf): Find out which methods are CPU intensive enough
   // that they should be spun off to the thread pool.
-  string handler_path_prefix("/ct/v1/");
+  const string handler_path_prefix("/ct/v1/");
 
   AddProxyWrappedHandler(server, handler_path_prefix + "get-entries",
                          bind(&HttpHandler::GetEntries, this, _1));

--- a/cpp/server/handler_v1.cc
+++ b/cpp/server/handler_v1.cc
@@ -28,7 +28,9 @@ using cert_trans::JsonOutput;
 using cert_trans::LoggedCertificate;
 using cert_trans::Proxy;
 using cert_trans::ScopedLatency;
+using ct::ShortMerkleAuditProof;
 using ct::SignedCertificateTimestamp;
+using ct::SignedTreeHead;
 using std::bind;
 using std::function;
 using std::make_shared;
@@ -85,6 +87,218 @@ void HttpHandlerV1::Add(libevent::HttpServer* server) {
   }
 }
 
+void HttpHandlerV1::GetEntries(evhttp_request* req) const {
+  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
+    return output_->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
+  }
+
+  const multimap<string, string> query(ParseQuery(req));
+
+  const int64_t start(GetIntParam(query, "start"));
+  if (start < 0) {
+    return output_->SendError(req, HTTP_BADREQUEST,
+                              "Missing or invalid \"start\" parameter.");
+  }
+
+  int64_t end(GetIntParam(query, "end"));
+  if (end < start) {
+    return output_->SendError(req, HTTP_BADREQUEST,
+                              "Missing or invalid \"end\" parameter.");
+  }
+
+  // Limit the number of entries returned in a single request.
+  end = std::min(end, start + GetMaxLeafEntriesPerResponse());
+
+  // Sekrit parameter to indicate that SCTs should be included too.
+  // This is non-standard, and is only used internally by other log nodes when
+  // "following" nodes with more data.
+  const bool include_scts(GetBoolParam(query, "include_scts"));
+
+  BlockingGetEntries(req, start, end, include_scts);
+}
+
+
+void HttpHandlerV1::GetRoots(evhttp_request* req) const {
+  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
+    return output_->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
+  }
+
+  JsonArray roots;
+  multimap<string, const Cert*>::const_iterator it;
+  for (it = cert_checker_->GetTrustedCertificates().begin();
+       it != cert_checker_->GetTrustedCertificates().end(); ++it) {
+    string cert;
+    if (it->second->DerEncoding(&cert) != util::Status::OK) {
+      LOG(ERROR) << "Cert encoding failed";
+      return output_->SendError(req, HTTP_INTERNAL, "Serialisation failed.");
+    }
+    roots.AddBase64(cert);
+  }
+
+  JsonObject json_reply;
+  json_reply.Add("certificates", roots);
+
+  output_->SendJsonReply(req, HTTP_OK, json_reply);
+}
+
+
+void HttpHandlerV1::GetProof(evhttp_request* req) const {
+  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
+    return output_->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
+  }
+
+  const multimap<string, string> query(ParseQuery(req));
+
+  string b64_hash;
+  if (!GetParam(query, "hash", &b64_hash)) {
+    return output_->SendError(req, HTTP_BADREQUEST,
+                              "Missing or invalid \"hash\" parameter.");
+  }
+
+  const string hash(util::FromBase64(b64_hash.c_str()));
+  if (hash.empty()) {
+    return output_->SendError(req, HTTP_BADREQUEST,
+                              "Invalid \"hash\" parameter.");
+  }
+
+  const int64_t tree_size(GetIntParam(query, "tree_size"));
+  if (tree_size < 0 ||
+      static_cast<int64_t>(tree_size) > log_lookup_->GetSTH().tree_size()) {
+    return output_->SendError(req, HTTP_BADREQUEST,
+                              "Missing or invalid \"tree_size\" parameter.");
+  }
+
+  ShortMerkleAuditProof proof;
+  if (log_lookup_->AuditProof(hash, tree_size, &proof) !=
+      LogLookup<LoggedCertificate>::OK) {
+    return output_->SendError(req, HTTP_BADREQUEST, "Couldn't find hash.");
+  }
+
+  JsonArray json_audit;
+  for (int i = 0; i < proof.path_node_size(); ++i) {
+    json_audit.AddBase64(proof.path_node(i));
+  }
+
+  JsonObject json_reply;
+  json_reply.Add("leaf_index", proof.leaf_index());
+  json_reply.Add("audit_path", json_audit);
+
+  output_->SendJsonReply(req, HTTP_OK, json_reply);
+}
+
+
+void HttpHandlerV1::GetSTH(evhttp_request* req) const {
+  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
+    return output_->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
+  }
+
+  const SignedTreeHead& sth(log_lookup_->GetSTH());
+
+  VLOG(2) << "SignedTreeHead:\n" << sth.DebugString();
+
+  JsonObject json_reply;
+  json_reply.Add("tree_size", sth.tree_size());
+  json_reply.Add("timestamp", sth.timestamp());
+  json_reply.AddBase64("sha256_root_hash", sth.sha256_root_hash());
+  json_reply.Add("tree_head_signature", sth.signature());
+
+  VLOG(2) << "GetSTH:\n" << json_reply.DebugString();
+
+  output_->SendJsonReply(req, HTTP_OK, json_reply);
+}
+
+
+void HttpHandlerV1::GetConsistency(evhttp_request* req) const {
+  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
+    return output_->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
+  }
+
+  const multimap<string, string> query(ParseQuery(req));
+
+  const int64_t first(GetIntParam(query, "first"));
+  if (first < 0) {
+    return output_->SendError(req, HTTP_BADREQUEST,
+                              "Missing or invalid \"first\" parameter.");
+  }
+
+  const int64_t second(GetIntParam(query, "second"));
+  if (second < first) {
+    return output_->SendError(req, HTTP_BADREQUEST,
+                              "Missing or invalid \"second\" parameter.");
+  }
+
+  const vector<string> consistency(
+      log_lookup_->ConsistencyProof(first, second));
+  JsonArray json_cons;
+  for (vector<string>::const_iterator it = consistency.begin();
+       it != consistency.end(); ++it) {
+    json_cons.AddBase64(*it);
+  }
+
+  JsonObject json_reply;
+  json_reply.Add("consistency", json_cons);
+
+  output_->SendJsonReply(req, HTTP_OK, json_reply);
+}
+
+
+void HttpHandlerV1::AddChain(evhttp_request* req) {
+  const shared_ptr<CertChain> chain(make_shared<CertChain>());
+  if (!ExtractChain(output_, req, chain.get())) {
+    return;
+  }
+
+  pool_->Add(bind(&HttpHandler::BlockingAddChain, this, req, chain));
+}
+
+
+void HttpHandlerV1::BlockingGetEntries(evhttp_request* req, int64_t start,
+                                       int64_t end, bool include_scts) const {
+  JsonArray json_entries;
+  auto it(db_->ScanEntries(start));
+  for (int64_t i = start; i <= end; ++i) {
+    LoggedCertificate cert;
+
+    if (!it->GetNextEntry(&cert) || cert.sequence_number() != i) {
+      break;
+    }
+
+    string leaf_input;
+    string extra_data;
+    string sct_data;
+    if (!cert.SerializeForLeaf(&leaf_input) ||
+        !cert.SerializeExtraData(&extra_data) ||
+        (include_scts &&
+         Serializer::SerializeSCT(cert.sct(), &sct_data) != Serializer::OK)) {
+      LOG(WARNING) << "Failed to serialize entry @ " << i << ":\n"
+                   << cert.DebugString();
+      return output_->SendError(req, HTTP_INTERNAL, "Serialization failed.");
+    }
+
+    JsonObject json_entry;
+    json_entry.AddBase64("leaf_input", leaf_input);
+    json_entry.AddBase64("extra_data", extra_data);
+
+    if (include_scts) {
+      // This is non-standard, and currently only used by other SuperDuper log
+      // nodes when "following" to fetch data from each other:
+      json_entry.AddBase64("sct", sct_data);
+    }
+
+    json_entries.Add(&json_entry);
+  }
+
+  if (json_entries.Length() < 1) {
+    return output_->SendError(req, HTTP_BADREQUEST, "Entry not found.");
+  }
+
+  JsonObject json_reply;
+  json_reply.Add("entries", json_entries);
+
+  output_->SendJsonReply(req, HTTP_OK, json_reply);
+}
+
+
 void HttpHandlerV1::AddPreChain(evhttp_request* req) {
   const shared_ptr<PreCertChain> chain(make_shared<PreCertChain>());
   if (!ExtractChain(output_, req, chain.get())) {
@@ -94,6 +308,16 @@ void HttpHandlerV1::AddPreChain(evhttp_request* req) {
   pool_->Add(bind(&HttpHandlerV1::BlockingAddPreChain, this, req, chain));
 }
 
+
+void HttpHandlerV1::BlockingAddChain(evhttp_request* req,
+                                   const shared_ptr<CertChain>& chain) {
+  SignedCertificateTimestamp sct;
+
+  AddChainReply(output_, req,
+                CHECK_NOTNULL(frontend_)
+                    ->QueueX509Entry(CHECK_NOTNULL(chain.get()), &sct),
+                sct);
+}
 
 
 void HttpHandlerV1::BlockingAddPreChain(

--- a/cpp/server/handler_v1.cc
+++ b/cpp/server/handler_v1.cc
@@ -1,0 +1,109 @@
+#include "server/handler_v1.h"
+
+#include <functional>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <map>
+#include <memory>
+#include <stdlib.h>
+
+#include "log/cert.h"
+#include "log/cert_checker.h"
+#include "log/cluster_state_controller.h"
+#include "log/frontend.h"
+#include "log/log_lookup.h"
+#include "log/logged_certificate.h"
+#include "monitoring/monitoring.h"
+#include "monitoring/latency.h"
+#include "server/json_output.h"
+#include "server/proxy.h"
+#include "util/json_wrapper.h"
+#include "util/thread_pool.h"
+
+using cert_trans::CertChain;
+using cert_trans::CertChecker;
+using cert_trans::HttpHandler;
+using cert_trans::HttpHandlerV1;
+using cert_trans::JsonOutput;
+using cert_trans::LoggedCertificate;
+using cert_trans::Proxy;
+using cert_trans::ScopedLatency;
+using ct::SignedCertificateTimestamp;
+using std::bind;
+using std::function;
+using std::make_shared;
+using std::multimap;
+using std::mutex;
+using std::placeholders::_1;
+using std::shared_ptr;
+using std::string;
+using std::to_string;
+using std::unique_ptr;
+using std::vector;
+
+HttpHandlerV1::HttpHandlerV1(JsonOutput* json_output,
+              LogLookup<LoggedCertificate>* log_lookup,
+              const ReadOnlyDatabase<LoggedCertificate>* db,
+              const ClusterStateController<LoggedCertificate>* controller,
+              const CertChecker* cert_checker, Frontend* frontend,
+              Proxy* proxy, ThreadPool* pool, libevent::Base* event_base)
+    : HttpHandler(json_output, log_lookup, db, controller, cert_checker,
+                  frontend, proxy, pool, event_base) {};
+
+HttpHandlerV1::~HttpHandlerV1() {}
+
+void HttpHandlerV1::Add(libevent::HttpServer* server) {
+  CHECK_NOTNULL(server);
+  // TODO(pphaneuf): An optional prefix might be nice?
+  // TODO(pphaneuf): Find out which methods are CPU intensive enough
+  // that they should be spun off to the thread pool.
+  string handler_path_prefix("/ct/v1/");
+
+  AddProxyWrappedHandler(server, handler_path_prefix + "get-entries",
+                         bind(&HttpHandler::GetEntries, this, _1));
+  // TODO(alcutter): Support this for mirrors too
+  if (cert_checker_) {
+    // Don't really need to proxy this one, but may as well just to keep
+    // everything tidy:
+    AddProxyWrappedHandler(server, handler_path_prefix + "get-roots",
+                           bind(&HttpHandler::GetRoots, this, _1));
+  }
+  AddProxyWrappedHandler(server, handler_path_prefix + "get-proof-by-hash",
+                         bind(&HttpHandler::GetProof, this, _1));
+  AddProxyWrappedHandler(server, handler_path_prefix + "get-sth",
+                         bind(&HttpHandler::GetSTH, this, _1));
+  AddProxyWrappedHandler(server, handler_path_prefix + "get-sth-consistency",
+                         bind(&HttpHandler::GetConsistency, this, _1));
+
+  if (frontend_) {
+    // Proxy the add-* calls too, technically we could serve them, but a
+    // more up-to-date node will have a better chance of handling dupes
+    // correctly, rather than bloating the tree.
+    AddProxyWrappedHandler(server, handler_path_prefix + "add-chain",
+                           bind(&HttpHandler::AddChain, this, _1));
+    AddProxyWrappedHandler(server, handler_path_prefix + "add-pre-chain",
+                           bind(&HttpHandlerV1::AddPreChain, this, _1));
+  }
+}
+
+void HttpHandlerV1::AddPreChain(evhttp_request* req) {
+  const shared_ptr<PreCertChain> chain(make_shared<PreCertChain>());
+  if (!ExtractChain(output_, req, chain.get())) {
+    return;
+  }
+
+  pool_->Add(bind(&HttpHandlerV1::BlockingAddPreChain, this, req, chain));
+}
+
+
+
+void HttpHandlerV1::BlockingAddPreChain(
+    evhttp_request* req, const shared_ptr<PreCertChain>& chain) {
+  SignedCertificateTimestamp sct;
+
+  AddChainReply(output_, req,
+                CHECK_NOTNULL(frontend_)
+                    ->QueuePreCertEntry(CHECK_NOTNULL(chain.get()), &sct),
+                sct);
+}
+

--- a/cpp/server/handler_v1.cc
+++ b/cpp/server/handler_v1.cc
@@ -61,27 +61,27 @@ void HttpHandlerV1::Add(libevent::HttpServer* server) {
   const string handler_path_prefix("/ct/v1/");
 
   AddProxyWrappedHandler(server, handler_path_prefix + "get-entries",
-                         bind(&HttpHandler::GetEntries, this, _1));
+                         bind(&HttpHandlerV1::GetEntries, this, _1));
   // TODO(alcutter): Support this for mirrors too
   if (cert_checker_) {
     // Don't really need to proxy this one, but may as well just to keep
     // everything tidy:
     AddProxyWrappedHandler(server, handler_path_prefix + "get-roots",
-                           bind(&HttpHandler::GetRoots, this, _1));
+                           bind(&HttpHandlerV1::GetRoots, this, _1));
   }
   AddProxyWrappedHandler(server, handler_path_prefix + "get-proof-by-hash",
-                         bind(&HttpHandler::GetProof, this, _1));
+                         bind(&HttpHandlerV1::GetProof, this, _1));
   AddProxyWrappedHandler(server, handler_path_prefix + "get-sth",
-                         bind(&HttpHandler::GetSTH, this, _1));
+                         bind(&HttpHandlerV1::GetSTH, this, _1));
   AddProxyWrappedHandler(server, handler_path_prefix + "get-sth-consistency",
-                         bind(&HttpHandler::GetConsistency, this, _1));
+                         bind(&HttpHandlerV1::GetConsistency, this, _1));
 
   if (frontend_) {
     // Proxy the add-* calls too, technically we could serve them, but a
     // more up-to-date node will have a better chance of handling dupes
     // correctly, rather than bloating the tree.
     AddProxyWrappedHandler(server, handler_path_prefix + "add-chain",
-                           bind(&HttpHandler::AddChain, this, _1));
+                           bind(&HttpHandlerV1::AddChain, this, _1));
     AddProxyWrappedHandler(server, handler_path_prefix + "add-pre-chain",
                            bind(&HttpHandlerV1::AddPreChain, this, _1));
   }

--- a/cpp/server/handler_v1.h
+++ b/cpp/server/handler_v1.h
@@ -1,0 +1,31 @@
+#ifndef CERT_TRANS_SERVER_HANDLER_V1_H_
+#define CERT_TRANS_SERVER_HANDLER_V1_H_
+
+#include "server/handler.h"
+
+namespace cert_trans {
+
+class HttpHandlerV1 : public HttpHandler {
+ public:
+  HttpHandlerV1(JsonOutput* json_output,
+                LogLookup<LoggedCertificate>* log_lookup,
+                const ReadOnlyDatabase<LoggedCertificate>* db,
+                const ClusterStateController<LoggedCertificate>* controller,
+                const CertChecker* cert_checker, Frontend* frontend,
+                Proxy* proxy, ThreadPool* pool, libevent::Base* event_base);
+
+  ~HttpHandlerV1();
+
+  void Add(libevent::HttpServer* server) override;
+
+  void AddPreChain(evhttp_request* req) override;
+
+  void BlockingAddPreChain(
+      evhttp_request* req,
+      const std::shared_ptr<PreCertChain>& chain) override;
+
+  DISALLOW_COPY_AND_ASSIGN(HttpHandlerV1);
+};
+}  // namespace cert_trans
+
+#endif  // CERT_TRANS_SERVER_HANDLER_V1_H_

--- a/cpp/server/handler_v1.h
+++ b/cpp/server/handler_v1.h
@@ -16,11 +16,20 @@ class HttpHandlerV1 : public HttpHandler {
 
   ~HttpHandlerV1();
 
-  void Add(libevent::HttpServer* server) override;
-
-  void AddPreChain(evhttp_request* req) override;
-
-  void BlockingAddPreChain(
+  virtual void GetEntries(evhttp_request* req) const override;
+  virtual void GetRoots(evhttp_request* req) const override;
+  virtual void GetProof(evhttp_request* req) const override;
+  virtual void GetSTH(evhttp_request* req) const override;
+  virtual void GetConsistency(evhttp_request* req) const override;
+  virtual void AddChain(evhttp_request* req) override;
+  virtual void Add(libevent::HttpServer* server) override;
+  virtual void AddPreChain(evhttp_request* req) override;
+  virtual void BlockingGetEntries(evhttp_request* req, int64_t start,
+                                  int64_t end,
+                                  bool include_scts) const override;
+  virtual void BlockingAddChain(
+      evhttp_request* req, const std::shared_ptr<CertChain>& chain) override;
+  virtual void BlockingAddPreChain(
       evhttp_request* req,
       const std::shared_ptr<PreCertChain>& chain) override;
 

--- a/cpp/server/handler_v2.cc
+++ b/cpp/server/handler_v2.cc
@@ -54,10 +54,9 @@ HttpHandlerV2::~HttpHandlerV2() {}
 
 void HttpHandlerV2::Add(libevent::HttpServer* server) {
   CHECK_NOTNULL(server);
-  // TODO(pphaneuf): An optional prefix might be nice?
   // TODO(pphaneuf): Find out which methods are CPU intensive enough
   // that they should be spun off to the thread pool.
-  string handler_path_prefix("/ct/v2/");
+  const string handler_path_prefix("/ct/v2/");
 
   AddProxyWrappedHandler(server, handler_path_prefix + "get-entries",
                          bind(&HttpHandler::GetEntries, this, _1));

--- a/cpp/server/handler_v2.cc
+++ b/cpp/server/handler_v2.cc
@@ -1,0 +1,99 @@
+#include "server/handler_v2.h"
+
+#include <functional>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <map>
+#include <memory>
+#include <stdlib.h>
+
+#include "log/cert.h"
+#include "log/cert_checker.h"
+#include "log/cluster_state_controller.h"
+#include "log/frontend.h"
+#include "log/log_lookup.h"
+#include "log/logged_certificate.h"
+#include "monitoring/monitoring.h"
+#include "monitoring/latency.h"
+#include "server/json_output.h"
+#include "server/proxy.h"
+#include "util/json_wrapper.h"
+#include "util/thread_pool.h"
+
+using cert_trans::CertChain;
+using cert_trans::CertChecker;
+using cert_trans::HttpHandler;
+using cert_trans::HttpHandlerV2;
+using cert_trans::JsonOutput;
+using cert_trans::LoggedCertificate;
+using cert_trans::Proxy;
+using cert_trans::ScopedLatency;
+using ct::SignedCertificateTimestamp;
+using std::bind;
+using std::function;
+using std::make_shared;
+using std::multimap;
+using std::mutex;
+using std::placeholders::_1;
+using std::shared_ptr;
+using std::string;
+using std::to_string;
+using std::unique_ptr;
+using std::vector;
+
+HttpHandlerV2::HttpHandlerV2(JsonOutput* json_output,
+              LogLookup<LoggedCertificate>* log_lookup,
+              const ReadOnlyDatabase<LoggedCertificate>* db,
+              const ClusterStateController<LoggedCertificate>* controller,
+              const CertChecker* cert_checker, Frontend* frontend,
+              Proxy* proxy, ThreadPool* pool, libevent::Base* event_base)
+    : HttpHandler(json_output, log_lookup, db, controller, cert_checker,
+                  frontend, proxy, pool, event_base) {};
+
+HttpHandlerV2::~HttpHandlerV2() {}
+
+void HttpHandlerV2::Add(libevent::HttpServer* server) {
+  CHECK_NOTNULL(server);
+  // TODO(pphaneuf): An optional prefix might be nice?
+  // TODO(pphaneuf): Find out which methods are CPU intensive enough
+  // that they should be spun off to the thread pool.
+  string handler_path_prefix("/ct/v2/");
+
+  AddProxyWrappedHandler(server, handler_path_prefix + "get-entries",
+                         bind(&HttpHandler::GetEntries, this, _1));
+  // TODO(alcutter): Support this for mirrors too
+  if (cert_checker_) {
+    // Don't really need to proxy this one, but may as well just to keep
+    // everything tidy:
+    AddProxyWrappedHandler(server, handler_path_prefix + "get-roots",
+                           bind(&HttpHandler::GetRoots, this, _1));
+  }
+  AddProxyWrappedHandler(server, handler_path_prefix + "get-proof-by-hash",
+                         bind(&HttpHandler::GetProof, this, _1));
+  AddProxyWrappedHandler(server, handler_path_prefix + "get-sth",
+                         bind(&HttpHandler::GetSTH, this, _1));
+  AddProxyWrappedHandler(server, handler_path_prefix + "get-sth-consistency",
+                         bind(&HttpHandler::GetConsistency, this, _1));
+
+  if (frontend_) {
+    // Proxy the add-* calls too, technically we could serve them, but a
+    // more up-to-date node will have a better chance of handling dupes
+    // correctly, rather than bloating the tree.
+    AddProxyWrappedHandler(server, handler_path_prefix + "add-chain",
+                           bind(&HttpHandler::AddChain, this, _1));
+    AddProxyWrappedHandler(server, handler_path_prefix + "add-pre-chain",
+                           bind(&HttpHandlerV2::AddPreChain, this, _1));
+  }
+}
+
+void HttpHandlerV2::AddPreChain(evhttp_request* req) {
+  output_->SendError(req, HTTP_NOTIMPLEMENTED, "Not yet implemented");
+}
+
+
+
+void HttpHandlerV2::BlockingAddPreChain(
+    evhttp_request* req, const shared_ptr<PreCertChain>& chain) {
+  output_->SendError(req, HTTP_NOTIMPLEMENTED, "Not yet implemented");
+}
+

--- a/cpp/server/handler_v2.cc
+++ b/cpp/server/handler_v2.cc
@@ -55,214 +55,38 @@ HttpHandlerV2::HttpHandlerV2(JsonOutput* json_output,
 HttpHandlerV2::~HttpHandlerV2() {}
 
 void HttpHandlerV2::GetEntries(evhttp_request* req) const {
-  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
-    return output_->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
-  }
-
-  const multimap<string, string> query(ParseQuery(req));
-
-  const int64_t start(GetIntParam(query, "start"));
-  if (start < 0) {
-    return output_->SendError(req, HTTP_BADREQUEST,
-                              "Missing or invalid \"start\" parameter.");
-  }
-
-  int64_t end(GetIntParam(query, "end"));
-  if (end < start) {
-    return output_->SendError(req, HTTP_BADREQUEST,
-                              "Missing or invalid \"end\" parameter.");
-  }
-
-  // Limit the number of entries returned in a single request.
-  end = std::min(end, start + GetMaxLeafEntriesPerResponse());
-
-  // Sekrit parameter to indicate that SCTs should be included too.
-  // This is non-standard, and is only used internally by other log nodes when
-  // "following" nodes with more data.
-  const bool include_scts(GetBoolParam(query, "include_scts"));
-
-  BlockingGetEntries(req, start, end, include_scts);
+  output_->SendError(req, HTTP_NOTIMPLEMENTED, "Not yet implemented");
 }
 
 
 void HttpHandlerV2::GetRoots(evhttp_request* req) const {
-  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
-    return output_->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
-  }
-
-  JsonArray roots;
-  multimap<string, const Cert*>::const_iterator it;
-  for (it = cert_checker_->GetTrustedCertificates().begin();
-       it != cert_checker_->GetTrustedCertificates().end(); ++it) {
-    string cert;
-    if (it->second->DerEncoding(&cert) != util::Status::OK) {
-      LOG(ERROR) << "Cert encoding failed";
-      return output_->SendError(req, HTTP_INTERNAL, "Serialisation failed.");
-    }
-    roots.AddBase64(cert);
-  }
-
-  JsonObject json_reply;
-  json_reply.Add("certificates", roots);
-
-  output_->SendJsonReply(req, HTTP_OK, json_reply);
+  output_->SendError(req, HTTP_NOTIMPLEMENTED, "Not yet implemented");
 }
 
 
 void HttpHandlerV2::GetProof(evhttp_request* req) const {
-  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
-    return output_->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
-  }
-
-  const multimap<string, string> query(ParseQuery(req));
-
-  string b64_hash;
-  if (!GetParam(query, "hash", &b64_hash)) {
-    return output_->SendError(req, HTTP_BADREQUEST,
-                              "Missing or invalid \"hash\" parameter.");
-  }
-
-  const string hash(util::FromBase64(b64_hash.c_str()));
-  if (hash.empty()) {
-    return output_->SendError(req, HTTP_BADREQUEST,
-                              "Invalid \"hash\" parameter.");
-  }
-
-  const int64_t tree_size(GetIntParam(query, "tree_size"));
-  if (tree_size < 0 ||
-      static_cast<int64_t>(tree_size) > log_lookup_->GetSTH().tree_size()) {
-    return output_->SendError(req, HTTP_BADREQUEST,
-                              "Missing or invalid \"tree_size\" parameter.");
-  }
-
-  ShortMerkleAuditProof proof;
-  if (log_lookup_->AuditProof(hash, tree_size, &proof) !=
-      LogLookup<LoggedCertificate>::OK) {
-    return output_->SendError(req, HTTP_BADREQUEST, "Couldn't find hash.");
-  }
-
-  JsonArray json_audit;
-  for (int i = 0; i < proof.path_node_size(); ++i) {
-    json_audit.AddBase64(proof.path_node(i));
-  }
-
-  JsonObject json_reply;
-  json_reply.Add("leaf_index", proof.leaf_index());
-  json_reply.Add("audit_path", json_audit);
-
-  output_->SendJsonReply(req, HTTP_OK, json_reply);
+  output_->SendError(req, HTTP_NOTIMPLEMENTED, "Not yet implemented");
 }
 
 
 void HttpHandlerV2::GetSTH(evhttp_request* req) const {
-  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
-    return output_->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
-  }
-
-  const SignedTreeHead& sth(log_lookup_->GetSTH());
-
-  VLOG(2) << "SignedTreeHead:\n" << sth.DebugString();
-
-  JsonObject json_reply;
-  json_reply.Add("tree_size", sth.tree_size());
-  json_reply.Add("timestamp", sth.timestamp());
-  json_reply.AddBase64("sha256_root_hash", sth.sha256_root_hash());
-  json_reply.Add("tree_head_signature", sth.signature());
-
-  VLOG(2) << "GetSTH:\n" << json_reply.DebugString();
-
-  output_->SendJsonReply(req, HTTP_OK, json_reply);
+  output_->SendError(req, HTTP_NOTIMPLEMENTED, "Not yet implemented");
 }
 
 
 void HttpHandlerV2::GetConsistency(evhttp_request* req) const {
-  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
-    return output_->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
-  }
-
-  const multimap<string, string> query(ParseQuery(req));
-
-  const int64_t first(GetIntParam(query, "first"));
-  if (first < 0) {
-    return output_->SendError(req, HTTP_BADREQUEST,
-                              "Missing or invalid \"first\" parameter.");
-  }
-
-  const int64_t second(GetIntParam(query, "second"));
-  if (second < first) {
-    return output_->SendError(req, HTTP_BADREQUEST,
-                              "Missing or invalid \"second\" parameter.");
-  }
-
-  const vector<string> consistency(
-      log_lookup_->ConsistencyProof(first, second));
-  JsonArray json_cons;
-  for (vector<string>::const_iterator it = consistency.begin();
-       it != consistency.end(); ++it) {
-    json_cons.AddBase64(*it);
-  }
-
-  JsonObject json_reply;
-  json_reply.Add("consistency", json_cons);
-
-  output_->SendJsonReply(req, HTTP_OK, json_reply);
+  output_->SendError(req, HTTP_NOTIMPLEMENTED, "Not yet implemented");
 }
 
 
 void HttpHandlerV2::AddChain(evhttp_request* req) {
-  const shared_ptr<CertChain> chain(make_shared<CertChain>());
-  if (!ExtractChain(output_, req, chain.get())) {
-    return;
-  }
-
-  pool_->Add(bind(&HttpHandler::BlockingAddChain, this, req, chain));
+  output_->SendError(req, HTTP_NOTIMPLEMENTED, "Not yet implemented");
 }
 
 
 void HttpHandlerV2::BlockingGetEntries(evhttp_request* req, int64_t start,
                                        int64_t end, bool include_scts) const {
-  JsonArray json_entries;
-  auto it(db_->ScanEntries(start));
-  for (int64_t i = start; i <= end; ++i) {
-    LoggedCertificate cert;
-
-    if (!it->GetNextEntry(&cert) || cert.sequence_number() != i) {
-      break;
-    }
-
-    string leaf_input;
-    string extra_data;
-    string sct_data;
-    if (!cert.SerializeForLeaf(&leaf_input) ||
-        !cert.SerializeExtraData(&extra_data) ||
-        (include_scts &&
-         Serializer::SerializeSCT(cert.sct(), &sct_data) != Serializer::OK)) {
-      LOG(WARNING) << "Failed to serialize entry @ " << i << ":\n"
-                   << cert.DebugString();
-      return output_->SendError(req, HTTP_INTERNAL, "Serialization failed.");
-    }
-
-    JsonObject json_entry;
-    json_entry.AddBase64("leaf_input", leaf_input);
-    json_entry.AddBase64("extra_data", extra_data);
-
-    if (include_scts) {
-      // This is non-standard, and currently only used by other SuperDuper log
-      // nodes when "following" to fetch data from each other:
-      json_entry.AddBase64("sct", sct_data);
-    }
-
-    json_entries.Add(&json_entry);
-  }
-
-  if (json_entries.Length() < 1) {
-    return output_->SendError(req, HTTP_BADREQUEST, "Entry not found.");
-  }
-
-  JsonObject json_reply;
-  json_reply.Add("entries", json_entries);
-
-  output_->SendJsonReply(req, HTTP_OK, json_reply);
+  output_->SendError(req, HTTP_NOTIMPLEMENTED, "Not yet implemented");
 }
 
 
@@ -273,27 +97,27 @@ void HttpHandlerV2::Add(libevent::HttpServer* server) {
   const string handler_path_prefix("/ct/v2/");
 
   AddProxyWrappedHandler(server, handler_path_prefix + "get-entries",
-                         bind(&HttpHandler::GetEntries, this, _1));
+                         bind(&HttpHandlerV2::GetEntries, this, _1));
   // TODO(alcutter): Support this for mirrors too
   if (cert_checker_) {
     // Don't really need to proxy this one, but may as well just to keep
     // everything tidy:
     AddProxyWrappedHandler(server, handler_path_prefix + "get-roots",
-                           bind(&HttpHandler::GetRoots, this, _1));
+                           bind(&HttpHandlerV2::GetRoots, this, _1));
   }
   AddProxyWrappedHandler(server, handler_path_prefix + "get-proof-by-hash",
-                         bind(&HttpHandler::GetProof, this, _1));
+                         bind(&HttpHandlerV2::GetProof, this, _1));
   AddProxyWrappedHandler(server, handler_path_prefix + "get-sth",
-                         bind(&HttpHandler::GetSTH, this, _1));
+                         bind(&HttpHandlerV2::GetSTH, this, _1));
   AddProxyWrappedHandler(server, handler_path_prefix + "get-sth-consistency",
-                         bind(&HttpHandler::GetConsistency, this, _1));
+                         bind(&HttpHandlerV2::GetConsistency, this, _1));
 
   if (frontend_) {
     // Proxy the add-* calls too, technically we could serve them, but a
     // more up-to-date node will have a better chance of handling dupes
     // correctly, rather than bloating the tree.
     AddProxyWrappedHandler(server, handler_path_prefix + "add-chain",
-                           bind(&HttpHandler::AddChain, this, _1));
+                           bind(&HttpHandlerV2::AddChain, this, _1));
     AddProxyWrappedHandler(server, handler_path_prefix + "add-pre-chain",
                            bind(&HttpHandlerV2::AddPreChain, this, _1));
   }
@@ -306,12 +130,7 @@ void HttpHandlerV2::AddPreChain(evhttp_request* req) {
 
 void HttpHandlerV2::BlockingAddChain(evhttp_request* req,
                                      const shared_ptr<CertChain>& chain) {
-  SignedCertificateTimestamp sct;
-
-  AddChainReply(output_, req,
-                CHECK_NOTNULL(frontend_)
-                    ->QueueX509Entry(CHECK_NOTNULL(chain.get()), &sct),
-                sct);
+  output_->SendError(req, HTTP_NOTIMPLEMENTED, "Not yet implemented");
 }
 
 

--- a/cpp/server/handler_v2.cc
+++ b/cpp/server/handler_v2.cc
@@ -28,7 +28,9 @@ using cert_trans::JsonOutput;
 using cert_trans::LoggedCertificate;
 using cert_trans::Proxy;
 using cert_trans::ScopedLatency;
+using ct::ShortMerkleAuditProof;
 using ct::SignedCertificateTimestamp;
+using ct::SignedTreeHead;
 using std::bind;
 using std::function;
 using std::make_shared;
@@ -51,6 +53,218 @@ HttpHandlerV2::HttpHandlerV2(JsonOutput* json_output,
                   frontend, proxy, pool, event_base) {};
 
 HttpHandlerV2::~HttpHandlerV2() {}
+
+void HttpHandlerV2::GetEntries(evhttp_request* req) const {
+  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
+    return output_->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
+  }
+
+  const multimap<string, string> query(ParseQuery(req));
+
+  const int64_t start(GetIntParam(query, "start"));
+  if (start < 0) {
+    return output_->SendError(req, HTTP_BADREQUEST,
+                              "Missing or invalid \"start\" parameter.");
+  }
+
+  int64_t end(GetIntParam(query, "end"));
+  if (end < start) {
+    return output_->SendError(req, HTTP_BADREQUEST,
+                              "Missing or invalid \"end\" parameter.");
+  }
+
+  // Limit the number of entries returned in a single request.
+  end = std::min(end, start + GetMaxLeafEntriesPerResponse());
+
+  // Sekrit parameter to indicate that SCTs should be included too.
+  // This is non-standard, and is only used internally by other log nodes when
+  // "following" nodes with more data.
+  const bool include_scts(GetBoolParam(query, "include_scts"));
+
+  BlockingGetEntries(req, start, end, include_scts);
+}
+
+
+void HttpHandlerV2::GetRoots(evhttp_request* req) const {
+  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
+    return output_->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
+  }
+
+  JsonArray roots;
+  multimap<string, const Cert*>::const_iterator it;
+  for (it = cert_checker_->GetTrustedCertificates().begin();
+       it != cert_checker_->GetTrustedCertificates().end(); ++it) {
+    string cert;
+    if (it->second->DerEncoding(&cert) != util::Status::OK) {
+      LOG(ERROR) << "Cert encoding failed";
+      return output_->SendError(req, HTTP_INTERNAL, "Serialisation failed.");
+    }
+    roots.AddBase64(cert);
+  }
+
+  JsonObject json_reply;
+  json_reply.Add("certificates", roots);
+
+  output_->SendJsonReply(req, HTTP_OK, json_reply);
+}
+
+
+void HttpHandlerV2::GetProof(evhttp_request* req) const {
+  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
+    return output_->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
+  }
+
+  const multimap<string, string> query(ParseQuery(req));
+
+  string b64_hash;
+  if (!GetParam(query, "hash", &b64_hash)) {
+    return output_->SendError(req, HTTP_BADREQUEST,
+                              "Missing or invalid \"hash\" parameter.");
+  }
+
+  const string hash(util::FromBase64(b64_hash.c_str()));
+  if (hash.empty()) {
+    return output_->SendError(req, HTTP_BADREQUEST,
+                              "Invalid \"hash\" parameter.");
+  }
+
+  const int64_t tree_size(GetIntParam(query, "tree_size"));
+  if (tree_size < 0 ||
+      static_cast<int64_t>(tree_size) > log_lookup_->GetSTH().tree_size()) {
+    return output_->SendError(req, HTTP_BADREQUEST,
+                              "Missing or invalid \"tree_size\" parameter.");
+  }
+
+  ShortMerkleAuditProof proof;
+  if (log_lookup_->AuditProof(hash, tree_size, &proof) !=
+      LogLookup<LoggedCertificate>::OK) {
+    return output_->SendError(req, HTTP_BADREQUEST, "Couldn't find hash.");
+  }
+
+  JsonArray json_audit;
+  for (int i = 0; i < proof.path_node_size(); ++i) {
+    json_audit.AddBase64(proof.path_node(i));
+  }
+
+  JsonObject json_reply;
+  json_reply.Add("leaf_index", proof.leaf_index());
+  json_reply.Add("audit_path", json_audit);
+
+  output_->SendJsonReply(req, HTTP_OK, json_reply);
+}
+
+
+void HttpHandlerV2::GetSTH(evhttp_request* req) const {
+  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
+    return output_->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
+  }
+
+  const SignedTreeHead& sth(log_lookup_->GetSTH());
+
+  VLOG(2) << "SignedTreeHead:\n" << sth.DebugString();
+
+  JsonObject json_reply;
+  json_reply.Add("tree_size", sth.tree_size());
+  json_reply.Add("timestamp", sth.timestamp());
+  json_reply.AddBase64("sha256_root_hash", sth.sha256_root_hash());
+  json_reply.Add("tree_head_signature", sth.signature());
+
+  VLOG(2) << "GetSTH:\n" << json_reply.DebugString();
+
+  output_->SendJsonReply(req, HTTP_OK, json_reply);
+}
+
+
+void HttpHandlerV2::GetConsistency(evhttp_request* req) const {
+  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
+    return output_->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
+  }
+
+  const multimap<string, string> query(ParseQuery(req));
+
+  const int64_t first(GetIntParam(query, "first"));
+  if (first < 0) {
+    return output_->SendError(req, HTTP_BADREQUEST,
+                              "Missing or invalid \"first\" parameter.");
+  }
+
+  const int64_t second(GetIntParam(query, "second"));
+  if (second < first) {
+    return output_->SendError(req, HTTP_BADREQUEST,
+                              "Missing or invalid \"second\" parameter.");
+  }
+
+  const vector<string> consistency(
+      log_lookup_->ConsistencyProof(first, second));
+  JsonArray json_cons;
+  for (vector<string>::const_iterator it = consistency.begin();
+       it != consistency.end(); ++it) {
+    json_cons.AddBase64(*it);
+  }
+
+  JsonObject json_reply;
+  json_reply.Add("consistency", json_cons);
+
+  output_->SendJsonReply(req, HTTP_OK, json_reply);
+}
+
+
+void HttpHandlerV2::AddChain(evhttp_request* req) {
+  const shared_ptr<CertChain> chain(make_shared<CertChain>());
+  if (!ExtractChain(output_, req, chain.get())) {
+    return;
+  }
+
+  pool_->Add(bind(&HttpHandler::BlockingAddChain, this, req, chain));
+}
+
+
+void HttpHandlerV2::BlockingGetEntries(evhttp_request* req, int64_t start,
+                                       int64_t end, bool include_scts) const {
+  JsonArray json_entries;
+  auto it(db_->ScanEntries(start));
+  for (int64_t i = start; i <= end; ++i) {
+    LoggedCertificate cert;
+
+    if (!it->GetNextEntry(&cert) || cert.sequence_number() != i) {
+      break;
+    }
+
+    string leaf_input;
+    string extra_data;
+    string sct_data;
+    if (!cert.SerializeForLeaf(&leaf_input) ||
+        !cert.SerializeExtraData(&extra_data) ||
+        (include_scts &&
+         Serializer::SerializeSCT(cert.sct(), &sct_data) != Serializer::OK)) {
+      LOG(WARNING) << "Failed to serialize entry @ " << i << ":\n"
+                   << cert.DebugString();
+      return output_->SendError(req, HTTP_INTERNAL, "Serialization failed.");
+    }
+
+    JsonObject json_entry;
+    json_entry.AddBase64("leaf_input", leaf_input);
+    json_entry.AddBase64("extra_data", extra_data);
+
+    if (include_scts) {
+      // This is non-standard, and currently only used by other SuperDuper log
+      // nodes when "following" to fetch data from each other:
+      json_entry.AddBase64("sct", sct_data);
+    }
+
+    json_entries.Add(&json_entry);
+  }
+
+  if (json_entries.Length() < 1) {
+    return output_->SendError(req, HTTP_BADREQUEST, "Entry not found.");
+  }
+
+  JsonObject json_reply;
+  json_reply.Add("entries", json_entries);
+
+  output_->SendJsonReply(req, HTTP_OK, json_reply);
+}
+
 
 void HttpHandlerV2::Add(libevent::HttpServer* server) {
   CHECK_NOTNULL(server);
@@ -89,6 +303,16 @@ void HttpHandlerV2::AddPreChain(evhttp_request* req) {
   output_->SendError(req, HTTP_NOTIMPLEMENTED, "Not yet implemented");
 }
 
+
+void HttpHandlerV2::BlockingAddChain(evhttp_request* req,
+                                     const shared_ptr<CertChain>& chain) {
+  SignedCertificateTimestamp sct;
+
+  AddChainReply(output_, req,
+                CHECK_NOTNULL(frontend_)
+                    ->QueueX509Entry(CHECK_NOTNULL(chain.get()), &sct),
+                sct);
+}
 
 
 void HttpHandlerV2::BlockingAddPreChain(

--- a/cpp/server/handler_v2.h
+++ b/cpp/server/handler_v2.h
@@ -1,0 +1,32 @@
+#ifndef CERT_TRANS_SERVER_HANDLER_V2_H_
+#define CERT_TRANS_SERVER_HANDLER_V2_H_
+
+#include "server/handler.h"
+
+namespace cert_trans {
+
+class HttpHandlerV2 : public HttpHandler {
+ public:
+
+  HttpHandlerV2(JsonOutput* json_output,
+                LogLookup<LoggedCertificate>* log_lookup,
+                const ReadOnlyDatabase<LoggedCertificate>* db,
+                const ClusterStateController<LoggedCertificate>* controller,
+                const CertChecker* cert_checker, Frontend* frontend,
+                Proxy* proxy, ThreadPool* pool, libevent::Base* event_base);
+
+  ~HttpHandlerV2();
+
+  void Add(libevent::HttpServer* server) override;
+
+  void AddPreChain(evhttp_request* req) override;
+
+  void BlockingAddPreChain(
+      evhttp_request* req,
+      const std::shared_ptr<PreCertChain>& chain) override;
+
+  DISALLOW_COPY_AND_ASSIGN(HttpHandlerV2);
+};
+}  // namespace cert_trans
+
+#endif  // CERT_TRANS_SERVER_HANDLER_V2_H_

--- a/cpp/server/handler_v2.h
+++ b/cpp/server/handler_v2.h
@@ -17,11 +17,20 @@ class HttpHandlerV2 : public HttpHandler {
 
   ~HttpHandlerV2();
 
-  void Add(libevent::HttpServer* server) override;
-
-  void AddPreChain(evhttp_request* req) override;
-
-  void BlockingAddPreChain(
+  virtual void GetEntries(evhttp_request* req) const override;
+  virtual void GetRoots(evhttp_request* req) const override;
+  virtual void GetProof(evhttp_request* req) const override;
+  virtual void GetSTH(evhttp_request* req) const override;
+  virtual void GetConsistency(evhttp_request* req) const override;
+  virtual void AddChain(evhttp_request* req) override;
+  virtual void Add(libevent::HttpServer* server) override;
+  virtual void AddPreChain(evhttp_request* req) override;
+  virtual void BlockingGetEntries(evhttp_request* req, int64_t start,
+                                  int64_t end,
+                                  bool include_scts) const override;
+  virtual void BlockingAddChain(
+      evhttp_request* req, const std::shared_ptr<CertChain>& chain) override;
+  virtual void BlockingAddPreChain(
       evhttp_request* req,
       const std::shared_ptr<PreCertChain>& chain) override;
 

--- a/cpp/server/server.h
+++ b/cpp/server/server.h
@@ -27,6 +27,7 @@
 #include "monitoring/latency.h"
 #include "monitoring/monitoring.h"
 #include "monitoring/registry.h"
+#include "server/handler_factory.h"
 #include "server/json_output.h"
 #include "server/proxy.h"
 #include "util/etcd.h"
@@ -333,10 +334,10 @@ void Server<Logged>::Initialise(bool is_mirror) {
                 bind(&ClusterStateController<LoggedCertificate>::GetFreshNodes,
                      cluster_controller_.get()),
                 url_fetcher_, &http_pool_));
-  handler_.reset(new HttpHandler(&json_output_, log_lookup_.get(), db_,
-                                 cluster_controller_.get(), cert_checker_,
-                                 frontend_.get(), proxy_.get(), &http_pool_,
-                                 event_base_.get()));
+  handler_.reset(HttpHandlerFactory::Create(
+      &json_output_, log_lookup_.get(), db_, cluster_controller_.get(),
+      cert_checker_, frontend_.get(), proxy_.get(), &http_pool_,
+      event_base_.get()));
 
   handler_->Add(&http_server_);
 }


### PR DESCRIPTION
This is my straw man proposal for supporting v1 and v2 handlers. There are other possible approaches, which would isolate handler implementations more.

Pulls out a 'server' library to share between ct-server and ct-mirror. Builds two binary versions with a different set of handlers, which have an abstract base and share all but pre-certificate submit at the moment. Avoids conditional compilation or configure time switches.
