### PR TITLE
Add conditional compilation for BoringSSL compatibility.

### DIFF
--- a/cpp/log/cert.h
+++ b/cpp/log/cert.h
@@ -221,6 +221,7 @@ class Cert {
   Status ExtensionStructure(int extension_nid, void** ext_struct) const;
   bool ValidateRedactionSubjectAltNameAndCN(int* dns_alt_name_count,
                                             Status* status) const;
+  util::StatusOr<bool> LogUnsupportedAlgorithm() const;
   static std::string PrintName(X509_NAME* name);
   static std::string PrintTime(ASN1_TIME* when);
   static util::Status DerEncodedName(X509_NAME* name, std::string* result);


### PR DESCRIPTION
- |Cert::IsSignedBy| tries to infer, from OpenSSL |X509_verify|
  errors, (a) which errors count as |ERROR|, as opposed to mere
  failures to verify, and (b) which errors count as
  |UNSUPPORTED_ALGORITHM|.  This needs conditional compilation, since
  BoringSSL's error reporting is slightly different.

- BoringSSL doesn't define |i2d_re_X509_tbs|, so it should get the
  same substitute function that OpenSSL does.

Along the way, #include <openssl/crypto.h>, for the definition of
|OPENSSL_free|.
