### PR TITLE
Mac ports puts the files protoc need under /opt/local/include.

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -2,7 +2,7 @@ all: ct/proto/client_pb2.py ct/proto/ct_pb2.py ct/proto/tls_options_pb2.py \
 	ct/proto/test_message_pb2.py ct/proto/certificate_pb2.py
 
 ct/proto/%_pb2.py: ct/proto/%.proto
-	protoc $^ -I/usr/include/ -I/usr/local/include -I. --python_out=.
+	protoc $^ -I/usr/include/ -I/usr/local/include -I/opt/local/include -I. --python_out=.
 
 ct/proto/ct_pb2.py: ../proto/ct.proto
 	protoc --python_out=ct/proto -I../proto ../proto/ct.proto


### PR DESCRIPTION
There's likely a better way to make that portable, but this seems to work, albeit with warnings about missing dirs.