### PR TITLE
Switch to using "cryptography" Python lib

### DIFF
--- a/python/README
+++ b/python/README
@@ -5,10 +5,9 @@ gflags (python_gflags if using easy_install)
 gviz-api-py (easy_install 'https://google-visualization-python.googlecode.com/files/gviz_api_py-1.8.2.tar.gz')
 requests (at least version 1.0)
 protobuf
-ecdsa
 mock
 twisted (at least 12.1; tested with 13.2)
-pycrypto (at least 2.5; tested with 2.6.1)
+cryptography
 
 If you use pip, simply run `pip install -r requirements.txt`
 

--- a/python/ct/crypto/verify_rsa.py
+++ b/python/ct/crypto/verify_rsa.py
@@ -2,9 +2,11 @@ from ct.crypto import error
 from ct.crypto import pem
 from ct.proto import client_pb2
 
-import Crypto.Hash.SHA256
-import Crypto.PublicKey.RSA
-import Crypto.Signature.PKCS1_v1_5
+import cryptography
+from cryptography.hazmat.backends import default_backend as crypto_backend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import padding
 
 class RsaVerifier(object):
     """Verifies RSA signatures."""
@@ -14,11 +16,6 @@ class RsaVerifier(object):
     # The hash algorithm used for this public key.
     HASH_ALGORITHM = client_pb2.DigitallySigned.SHA256
 
-    # Markers to look for when reading a PEM-encoded RSA public key.
-    __READ_MARKERS = ("PUBLIC KEY", "RSA PUBLIC KEY")
-    # A marker to write when writing a PEM-encoded RSA public key.
-    __WRITE_MARKER = "RSA PUBLIC KEY"
-
     def __init__(self, key_info):
         """Creates a verifier that uses a PEM-encoded RSA public key.
 
@@ -27,22 +24,27 @@ class RsaVerifier(object):
 
         Raises:
         - PemError: If the key has an invalid encoding
+        - UnsupportedAlgorithmError: If the key uses an unsupported algorithm
         """
         if (key_info.type != client_pb2.KeyInfo.RSA):
             raise error.UnsupportedAlgorithmError(
                 "Expected RSA key, but got key type %d" % key_info.type)
 
-        # Will raise a PemError on invalid encoding
-        self.__der, _ = pem.from_pem(key_info.pem_key, self.__READ_MARKERS)
+        pem_key = str(key_info.pem_key)
+
         try:
-            self.__key = Crypto.PublicKey.RSA.importKey(self.__der)
-        except (ValueError, IndexError, TypeError) as e:
-            raise error.EncodingError(e)
+            self.__key = crypto_backend().load_pem_public_key(pem_key)
+        except ValueError as e:
+            raise pem.PemError(e)
+        except cryptography.exceptions.UnsupportedAlgorithm as e:
+            raise error.UnsupportedAlgorithmError(e)
 
     def __repr__(self):
-        return "%s(public key: %r)" % (self.__class__.__name__,
-                                       pem.to_pem(self.__der,
-                                                  self.__WRITE_MARKER))
+        key_pem = self.__key.public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo)
+
+        return "%s(public key: %r)" % (self.__class__.__name__, key_pem)
 
     @error.returns_true_or_raises
     def verify(self, signature_input, signature):
@@ -58,12 +60,13 @@ class RsaVerifier(object):
         Raises:
         - error.SignatureError: If the signature fails verification.
         """
-        verifier = Crypto.Signature.PKCS1_v1_5.new(self.__key)
-        sha256_hash = Crypto.Hash.SHA256.new(signature_input)
+        verifier = self.__key.verifier(signature, padding.PKCS1v15(), hashes.SHA256())
+        verifier.update(signature_input)
 
-        if verifier.verify(sha256_hash, signature):
-            return True
-        else:
-            raise error.SignatureError("Signature did not verify: %s",
+        try:
+            verifier.verify()
+        except cryptography.exceptions.InvalidSignature:
+            raise error.SignatureError("Signature did not verify: %s" %
                                        signature.encode("hex"))
 
+        return True

--- a/python/ct/crypto/verify_test.py
+++ b/python/ct/crypto/verify_test.py
@@ -350,21 +350,17 @@ class LogVerifierEcdsaTest(LogVerifierTest, unittest.TestCase):
             sth_fixture.tree_head_signature[:i] +
             chr(ord(sth_fixture.tree_head_signature[i]) - 1) +
             sth_fixture.tree_head_signature[i+1:])
-        self.assertRaises(error.EncodingError, verifier.verify_sth, sth)
+        self.assertRaises(error.SignatureError, verifier.verify_sth, sth)
 
         # Increasing the length means there are not enough ASN.1 bytes left to
-        # decode the sequence, however the ecdsa module silently slices it.
-        # Our ECDSA verifier checks for it and will fail.
+        # decode the sequence.
         sth = client_pb2.SthResponse()
         sth.CopyFrom(sth_fixture)
         sth.tree_head_signature = (
             sth_fixture.tree_head_signature[:i] +
             chr(ord(sth_fixture.tree_head_signature[i]) + 1) +
             sth_fixture.tree_head_signature[i+1:])
-        self.assertRaises(
-            error.EncodingError,
-            verifier.verify_sth,
-            sth)
+        self.assertRaises(error.SignatureError, verifier.verify_sth, sth)
 
         # The byte that encodes the length of the first integer r in the
         # sequence (r, s). Modifying the length corrupts the second integer
@@ -376,7 +372,7 @@ class LogVerifierEcdsaTest(LogVerifierTest, unittest.TestCase):
             sth_fixture.tree_head_signature[:i] +
             chr(ord(sth_fixture.tree_head_signature[i]) - 1) +
             sth_fixture.tree_head_signature[i+1:])
-        self.assertRaises(error.EncodingError, verifier.verify_sth, sth)
+        self.assertRaises(error.SignatureError, verifier.verify_sth, sth)
 
         sth = client_pb2.SthResponse()
         sth.CopyFrom(sth_fixture)
@@ -384,11 +380,11 @@ class LogVerifierEcdsaTest(LogVerifierTest, unittest.TestCase):
             sth_fixture.tree_head_signature[:i] +
             chr(ord(sth_fixture.tree_head_signature[i]) + 1) +
             sth_fixture.tree_head_signature[i+1:])
-        self.assertRaises(error.EncodingError, verifier.verify_sth, sth)
+        self.assertRaises(error.SignatureError, verifier.verify_sth, sth)
 
         # The byte that encodes the length of the second integer s in the
-        # sequence (r, s). Increasing this length leaves bytes unread which
-        # is now also detected in the verify_ecdsa module.
+        # sequence (r, s). Modifying the length corrupts the integer and causes
+        # a decoding error.
         i = 42
         sth = client_pb2.SthResponse()
         sth.CopyFrom(sth_fixture)
@@ -396,7 +392,7 @@ class LogVerifierEcdsaTest(LogVerifierTest, unittest.TestCase):
             sth_fixture.tree_head_signature[:i] +
             chr(ord(sth_fixture.tree_head_signature[i]) - 1) +
             sth_fixture.tree_head_signature[i+1:])
-        self.assertRaises(error.EncodingError, verifier.verify_sth, sth)
+        self.assertRaises(error.SignatureError, verifier.verify_sth, sth)
 
         sth = client_pb2.SthResponse()
         sth.CopyFrom(sth_fixture)
@@ -404,7 +400,7 @@ class LogVerifierEcdsaTest(LogVerifierTest, unittest.TestCase):
             sth_fixture.tree_head_signature[:i] +
             chr(ord(sth_fixture.tree_head_signature[i]) + 1) +
             sth_fixture.tree_head_signature[i+1:])
-        self.assertRaises(error.EncodingError, verifier.verify_sth, sth)
+        self.assertRaises(error.SignatureError, verifier.verify_sth, sth)
 
         # Trailing garbage is correctly detected.
         sth = client_pb2.SthResponse()
@@ -414,7 +410,7 @@ class LogVerifierEcdsaTest(LogVerifierTest, unittest.TestCase):
             # Correct outer length to include trailing garbage.
             chr(ord(sth_fixture.tree_head_signature[3]) + 1) +
             sth_fixture.tree_head_signature[4:]) + "\x01"
-        self.assertRaises(error.EncodingError, verifier.verify_sth, sth)
+        self.assertRaises(error.SignatureError, verifier.verify_sth, sth)
 
     def test_verify_sth_for_bad_asn1_signature(self):
         # www.google.com certificate for which a bad SCT was issued.
@@ -463,7 +459,7 @@ class LogVerifierEcdsaTest(LogVerifierTest, unittest.TestCase):
             'PUBLIC KEY')
         verifier = verify.LogVerifier(key_info)
         self.assertRaises(
-            error.EncodingError,
+            error.SignatureError,
             verifier.verify_sct,
             symantec_sct,
             [cert.Certificate.from_pem("\n".join(google_cert)),])

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,4 @@
 dnspython
-ecdsa
 git+https://github.com/google/google-visualization-python.git@04e4c03909980bc12be2ebb3ecf476716d9855d4
 mock>=1.0
 protobuf
@@ -7,5 +6,5 @@ python-gflags
 requests>=1.0
 Twisted>=12.1
 bitstring
-pycrypto>=2.5
 jsonschema
+cryptography>=1.0


### PR DESCRIPTION
Replaces "ecdsa" and "pycrypto" libraries; the former is considered to be poorly implemented, whilst the latter is poorly maintained.

This library correctly raises exceptions for all forms of invalid ASN.1 in STHs, unlike the "ecdsa" library, so some tests have been modified to account for this and a TODO removed.

See: https://cryptography.io
