### PR TITLE
Fix use-after-free in remote_peer.

### DIFF
--- a/cpp/fetcher/remote_peer.cc
+++ b/cpp/fetcher/remote_peer.cc
@@ -143,7 +143,6 @@ RemotePeer::RemotePeer(
     : Peer(move(client)),
       impl_(new Impl(move(verifier), client_.get(), on_new_sth, task)) {
   TaskHold hold(task);
-  task->DeleteWhenDone(impl_);
 
   impl_->FetchSTH();
 }

--- a/cpp/fetcher/remote_peer.h
+++ b/cpp/fetcher/remote_peer.h
@@ -1,6 +1,8 @@
 #ifndef CERT_TRANS_FETCHER_REMOTE_PEER_H_
 #define CERT_TRANS_FETCHER_REMOTE_PEER_H_
 
+#include <memory>
+
 #include "fetcher/peer.h"
 #include "log/log_verifier.h"
 #include "util/task.h"
@@ -27,8 +29,7 @@ class RemotePeer : public Peer {
  private:
   struct Impl;
 
-  // This gets deleted via the util::Task.
-  Impl* const impl_;
+  std::unique_ptr<Impl> const impl_;
 };
 
 


### PR DESCRIPTION
The d'tor tries to send a `CANCELLED` status, but `impl_` is already deleted if a `Status` has been returned elsewhere.