### PR TITLE
Cert::IsIdenticalTo can only be true or false.

### DIFF
--- a/cpp/log/cert.cc
+++ b/cpp/log/cert.cc
@@ -233,8 +233,8 @@ string Cert::PrintTime(ASN1_TIME* when) {
 }
 
 
-Cert::Status Cert::IsIdenticalTo(const Cert& other) const {
-  return X509_cmp(x509_, other.x509_) == 0 ? TRUE : FALSE;
+bool Cert::IsIdenticalTo(const Cert& other) const {
+  return X509_cmp(x509_, other.x509_) == 0;
 }
 
 

--- a/cpp/log/cert.h
+++ b/cpp/log/cert.h
@@ -72,7 +72,7 @@ class Cert {
   std::string PrintNotAfter() const;
   std::string PrintSignatureAlgorithm() const;
 
-  Status IsIdenticalTo(const Cert& other) const;
+  bool IsIdenticalTo(const Cert& other) const;
 
   // Returns TRUE if the extension is present.
   // Returns FALSE if the extension is not present.

--- a/cpp/log/cert_checker.cc
+++ b/cpp/log/cert_checker.cc
@@ -370,12 +370,7 @@ CertChecker::CertVerifyResult CertChecker::IsTrusted(
            cand_range.first;
        it != cand_range.second; ++it) {
     const Cert* cand = it->second;
-    Cert::Status matches = cert.IsIdenticalTo(*cand);
-    if (matches != Cert::TRUE && matches != Cert::FALSE) {
-      LOG(ERROR) << "Cert comparison failed";
-      return INTERNAL_ERROR;
-    }
-    if (matches == Cert::TRUE) {
+    if (cert.IsIdenticalTo(*cand)) {
       return OK;
     }
   }

--- a/cpp/log/cert_test.cc
+++ b/cpp/log/cert_test.cc
@@ -361,9 +361,9 @@ TEST_F(CertTest, TestUnsupportedAlgorithm) {
 TEST_F(CertTest, Identical) {
   Cert leaf(leaf_pem_);
   Cert ca(ca_pem_);
-  EXPECT_EQ(Cert::TRUE, leaf.IsIdenticalTo(leaf));
-  EXPECT_EQ(Cert::FALSE, leaf.IsIdenticalTo(ca));
-  EXPECT_EQ(Cert::FALSE, ca.IsIdenticalTo(leaf));
+  EXPECT_TRUE(leaf.IsIdenticalTo(leaf));
+  EXPECT_FALSE(leaf.IsIdenticalTo(ca));
+  EXPECT_FALSE(ca.IsIdenticalTo(leaf));
 }
 
 TEST_F(CertTest, Extensions) {


### PR DESCRIPTION
Fewer states, more happies!