### PR TITLE
Start to migrate away from using Cert::Status

### DIFF
--- a/cpp/log/cert.cc
+++ b/cpp/log/cert.cc
@@ -233,8 +233,8 @@ string Cert::PrintTime(ASN1_TIME* when) {
 }
 
 
-Cert::Status Cert::IsIdenticalTo(const Cert& other) const {
-  return X509_cmp(x509_, other.x509_) == 0 ? TRUE : FALSE;
+StatusOr<bool> Cert::IsIdenticalTo(const Cert& other) const {
+  return StatusOr<bool>(X509_cmp(x509_, other.x509_) == 0 ? true : false);
 }
 
 

--- a/cpp/log/cert.h
+++ b/cpp/log/cert.h
@@ -8,6 +8,9 @@
 #include <vector>
 
 #include "base/macros.h"
+#include "util/statusor.h"
+
+using util::StatusOr;
 
 namespace cert_trans {
 
@@ -72,7 +75,7 @@ class Cert {
   std::string PrintNotAfter() const;
   std::string PrintSignatureAlgorithm() const;
 
-  Status IsIdenticalTo(const Cert& other) const;
+  StatusOr<bool> IsIdenticalTo(const Cert& other) const;
 
   // Returns TRUE if the extension is present.
   // Returns FALSE if the extension is not present.

--- a/cpp/log/cert.h
+++ b/cpp/log/cert.h
@@ -109,7 +109,7 @@ class Cert {
   // or some other unknown error occurred while parsing the extensions.
   // NID must be either an OpenSSL built-in NID, or one registered by the user
   // with OBJ_create. (See log/ct_extensions.h for sample code.)
-  Status HasExtendedKeyUsage(int key_usage_nid) const;
+  StatusOr<bool> HasExtendedKeyUsage(int key_usage_nid) const;
 
   // Returns TRUE if the Cert's issuer matches |issuer|.
   // Returns FALSE if there is no match.

--- a/cpp/log/cert.h
+++ b/cpp/log/cert.h
@@ -99,7 +99,7 @@ class Cert {
   // or is present but could not be decoded.
   // Returns ERROR if the cert is not loaded or some other unknown error
   // occurred while parsing the extensions.
-  Status HasBasicConstraintCATrue() const;
+  StatusOr<bool> HasBasicConstraintCATrue() const;
 
   // Returns TRUE if extendedKeyUsage extension is present and the specified
   // key usage is set.

--- a/cpp/log/cert_checker.cc
+++ b/cpp/log/cert_checker.cc
@@ -345,12 +345,12 @@ CertChecker::CertVerifyResult CertChecker::IsTrusted(
            cand_range.first;
        it != cand_range.second; ++it) {
     const Cert* cand = it->second;
-    Cert::Status matches = cert.IsIdenticalTo(*cand);
-    if (matches != Cert::TRUE && matches != Cert::FALSE) {
+    StatusOr<bool> matches = cert.IsIdenticalTo(*cand);
+    if (!matches.ok()) {
       LOG(ERROR) << "Cert comparison failed";
       return INTERNAL_ERROR;
     }
-    if (matches == Cert::TRUE) {
+    if (matches.ValueOrDie() == true) {
       return OK;
     }
   }

--- a/cpp/log/cert_checker_test.cc
+++ b/cpp/log/cert_checker_test.cc
@@ -336,7 +336,9 @@ TEST_F(CertCheckerTest, AcceptNoBasicConstraintsAndMd2) {
   Cert ca(ca_pem);
   // Verify testdata properties: CA is legacy root.
   ASSERT_EQ("md2WithRSAEncryption", ca.PrintSignatureAlgorithm());
-  ASSERT_EQ(Cert::FALSE, ca.HasBasicConstraintCATrue());
+  StatusOr<bool> has_ca_constraint = ca.HasBasicConstraintCATrue();
+  ASSERT_TRUE(has_ca_constraint.ok() &&
+              has_ca_constraint.ValueOrDie() == false);
 
   string chain_pem;
   ASSERT_TRUE(util::ReadTextFile(cert_dir_ + "/" + kNoBCChain, &chain_pem));
@@ -371,7 +373,8 @@ TEST_F(CertCheckerTest, DontAcceptMD2) {
   ASSERT_TRUE(chain.IsLoaded());
   // Verify testdata properties: chain terminates in an MD2 intermediate.
   ASSERT_EQ(Cert::FALSE, chain.LastCert()->IsSelfSigned());
-  ASSERT_EQ(Cert::TRUE, chain.LastCert()->HasBasicConstraintCATrue());
+  StatusOr<bool> last_ca_status = chain.LastCert()->HasBasicConstraintCATrue();
+  ASSERT_TRUE(last_ca_status.ok() && last_ca_status.ValueOrDie() == true);
   ASSERT_EQ("md2WithRSAEncryption",
             chain.LastCert()->PrintSignatureAlgorithm());
 

--- a/cpp/log/cert_test.cc
+++ b/cpp/log/cert_test.cc
@@ -386,8 +386,10 @@ TEST_F(CertTest, Extensions) {
 
   EXPECT_EQ(Cert::TRUE, pre.HasCriticalExtension(cert_trans::NID_ctPoison));
 
-  EXPECT_EQ(Cert::FALSE, leaf.HasBasicConstraintCATrue());
-  EXPECT_EQ(Cert::TRUE, ca.HasBasicConstraintCATrue());
+  StatusOr<bool> leaf_ca_status = leaf.HasBasicConstraintCATrue();
+  EXPECT_TRUE(leaf_ca_status.ok() && leaf_ca_status.ValueOrDie() == false);
+  StatusOr<bool> ca_ca_status = ca.HasBasicConstraintCATrue();
+  EXPECT_TRUE(ca_ca_status.ok() && ca_ca_status.ValueOrDie() == true);
 
   StatusOr<bool> ca_pre_status = ca_pre.HasExtendedKeyUsage(
       cert_trans::NID_ctPrecertificateSigning);

--- a/cpp/log/cert_test.cc
+++ b/cpp/log/cert_test.cc
@@ -361,9 +361,15 @@ TEST_F(CertTest, TestUnsupportedAlgorithm) {
 TEST_F(CertTest, Identical) {
   Cert leaf(leaf_pem_);
   Cert ca(ca_pem_);
-  EXPECT_EQ(Cert::TRUE, leaf.IsIdenticalTo(leaf));
-  EXPECT_EQ(Cert::FALSE, leaf.IsIdenticalTo(ca));
-  EXPECT_EQ(Cert::FALSE, ca.IsIdenticalTo(leaf));
+
+  StatusOr<bool> leaf_leaf_status = leaf.IsIdenticalTo(leaf);
+  EXPECT_TRUE(leaf_leaf_status.ok() && leaf_leaf_status.ValueOrDie());
+
+  StatusOr<bool> leaf_ca_status = leaf.IsIdenticalTo(ca);
+  EXPECT_TRUE(leaf_ca_status.ok() && !leaf_ca_status.ValueOrDie());
+
+  StatusOr<bool> ca_leaf_status = ca.IsIdenticalTo(leaf);
+  EXPECT_TRUE(ca_leaf_status.ok() && !ca_leaf_status.ValueOrDie());
 }
 
 TEST_F(CertTest, Extensions) {

--- a/cpp/log/cert_test.cc
+++ b/cpp/log/cert_test.cc
@@ -389,8 +389,9 @@ TEST_F(CertTest, Extensions) {
   EXPECT_EQ(Cert::FALSE, leaf.HasBasicConstraintCATrue());
   EXPECT_EQ(Cert::TRUE, ca.HasBasicConstraintCATrue());
 
-  EXPECT_EQ(Cert::TRUE, ca_pre.HasExtendedKeyUsage(
-                            cert_trans::NID_ctPrecertificateSigning));
+  StatusOr<bool> ca_pre_status = ca_pre.HasExtendedKeyUsage(
+      cert_trans::NID_ctPrecertificateSigning);
+  EXPECT_TRUE(ca_pre_status.ok() && ca_pre_status.ValueOrDie());
 }
 
 TEST_F(CertTest, Issuers) {

--- a/cpp/log/ct_extensions_test.cc
+++ b/cpp/log/ct_extensions_test.cc
@@ -166,16 +166,20 @@ TEST_F(CtExtensionsTest, TestPoisonExtension) {
 TEST_F(CtExtensionsTest, TestPrecertSigning) {
   // Sanity check
   Cert simple_ca_cert(simple_ca_cert_);
-  EXPECT_EQ(Cert::FALSE, simple_ca_cert.HasExtendedKeyUsage(
-                             cert_trans::NID_ctPrecertificateSigning));
+  StatusOr<bool> simple_ca_eku_status = simple_ca_cert.HasExtendedKeyUsage(
+      cert_trans::NID_ctPrecertificateSigning);
+  EXPECT_TRUE(simple_ca_eku_status.ok() &&
+              simple_ca_eku_status.ValueOrDie() == false);
 
   Cert pre_signing_cert(pre_signing_cert_);
   ASSERT_TRUE(pre_signing_cert.IsLoaded());
   // Check we can find the key usage by its advertised NID.
   // We should really be checking that the OID matches the expected OID but
   // what other key usage could this cert be having that the other one doesn't?
-  ASSERT_EQ(Cert::TRUE, pre_signing_cert.HasExtendedKeyUsage(
-                            cert_trans::NID_ctPrecertificateSigning));
+  StatusOr<bool> pre_signing_eku_status = pre_signing_cert.HasExtendedKeyUsage(
+      cert_trans::NID_ctPrecertificateSigning);
+  ASSERT_TRUE(pre_signing_eku_status.ok() &&
+              pre_signing_eku_status.ValueOrDie());
 }
 
 }  // namespace cert_trans


### PR DESCRIPTION
Cert::Status is being deprecated in favour of util::Status and util::StatusOr<T>. This converts 3 methods to StatusOr<bool> and adds some helpers to support the change.