### PR TITLE
Allow TLS client to support various TLS versions.

### DIFF
--- a/Dockerfile-ct-mirror
+++ b/Dockerfile-ct-mirror
@@ -35,6 +35,7 @@ CMD cd /mnt/ctmirror/ && \
     echo "Container: ${CONTAINER_HOST}" && \
     echo "Etcd: ${ETCD_SERVERS}" && \
     echo "Target: ${TARGET_LOG_URL}" && \
+    echo "Target TLS version: ${TARGET_LOG_TLS_VERSION}" && \
     echo "Target Key: ${TARGET_LOG_PUBLIC_KEY}" && \
     echo "Project: ${PROJECT}" && \
     echo "Monitoring: ${MONITORING}" && \

--- a/cloud/google/config.sh
+++ b/cloud/google/config.sh
@@ -50,6 +50,7 @@ if [ "${INSTANCE_TYPE}" == "mirror" ]; then
                    s^@@ETCD_SERVERS@@^${ETCD_SERVER_LIST}^
                    s^@@CONTAINER_HOST@@^${MIRROR_MACHINES[${MIRROR_NUM_REPLICAS}]}^
                    s^@@TARGET_LOG_URL@@^${MIRROR_TARGET_URL}^
+                   s^@@TARGET_LOG_TLS_VERSION@@^${MIRROR_TARGET_TLS_VERSION:-tlsv12}^
                    s^@@TARGET_LOG_PUBLIC_KEY@@^${MIRROR_TARGET_PUBLIC_KEY}^
                    s^@@MONITORING@@^${MONITORING}^" \
                       < ${DIR}/mirror_container.yaml)

--- a/cloud/google/configs/ct-mirror-izenpe1.sh
+++ b/cloud/google/configs/ct-mirror-izenpe1.sh
@@ -5,5 +5,6 @@ export CLUSTER="ct-mirror-izenpe1"
 export ZONES="a c f"
 export MIRROR_NUM_REPLICAS_PER_ZONE=2
 export MIRROR_TARGET_URL="https://ct.izenpe.com"
+export MIRROR_TARGET_TLS_VERSION="tlsv1"
 export MIRROR_TARGET_PUBLIC_KEY="izenpe_1.pem"
 export MONITORING="gcm"

--- a/cloud/google/mirror_container.yaml
+++ b/cloud/google/mirror_container.yaml
@@ -19,6 +19,8 @@ spec:
           value: "@@CONTAINER_HOST@@"
         - name: TARGET_LOG_URL
           value: "@@TARGET_LOG_URL@@"
+        - name: TARGET_LOG_TLS_VERSION
+          value: "@@TARGET_LOG_TLS_VERSION@@"
         - name: TARGET_LOG_PUBLIC_KEY
           value: "@@TARGET_LOG_PUBLIC_KEY@@"
         - name: PROJECT


### PR DESCRIPTION
Defaults to only allowing TLSv1.2, but optionally can support TLSv1 or TLSv1.1 and above via a flag.
Also allows passing of acceptable ciphers for the TLS client through to OpenSSL, with a default of the Mozilla 'modern compatibility' set.

All current known CT Logs support TLSv1.2, except `ct.izenpe.com` which only supports TLSv1,   adjusted config accordingly.