### PR TITLE
Convert a few accessors from Cert::Status to bool/void.

### DIFF
--- a/cpp/log/cert.h
+++ b/cpp/log/cert.h
@@ -306,21 +306,19 @@ class CertChain {
 
   // Takes ownership of the cert.
   // If the cert has a valid X509 structure, adds it to the end of the chain
-  // and returns TRUE.
-  // Else returns ERROR.
-  Cert::Status AddCert(Cert* cert);
+  // and returns true.
+  // Else returns false.
+  bool AddCert(Cert* cert);
 
-  // Remove a cert from the end of the chain.
-  // If successful, returns TRUE.
-  // If the chain is empty, returns ERROR.
-  Cert::Status RemoveCert();
+  // Remove a cert from the end of the chain, if there is one.
+  void RemoveCert();
 
   // Keep the first self-signed, remove the rest. We keep the first one so that
   // chains consisting only of a self-signed cert don't become invalid.
-  // If successful, returns TRUE.
-  // If the chain is empty, returns ERROR.
-  // If the chain has no self-signed certs, does nothing and also returns TRUE.
-  Cert::Status RemoveCertsAfterFirstSelfSigned();
+  // If successful, returns true.
+  // If the chain is empty, returns false.
+  // If the chain has no self-signed certs, does nothing and also returns true.
+  bool RemoveCertsAfterFirstSelfSigned();
 
   // True if the chain loaded correctly, and contains at least one valid cert.
   bool IsLoaded() const {

--- a/cpp/log/cert_checker.cc
+++ b/cpp/log/cert_checker.cc
@@ -154,7 +154,7 @@ Status CertChecker::CheckCertChain(CertChain* chain) const {
 }
 
 Status CertChecker::CheckIssuerChain(CertChain* chain) const {
-  if (chain->RemoveCertsAfterFirstSelfSigned() != Cert::TRUE) {
+  if (!chain->RemoveCertsAfterFirstSelfSigned()) {
     LOG(ERROR) << "Failed to trim chain";
     return Status(util::error::INTERNAL, "failed to trim chain");
   }
@@ -318,7 +318,7 @@ Status CertChecker::GetTrustedCa(CertChain* chain) const {
   // Clone creates a new Cert but AddCert takes ownership even if Clone
   // failed and the cert can't be added, so we don't have to explicitly
   // check for IsLoaded here.
-  if (chain->AddCert(issuer->Clone()) != Cert::TRUE) {
+  if (!chain->AddCert(issuer->Clone())) {
     LOG(ERROR) << "Failed to add trusted root to chain";
     return Status(util::error::INTERNAL,
                   "failed to add trusted root to chain");

--- a/cpp/log/cert_checker_test.cc
+++ b/cpp/log/cert_checker_test.cc
@@ -211,7 +211,7 @@ TEST_F(CertCheckerTest, Certificate) {
 TEST_F(CertCheckerTest, CertificateWithRoot) {
   CertChain chain(leaf_pem_);
   ASSERT_TRUE(chain.IsLoaded());
-  ASSERT_EQ(Cert::TRUE, chain.AddCert(new Cert(ca_pem_)));
+  ASSERT_TRUE(chain.AddCert(new Cert(ca_pem_)));
 
   // Fail as even though we give a CA cert, it's not in the local store.
   EXPECT_THAT(checker_.CheckCertChain(&chain),
@@ -226,8 +226,8 @@ TEST_F(CertCheckerTest, CertificateWithRoot) {
 TEST_F(CertCheckerTest, TrimsRepeatedRoots) {
   CertChain chain(leaf_pem_);
   ASSERT_TRUE(chain.IsLoaded());
-  ASSERT_EQ(Cert::TRUE, chain.AddCert(new Cert(ca_pem_)));
-  ASSERT_EQ(Cert::TRUE, chain.AddCert(new Cert(ca_pem_)));
+  ASSERT_TRUE(chain.AddCert(new Cert(ca_pem_)));
+  ASSERT_TRUE(chain.AddCert(new Cert(ca_pem_)));
 
   // Load CA certs and expect success.
   EXPECT_TRUE(checker_.LoadTrustedCertificates(cert_dir_ + "/" + kCaCert));
@@ -245,7 +245,7 @@ TEST_F(CertCheckerTest, Intermediates) {
   EXPECT_THAT(checker_.CheckCertChain(&chain),
               StatusIs(util::error::FAILED_PRECONDITION));
   // Add the intermediate and expect success.
-  ASSERT_EQ(Cert::TRUE, chain.AddCert(new Cert(intermediate_pem_)));
+  ASSERT_TRUE(chain.AddCert(new Cert(intermediate_pem_)));
   ASSERT_EQ(2U, chain.Length());
   EXPECT_OK(checker_.CheckCertChain(&chain));
   EXPECT_EQ(3U, chain.Length());


### PR DESCRIPTION
This change is dangerous, but I've tested it on top of #916 (with which it is safe). Rebased on top of master, since it's actually independent (but I'd understand if you wouldn't want to merge this before #916!).