### PR TITLE
Replace CertSubmissionHandler::SubmitResult with util::Status.

### DIFF
--- a/cpp/log/cert_submission_handler.h
+++ b/cpp/log/cert_submission_handler.h
@@ -7,6 +7,7 @@
 #include "log/cert_checker.h"
 #include "proto/ct.pb.h"
 #include "proto/serializer.h"
+#include "util/status.h"
 
 // Parse incoming submissions, do preliminary sanity checks and pass them
 // through cert checker.
@@ -17,22 +18,11 @@ class CertSubmissionHandler {
   // Does not take ownership of the cert_checker.
   explicit CertSubmissionHandler(cert_trans::CertChecker* cert_checker);
 
-  enum SubmitResult {
-    OK,
-    INVALID_TYPE,
-    EMPTY_SUBMISSION,
-    SUBMISSION_TOO_LONG,
-    INVALID_PEM_ENCODED_CHAIN,
-    INVALID_CERTIFICATE_CHAIN,
-    PRECERT_CHAIN_NOT_WELL_FORMED,
-    UNKNOWN_ROOT,
-    INTERNAL_ERROR,
-  };
-
   // These may change |chain|.
-  SubmitResult ProcessX509Submission(cert_trans::CertChain* chain,
+  // TODO(pphaneuf): These could return StatusOr<ct::LogEntry>.
+  util::Status ProcessX509Submission(cert_trans::CertChain* chain,
                                      ct::LogEntry* entry);
-  SubmitResult ProcessPreCertSubmission(cert_trans::PreCertChain* chain,
+  util::Status ProcessPreCertSubmission(cert_trans::PreCertChain* chain,
                                         ct::LogEntry* entry);
 
   // For clients, to reconstruct the bytestring under the signature
@@ -47,8 +37,6 @@ class CertSubmissionHandler {
 
  private:
   static bool SerializedTbs(const cert_trans::Cert& cert, std::string* result);
-  static SubmitResult GetVerifyError(
-      cert_trans::CertChecker::CertVerifyResult result);
 
   cert_trans::CertChecker* const cert_checker_;
 

--- a/cpp/log/frontend.h
+++ b/cpp/log/frontend.h
@@ -37,9 +37,9 @@ class Frontend {
   const std::unique_ptr<CertSubmissionHandler> handler_;
   const std::unique_ptr<FrontendSigner> signer_;
 
-  util::Status QueueProcessedEntry(
-      CertSubmissionHandler::SubmitResult pre_result,
-      const ct::LogEntry& entry, ct::SignedCertificateTimestamp* sct);
+  util::Status QueueProcessedEntry(util::Status pre_status,
+                                   const ct::LogEntry& entry,
+                                   ct::SignedCertificateTimestamp* sct);
 
   DISALLOW_COPY_AND_ASSIGN(Frontend);
 };


### PR DESCRIPTION
From the top, allowing to make sure the `util::Status` that comes out is as callers received in the same situation more easily.