### PR TITLE
Start to migrate away from Cert::Status, this is being done incrementally

### DIFF
--- a/cpp/log/cert.cc
+++ b/cpp/log/cert.cc
@@ -56,11 +56,11 @@ static Cert::Status StatusOrBoolToCertStatus(StatusOr<bool> status) {
 
 static StatusOr<bool> CertStatusToStatusOrBool(Cert::Status status) {
   if (status == Cert::FALSE) {
-    return StatusOr<bool>(false);
+    return false;
   } else if (status == Cert::TRUE) {
-    return StatusOr<bool>(true);
+    return true;
   } else {
-    return StatusOr<bool>(ERROR_STATUS);
+    return ERROR_STATUS;
   }
 }
 
@@ -296,7 +296,7 @@ Cert::Status Cert::HasCriticalExtension(int extension_nid) const {
 StatusOr<bool> Cert::HasBasicConstraintCATrue() const {
   if (!IsLoaded()) {
     LOG(ERROR) << "Cert not loaded";
-    return StatusOr<bool>(ERROR_STATUS);
+    return ERROR_STATUS;
   }
 
   void* ext_struct;
@@ -315,14 +315,14 @@ StatusOr<bool> Cert::HasBasicConstraintCATrue() const {
   BASIC_CONSTRAINTS* constraints = static_cast<BASIC_CONSTRAINTS*>(ext_struct);
   bool is_ca = constraints->ca;
   BASIC_CONSTRAINTS_free(constraints);
-  return StatusOr<bool>(is_ca ? true : false);
+  return is_ca ? true : false;
 }
 
 
 StatusOr<bool> Cert::HasExtendedKeyUsage(int key_usage_nid) const {
   if (!IsLoaded()) {
     LOG(ERROR) << "Cert not loaded";
-    return StatusOr<bool>(ERROR_STATUS);
+    return ERROR_STATUS;
   }
 
   const ASN1_OBJECT* key_usage_obj = OBJ_nid2obj(key_usage_nid);
@@ -330,7 +330,7 @@ StatusOr<bool> Cert::HasExtendedKeyUsage(int key_usage_nid) const {
     LOG(ERROR) << "OpenSSL OBJ_nid2obj returned NULL for NID " << key_usage_nid
                << ". Is the NID not recognised?";
     LOG_OPENSSL_ERRORS(WARNING);
-    return StatusOr<bool>(ERROR_STATUS);
+    return ERROR_STATUS;
   }
 
   void* ext_struct;

--- a/cpp/log/cert.cc
+++ b/cpp/log/cert.cc
@@ -315,7 +315,7 @@ StatusOr<bool> Cert::HasBasicConstraintCATrue() const {
   BASIC_CONSTRAINTS* constraints = static_cast<BASIC_CONSTRAINTS*>(ext_struct);
   bool is_ca = constraints->ca;
   BASIC_CONSTRAINTS_free(constraints);
-  return is_ca ? true : false;
+  return is_ca;
 }
 
 

--- a/cpp/log/cert.cc
+++ b/cpp/log/cert.cc
@@ -356,7 +356,7 @@ StatusOr<bool> Cert::HasExtendedKeyUsage(int key_usage_nid) const {
   }
 
   EXTENDED_KEY_USAGE_free(eku);
-  return ext_key_usage_found ? true : false;
+  return ext_key_usage_found;
 }
 
 

--- a/cpp/log/cert.cc
+++ b/cpp/log/cert.cc
@@ -356,7 +356,7 @@ StatusOr<bool> Cert::HasExtendedKeyUsage(int key_usage_nid) const {
   }
 
   EXTENDED_KEY_USAGE_free(eku);
-  return StatusOr<bool>(ext_key_usage_found ? true : false);
+  return ext_key_usage_found ? true : false;
 }
 
 

--- a/cpp/log/cert.h
+++ b/cpp/log/cert.h
@@ -10,8 +10,6 @@
 #include "base/macros.h"
 #include "util/statusor.h"
 
-using util::StatusOr;
-
 namespace cert_trans {
 
 // Tests if a hostname contains any redactions ('?' elements). If it does
@@ -99,7 +97,7 @@ class Cert {
   // or is present but could not be decoded.
   // Returns ERROR if the cert is not loaded or some other unknown error
   // occurred while parsing the extensions.
-  StatusOr<bool> HasBasicConstraintCATrue() const;
+  util::StatusOr<bool> HasBasicConstraintCATrue() const;
 
   // Returns TRUE if extendedKeyUsage extension is present and the specified
   // key usage is set.
@@ -109,7 +107,7 @@ class Cert {
   // or some other unknown error occurred while parsing the extensions.
   // NID must be either an OpenSSL built-in NID, or one registered by the user
   // with OBJ_create. (See log/ct_extensions.h for sample code.)
-  StatusOr<bool> HasExtendedKeyUsage(int key_usage_nid) const;
+  util::StatusOr<bool> HasExtendedKeyUsage(int key_usage_nid) const;
 
   // Returns TRUE if the Cert's issuer matches |issuer|.
   // Returns FALSE if there is no match.

--- a/cpp/log/cert.h
+++ b/cpp/log/cert.h
@@ -109,7 +109,7 @@ class Cert {
   // or some other unknown error occurred while parsing the extensions.
   // NID must be either an OpenSSL built-in NID, or one registered by the user
   // with OBJ_create. (See log/ct_extensions.h for sample code.)
-  Status HasExtendedKeyUsage(int key_usage_nid) const;
+  StatusOr<bool> HasExtendedKeyUsage(int key_usage_nid) const;
 
   // Returns TRUE if the Cert's issuer matches |issuer|.
   // Returns FALSE if there is no match.

--- a/cpp/log/cert.h
+++ b/cpp/log/cert.h
@@ -99,7 +99,7 @@ class Cert {
   // or is present but could not be decoded.
   // Returns ERROR if the cert is not loaded or some other unknown error
   // occurred while parsing the extensions.
-  Status HasBasicConstraintCATrue() const;
+  StatusOr<bool> HasBasicConstraintCATrue() const;
 
   // Returns TRUE if extendedKeyUsage extension is present and the specified
   // key usage is set.

--- a/cpp/log/cert.h
+++ b/cpp/log/cert.h
@@ -8,6 +8,9 @@
 #include <vector>
 
 #include "base/macros.h"
+#include "util/statusor.h"
+
+using util::StatusOr;
 
 namespace cert_trans {
 

--- a/cpp/log/cert_checker_test.cc
+++ b/cpp/log/cert_checker_test.cc
@@ -336,7 +336,9 @@ TEST_F(CertCheckerTest, AcceptNoBasicConstraintsAndMd2) {
   Cert ca(ca_pem);
   // Verify testdata properties: CA is legacy root.
   ASSERT_EQ("md2WithRSAEncryption", ca.PrintSignatureAlgorithm());
-  ASSERT_EQ(Cert::FALSE, ca.HasBasicConstraintCATrue());
+  StatusOr<bool> has_ca_constraint = ca.HasBasicConstraintCATrue();
+  ASSERT_TRUE(has_ca_constraint.ok() &&
+              has_ca_constraint.ValueOrDie() == false);
 
   string chain_pem;
   ASSERT_TRUE(util::ReadTextFile(cert_dir_ + "/" + kNoBCChain, &chain_pem));
@@ -371,7 +373,8 @@ TEST_F(CertCheckerTest, DontAcceptMD2) {
   ASSERT_TRUE(chain.IsLoaded());
   // Verify testdata properties: chain terminates in an MD2 intermediate.
   ASSERT_EQ(Cert::FALSE, chain.LastCert()->IsSelfSigned());
-  ASSERT_EQ(Cert::TRUE, chain.LastCert()->HasBasicConstraintCATrue());
+  StatusOr<bool> last_ca_status = chain.LastCert()->HasBasicConstraintCATrue();
+  ASSERT_TRUE(last_ca_status.ok() && last_ca_status.ValueOrDie() == true);
   ASSERT_EQ("md2WithRSAEncryption",
             chain.LastCert()->PrintSignatureAlgorithm());
 

--- a/cpp/log/cert_checker_test.cc
+++ b/cpp/log/cert_checker_test.cc
@@ -336,9 +336,7 @@ TEST_F(CertCheckerTest, AcceptNoBasicConstraintsAndMd2) {
   Cert ca(ca_pem);
   // Verify testdata properties: CA is legacy root.
   ASSERT_EQ("md2WithRSAEncryption", ca.PrintSignatureAlgorithm());
-  StatusOr<bool> has_ca_constraint = ca.HasBasicConstraintCATrue();
-  ASSERT_TRUE(has_ca_constraint.ok() &&
-              has_ca_constraint.ValueOrDie() == false);
+  ASSERT_FALSE(ca.HasBasicConstraintCATrue().ValueOrDie());
 
   string chain_pem;
   ASSERT_TRUE(util::ReadTextFile(cert_dir_ + "/" + kNoBCChain, &chain_pem));
@@ -373,8 +371,7 @@ TEST_F(CertCheckerTest, DontAcceptMD2) {
   ASSERT_TRUE(chain.IsLoaded());
   // Verify testdata properties: chain terminates in an MD2 intermediate.
   ASSERT_EQ(Cert::FALSE, chain.LastCert()->IsSelfSigned());
-  StatusOr<bool> last_ca_status = chain.LastCert()->HasBasicConstraintCATrue();
-  ASSERT_TRUE(last_ca_status.ok() && last_ca_status.ValueOrDie() == true);
+  ASSERT_TRUE(chain.LastCert()->HasBasicConstraintCATrue().ValueOrDie());
   ASSERT_EQ("md2WithRSAEncryption",
             chain.LastCert()->PrintSignatureAlgorithm());
 

--- a/cpp/log/cert_test.cc
+++ b/cpp/log/cert_test.cc
@@ -377,17 +377,13 @@ TEST_F(CertTest, Extensions) {
   EXPECT_EQ(Cert::TRUE, leaf.HasExtension(NID_authority_key_identifier));
   EXPECT_EQ(Cert::FALSE,
             leaf.HasCriticalExtension(NID_authority_key_identifier));
-
   EXPECT_EQ(Cert::TRUE, pre.HasCriticalExtension(cert_trans::NID_ctPoison));
 
-  StatusOr<bool> leaf_ca_status = leaf.HasBasicConstraintCATrue();
-  EXPECT_TRUE(leaf_ca_status.ok() && leaf_ca_status.ValueOrDie() == false);
-  StatusOr<bool> ca_ca_status = ca.HasBasicConstraintCATrue();
-  EXPECT_TRUE(ca_ca_status.ok() && ca_ca_status.ValueOrDie() == true);
-
-  StatusOr<bool> ca_pre_status = ca_pre.HasExtendedKeyUsage(
-      cert_trans::NID_ctPrecertificateSigning);
-  EXPECT_TRUE(ca_pre_status.ok() && ca_pre_status.ValueOrDie());
+  EXPECT_FALSE(leaf.HasBasicConstraintCATrue().ValueOrDie());
+  EXPECT_TRUE(ca.HasBasicConstraintCATrue().ValueOrDie());
+  EXPECT_TRUE(
+      ca_pre.HasExtendedKeyUsage(cert_trans::NID_ctPrecertificateSigning)
+          .ValueOrDie());
 }
 
 TEST_F(CertTest, Issuers) {

--- a/cpp/log/cert_test.cc
+++ b/cpp/log/cert_test.cc
@@ -380,8 +380,10 @@ TEST_F(CertTest, Extensions) {
 
   EXPECT_EQ(Cert::TRUE, pre.HasCriticalExtension(cert_trans::NID_ctPoison));
 
-  EXPECT_EQ(Cert::FALSE, leaf.HasBasicConstraintCATrue());
-  EXPECT_EQ(Cert::TRUE, ca.HasBasicConstraintCATrue());
+  StatusOr<bool> leaf_ca_status = leaf.HasBasicConstraintCATrue();
+  EXPECT_TRUE(leaf_ca_status.ok() && leaf_ca_status.ValueOrDie() == false);
+  StatusOr<bool> ca_ca_status = ca.HasBasicConstraintCATrue();
+  EXPECT_TRUE(ca_ca_status.ok() && ca_ca_status.ValueOrDie() == true);
 
   StatusOr<bool> ca_pre_status = ca_pre.HasExtendedKeyUsage(
       cert_trans::NID_ctPrecertificateSigning);

--- a/cpp/log/cert_test.cc
+++ b/cpp/log/cert_test.cc
@@ -383,8 +383,9 @@ TEST_F(CertTest, Extensions) {
   EXPECT_EQ(Cert::FALSE, leaf.HasBasicConstraintCATrue());
   EXPECT_EQ(Cert::TRUE, ca.HasBasicConstraintCATrue());
 
-  EXPECT_EQ(Cert::TRUE, ca_pre.HasExtendedKeyUsage(
-                            cert_trans::NID_ctPrecertificateSigning));
+  StatusOr<bool> ca_pre_status = ca_pre.HasExtendedKeyUsage(
+      cert_trans::NID_ctPrecertificateSigning);
+  EXPECT_TRUE(ca_pre_status.ok() && ca_pre_status.ValueOrDie());
 }
 
 TEST_F(CertTest, Issuers) {

--- a/cpp/log/ct_extensions_test.cc
+++ b/cpp/log/ct_extensions_test.cc
@@ -166,20 +166,16 @@ TEST_F(CtExtensionsTest, TestPoisonExtension) {
 TEST_F(CtExtensionsTest, TestPrecertSigning) {
   // Sanity check
   Cert simple_ca_cert(simple_ca_cert_);
-  StatusOr<bool> simple_ca_eku_status = simple_ca_cert.HasExtendedKeyUsage(
-      cert_trans::NID_ctPrecertificateSigning);
-  EXPECT_TRUE(simple_ca_eku_status.ok() &&
-              simple_ca_eku_status.ValueOrDie() == false);
+  EXPECT_FALSE(simple_ca_cert.HasExtendedKeyUsage(
+      cert_trans::NID_ctPrecertificateSigning).ValueOrDie());
 
   Cert pre_signing_cert(pre_signing_cert_);
   ASSERT_TRUE(pre_signing_cert.IsLoaded());
   // Check we can find the key usage by its advertised NID.
   // We should really be checking that the OID matches the expected OID but
   // what other key usage could this cert be having that the other one doesn't?
-  StatusOr<bool> pre_signing_eku_status = pre_signing_cert.HasExtendedKeyUsage(
-      cert_trans::NID_ctPrecertificateSigning);
-  ASSERT_TRUE(pre_signing_eku_status.ok() &&
-              pre_signing_eku_status.ValueOrDie());
+  ASSERT_TRUE(pre_signing_cert.HasExtendedKeyUsage(
+      cert_trans::NID_ctPrecertificateSigning).ValueOrDie());
 }
 
 }  // namespace cert_trans

--- a/cpp/log/ct_extensions_test.cc
+++ b/cpp/log/ct_extensions_test.cc
@@ -166,16 +166,20 @@ TEST_F(CtExtensionsTest, TestPoisonExtension) {
 TEST_F(CtExtensionsTest, TestPrecertSigning) {
   // Sanity check
   Cert simple_ca_cert(simple_ca_cert_);
-  EXPECT_EQ(Cert::FALSE, simple_ca_cert.HasExtendedKeyUsage(
-                             cert_trans::NID_ctPrecertificateSigning));
+  StatusOr<bool> simple_ca_eku_status = simple_ca_cert.HasExtendedKeyUsage(
+      cert_trans::NID_ctPrecertificateSigning);
+  EXPECT_TRUE(simple_ca_eku_status.ok() &&
+              simple_ca_eku_status.ValueOrDie() == false);
 
   Cert pre_signing_cert(pre_signing_cert_);
   ASSERT_TRUE(pre_signing_cert.IsLoaded());
   // Check we can find the key usage by its advertised NID.
   // We should really be checking that the OID matches the expected OID but
   // what other key usage could this cert be having that the other one doesn't?
-  ASSERT_EQ(Cert::TRUE, pre_signing_cert.HasExtendedKeyUsage(
-                            cert_trans::NID_ctPrecertificateSigning));
+  StatusOr<bool> pre_signing_eku_status = pre_signing_cert.HasExtendedKeyUsage(
+      cert_trans::NID_ctPrecertificateSigning);
+  ASSERT_TRUE(pre_signing_eku_status.ok() &&
+              pre_signing_eku_status.ValueOrDie());
 }
 
 }  // namespace cert_trans


### PR DESCRIPTION
Cert::Status is being deprecated in favour of util::Status and util::StatusOr. This converts 3 methods to StatusOr and adds some helpers to support the change.