### PR TITLE
Convert Cert::Status to an "enum class".

### DIFF
--- a/cpp/log/cert.cc
+++ b/cpp/log/cert.cc
@@ -88,6 +88,12 @@ string ASN1ToStringAndCheckForNulls(ASN1_STRING* asn1_string,
 }
 
 
+const Cert::Status Cert::TRUE;
+const Cert::Status Cert::FALSE;
+const Cert::Status Cert::ERROR;
+const Cert::Status Cert::UNSUPPORTED_ALGORITHM;
+
+
 Cert::Cert(X509* x509) : x509_(x509) {
 }
 

--- a/cpp/log/cert.h
+++ b/cpp/log/cert.h
@@ -31,7 +31,7 @@ class Cert {
   }
   ~Cert();
 
-  enum Status {
+  enum class Status {
     TRUE,
     // OpenSSL makes it very hard to distinguish between input errors
     // (cert somehow corrupt) and internal library errors (malloc errors,
@@ -50,6 +50,11 @@ class Cert {
     // unconditionally not accepted.
     UNSUPPORTED_ALGORITHM,
   };
+
+  static const Status TRUE = Status::TRUE;
+  static const Status FALSE = Status::FALSE;
+  static const Status ERROR = Status::ERROR;
+  static const Status UNSUPPORTED_ALGORITHM = Status::UNSUPPORTED_ALGORITHM;
 
   bool IsLoaded() const {
     return x509_ != NULL;
@@ -271,6 +276,22 @@ class TbsCertificate {
 
   DISALLOW_COPY_AND_ASSIGN(TbsCertificate);
 };
+
+inline std::ostream& operator<<(std::ostream& out,
+                                const Cert::Status& status) {
+  switch (status) {
+    case Cert::Status::TRUE:
+      return out << "TRUE";
+    case Cert::Status::FALSE:
+      return out << "FALSE";
+    case Cert::Status::ERROR:
+      return out << "ERROR";
+    case Cert::Status::UNSUPPORTED_ALGORITHM:
+      return out << "UNSUPPORTED_ALGORITHM";
+  }
+
+  return out << "<unknown Cert::Status: " << static_cast<int>(status) << ")";
+}
 
 class CertChain {
  public:


### PR DESCRIPTION
Simple `enum`s are just too dangerous... While they were just sitting there, presumably well reviewed, it was okay, but now that we're poking the wasp nest, I think this hack is a good idea.