### PR TITLE
Use unique_ptr rather than shared_ptr for Cert vectors.

### DIFF
--- a/cpp/client/async_log_client.h
+++ b/cpp/client/async_log_client.h
@@ -54,7 +54,7 @@ class AsyncLogClient {
   void GetSTH(ct::SignedTreeHead* sth, const Callback& done);
 
   // This does not clear "roots" before appending to it.
-  void GetRoots(std::vector<std::shared_ptr<Cert> >* roots,
+  void GetRoots(std::vector<std::unique_ptr<Cert>>* roots,
                 const Callback& done);
 
   // This does not clear "entries" before appending the retrieved

--- a/cpp/client/ct.cc
+++ b/cpp/client/ct.cc
@@ -885,11 +885,11 @@ void GetEntries() {
 int GetRoots() {
   HTTPLogClient client(FLAGS_ct_server);
 
-  vector<shared_ptr<Cert> > roots;
+  vector<unique_ptr<Cert>> roots;
   CHECK_EQ(client.GetRoots(&roots), AsyncLogClient::OK);
 
   LOG(INFO) << "number of certs: " << roots.size();
-  for (vector<shared_ptr<Cert> >::const_iterator it = roots.begin();
+  for (vector<unique_ptr<Cert>>::const_iterator it = roots.begin();
        it != roots.end(); ++it) {
     string pem_cert;
     CHECK_EQ((*it)->PemEncoding(&pem_cert), Cert::TRUE);

--- a/cpp/client/http_log_client.cc
+++ b/cpp/client/http_log_client.cc
@@ -24,9 +24,8 @@ using ct::MerkleAuditProof;
 using ct::SignedCertificateTimestamp;
 using ct::SignedTreeHead;
 using std::bind;
-using std::make_shared;
+using std::unique_ptr;
 using std::placeholders::_1;
-using std::shared_ptr;
 using std::string;
 using std::vector;
 
@@ -85,7 +84,7 @@ AsyncLogClient::Status HTTPLogClient::GetSTH(SignedTreeHead* sth) {
 }
 
 AsyncLogClient::Status HTTPLogClient::GetRoots(
-    vector<shared_ptr<Cert> >* roots) {
+    vector<unique_ptr<Cert>>* roots) {
   AsyncLogClient::Status retval(AsyncLogClient::UNKNOWN_ERROR);
   bool done(false);
 

--- a/cpp/client/http_log_client.h
+++ b/cpp/client/http_log_client.h
@@ -27,7 +27,7 @@ class HTTPLogClient {
 
   AsyncLogClient::Status GetSTH(ct::SignedTreeHead* sth);
 
-  AsyncLogClient::Status GetRoots(std::vector<std::shared_ptr<Cert> >* roots);
+  AsyncLogClient::Status GetRoots(std::vector<std::unique_ptr<Cert>>* roots);
 
   AsyncLogClient::Status QueryAuditProof(const std::string& merkle_leaf_hash,
                                          ct::MerkleAuditProof* proof);


### PR DESCRIPTION
That's what we wanted all along, but didn't have C++11 back then (as you can also tell by the `> >`).

I'm having some evening project of managing the damned memory, and `unique_ptr` is better suited for that...