### PR TITLE
Update CT tests to use StatusIs / EXPECT_OK

### DIFF
--- a/cpp/log/file_storage_test.cc
+++ b/cpp/log/file_storage_test.cc
@@ -10,12 +10,14 @@
 #include "log/file_storage.h"
 #include "log/filesystem_ops.h"
 #include "log/test_db.h"
+#include "util/status_test_util.h"
 #include "util/testing.h"
 #include "util/util.h"
 
 using cert_trans::FailingFilesystemOps;
 using cert_trans::FileStorage;
 using std::string;
+using util::testing::StatusIs;
 
 namespace {
 
@@ -40,18 +42,16 @@ TEST_F(BasicFileStorageTest, Create) {
   string key1("1245abcd", 8);
   string value1("Alice", 5);
 
-  EXPECT_EQ(util::error::NOT_FOUND,
-            fs()->LookupEntry(key0, NULL).CanonicalCode());
-  EXPECT_EQ(util::error::NOT_FOUND,
-            fs()->LookupEntry(key1, NULL).CanonicalCode());
+  EXPECT_THAT(fs()->LookupEntry(key0, NULL), StatusIs(util::error::NOT_FOUND));
+  EXPECT_THAT(fs()->LookupEntry(key1, NULL), StatusIs(util::error::NOT_FOUND));
 
-  EXPECT_EQ(util::Status::OK, fs()->CreateEntry(key0, value0));
+  EXPECT_OK(fs()->CreateEntry(key0, value0));
   string lookup_result;
-  EXPECT_EQ(util::Status::OK, fs()->LookupEntry(key0, &lookup_result));
+  EXPECT_OK(fs()->LookupEntry(key0, &lookup_result));
   EXPECT_EQ(value0, lookup_result);
 
-  EXPECT_EQ(util::Status::OK, fs()->CreateEntry(key1, value1));
-  EXPECT_EQ(util::Status::OK, fs()->LookupEntry(key1, &lookup_result));
+  EXPECT_OK(fs()->CreateEntry(key1, value1));
+  EXPECT_OK(fs()->LookupEntry(key1, &lookup_result));
   EXPECT_EQ(value1, lookup_result);
 }
 
@@ -62,8 +62,8 @@ TEST_F(BasicFileStorageTest, Scan) {
   string key1("1245abcd", 8);
   string value1("Alice", 5);
 
-  EXPECT_EQ(util::Status::OK, fs()->CreateEntry(key0, value0));
-  EXPECT_EQ(util::Status::OK, fs()->CreateEntry(key1, value1));
+  EXPECT_OK(fs()->CreateEntry(key0, value0));
+  EXPECT_OK(fs()->CreateEntry(key1, value1));
 
   std::set<string> keys;
   keys.insert(key0);
@@ -77,19 +77,18 @@ TEST_F(BasicFileStorageTest, CreateDuplicate) {
   string key("1234xyzw", 8);
   string value("unicorn", 7);
 
-  EXPECT_EQ(util::error::NOT_FOUND,
-            fs()->LookupEntry(key, NULL).CanonicalCode());
-  EXPECT_EQ(util::Status::OK, fs()->CreateEntry(key, value));
+  EXPECT_THAT(fs()->LookupEntry(key, NULL), StatusIs(util::error::NOT_FOUND));
+  EXPECT_OK(fs()->CreateEntry(key, value));
   string lookup_result;
-  EXPECT_EQ(util::Status::OK, fs()->LookupEntry(key, &lookup_result));
+  EXPECT_OK(fs()->LookupEntry(key, &lookup_result));
   EXPECT_EQ(value, lookup_result);
 
   // Try to log another entry with the same key.
   string new_value("alice", 5);
-  EXPECT_EQ(util::error::ALREADY_EXISTS,
-            fs()->CreateEntry(key, new_value).CanonicalCode());
+  EXPECT_THAT(fs()->CreateEntry(key, new_value),
+              StatusIs(util::error::ALREADY_EXISTS));
   lookup_result.clear();
-  EXPECT_EQ(util::Status::OK, fs()->LookupEntry(key, &lookup_result));
+  EXPECT_OK(fs()->LookupEntry(key, &lookup_result));
 
   // Expect to receive the original entry on lookup.
   EXPECT_EQ(value, lookup_result);
@@ -99,17 +98,16 @@ TEST_F(BasicFileStorageTest, Update) {
   string key("1234xyzw", 8);
   string value("unicorn", 7);
 
-  EXPECT_EQ(util::error::NOT_FOUND,
-            fs()->LookupEntry(key, NULL).CanonicalCode());
-  EXPECT_EQ(util::Status::OK, fs()->CreateEntry(key, value));
+  EXPECT_THAT(fs()->LookupEntry(key, NULL), StatusIs(util::error::NOT_FOUND));
+  EXPECT_OK(fs()->CreateEntry(key, value));
   string lookup_result;
-  EXPECT_EQ(util::Status::OK, fs()->LookupEntry(key, &lookup_result));
+  EXPECT_OK(fs()->LookupEntry(key, &lookup_result));
   EXPECT_EQ(value, lookup_result);
 
   // Update.
   string new_value("alice", 5);
-  EXPECT_EQ(util::Status::OK, fs()->UpdateEntry(key, new_value));
-  EXPECT_EQ(util::Status::OK, fs()->LookupEntry(key, &lookup_result));
+  EXPECT_OK(fs()->UpdateEntry(key, new_value));
+  EXPECT_OK(fs()->LookupEntry(key, &lookup_result));
 
   // Expect to receive the new entry on lookup.
   EXPECT_EQ(new_value, lookup_result);
@@ -125,16 +123,16 @@ TEST_F(BasicFileStorageTest, LookupInvalidKey) {
   string similar_key2("123", 3);
   string empty_key;
 
-  EXPECT_EQ(util::Status::OK, fs()->CreateEntry(key, value));
-  EXPECT_EQ(util::Status::OK, fs()->LookupEntry(key, NULL));
-  EXPECT_EQ(util::error::NOT_FOUND,
-            fs()->LookupEntry(similar_key0, NULL).CanonicalCode());
-  EXPECT_EQ(util::error::NOT_FOUND,
-            fs()->LookupEntry(similar_key1, NULL).CanonicalCode());
-  EXPECT_EQ(util::error::NOT_FOUND,
-            fs()->LookupEntry(similar_key2, NULL).CanonicalCode());
-  EXPECT_EQ(util::error::NOT_FOUND,
-            fs()->LookupEntry(empty_key, NULL).CanonicalCode());
+  EXPECT_OK(fs()->CreateEntry(key, value));
+  EXPECT_OK(fs()->LookupEntry(key, NULL));
+  EXPECT_THAT(fs()->LookupEntry(similar_key0, NULL),
+              StatusIs(util::error::NOT_FOUND));
+  EXPECT_THAT(fs()->LookupEntry(similar_key1, NULL),
+              StatusIs(util::error::NOT_FOUND));
+  EXPECT_THAT(fs()->LookupEntry(similar_key2, NULL),
+              StatusIs(util::error::NOT_FOUND));
+  EXPECT_THAT(fs()->LookupEntry(empty_key, NULL),
+              StatusIs(util::error::NOT_FOUND));
 }
 
 TEST_F(BasicFileStorageTest, Resume) {
@@ -144,18 +142,18 @@ TEST_F(BasicFileStorageTest, Resume) {
   string key1("1245abcd", 8);
   string value1("Alice", 5);
 
-  EXPECT_EQ(util::Status::OK, fs()->CreateEntry(key0, value0));
-  EXPECT_EQ(util::Status::OK, fs()->CreateEntry(key1, value1));
+  EXPECT_OK(fs()->CreateEntry(key0, value0));
+  EXPECT_OK(fs()->CreateEntry(key1, value1));
 
   // A second database.
   FileStorage* db2 = test_db_.SecondDB();
 
   // Look up and expect to find the entries.
   string lookup_result;
-  EXPECT_EQ(util::Status::OK, db2->LookupEntry(key0, &lookup_result));
+  EXPECT_OK(db2->LookupEntry(key0, &lookup_result));
   EXPECT_EQ(value0, lookup_result);
 
-  EXPECT_EQ(util::Status::OK, db2->LookupEntry(key1, &lookup_result));
+  EXPECT_OK(db2->LookupEntry(key1, &lookup_result));
   EXPECT_EQ(value1, lookup_result);
 
   delete db2;
@@ -168,8 +166,8 @@ TEST_F(BasicFileStorageTest, ScanOnResume) {
   string key1("1245abcd", 8);
   string value1("Alice", 5);
 
-  EXPECT_EQ(util::Status::OK, fs()->CreateEntry(key0, value0));
-  EXPECT_EQ(util::Status::OK, fs()->CreateEntry(key1, value1));
+  EXPECT_OK(fs()->CreateEntry(key0, value0));
+  EXPECT_OK(fs()->CreateEntry(key1, value1));
 
   // A second database.
   FileStorage* db2 = test_db_.SecondDB();
@@ -219,14 +217,14 @@ TEST_F(FailingFileStorageDeathTest, DieOnFailedCreate) {
   string key0("1234xyzw", 8);
   string value0("unicorn", 7);
 
-  EXPECT_EQ(util::Status::OK, db.CreateEntry(key0, value0));
+  EXPECT_OK(db.CreateEntry(key0, value0));
   int op_count0 = failing_file_op->OpCount();
   ASSERT_GT(op_count0, op_count_init);
 
   string key1("1245abcd", 8);
   string value1("Alice", 5);
 
-  EXPECT_EQ(util::Status::OK, db.CreateEntry(key1, value1));
+  EXPECT_OK(db.CreateEntry(key1, value1));
   int op_count1 = failing_file_op->OpCount();
   ASSERT_GT(op_count1, op_count0);
 
@@ -240,7 +238,7 @@ TEST_F(FailingFileStorageDeathTest, DieOnFailedCreate) {
   for (int i = op_count0; i < op_count1; ++i) {
     FileStorage db(GetTemporaryDirectory(), kStorageDepth,
                    new FailingFilesystemOps(i));
-    EXPECT_EQ(util::Status::OK, db.CreateEntry(key0, value0));
+    EXPECT_OK(db.CreateEntry(key0, value0));
     EXPECT_DEATH_IF_SUPPORTED(db.CreateEntry(key1, value1), "");
   }
 };
@@ -253,13 +251,13 @@ TEST_F(FailingFileStorageDeathTest, DieOnFailedUpdate) {
   string key("1234xyzw", 8);
   string value("unicorn", 7);
 
-  EXPECT_EQ(util::Status::OK, db.CreateEntry(key, value));
+  EXPECT_OK(db.CreateEntry(key, value));
   int op_count0 = failing_file_op->OpCount();
   ASSERT_GT(op_count0, 0);
 
   string new_value("Alice", 5);
 
-  EXPECT_EQ(util::Status::OK, db.UpdateEntry(key, new_value));
+  EXPECT_OK(db.UpdateEntry(key, new_value));
   int op_count1 = failing_file_op->OpCount();
   ASSERT_GT(op_count1, op_count0);
 
@@ -267,7 +265,7 @@ TEST_F(FailingFileStorageDeathTest, DieOnFailedUpdate) {
   for (int i = op_count0; i < op_count1; ++i) {
     FileStorage db(GetTemporaryDirectory(), kStorageDepth,
                    new FailingFilesystemOps(i));
-    EXPECT_EQ(util::Status::OK, db.CreateEntry(key, value));
+    EXPECT_OK(db.CreateEntry(key, value));
     EXPECT_DEATH_IF_SUPPORTED(db.UpdateEntry(key, new_value), "");
   }
 };
@@ -281,14 +279,14 @@ TEST_F(FailingFileStorageDeathTest, ResumeOnFailedCreate) {
   string value0("unicorn", 7);
 
   int op_count_init = failing_file_op->OpCount();
-  EXPECT_EQ(util::Status::OK, db.CreateEntry(key0, value0));
+  EXPECT_OK(db.CreateEntry(key0, value0));
   int op_count0 = failing_file_op->OpCount();
   ASSERT_GT(op_count0, 0);
 
   string key1("1245abcd", 8);
   string value1("Alice", 5);
 
-  EXPECT_EQ(util::Status::OK, db.CreateEntry(key1, value1));
+  EXPECT_OK(db.CreateEntry(key1, value1));
   int op_count1 = failing_file_op->OpCount();
   ASSERT_GT(op_count1, op_count0);
 
@@ -299,32 +297,30 @@ TEST_F(FailingFileStorageDeathTest, ResumeOnFailedCreate) {
     EXPECT_DEATH_IF_SUPPORTED(db.CreateEntry(key0, value0), "");
     FileStorage db2(db_dir, kStorageDepth);
     // Entry should not be there, and we should be able to insert it.
-    EXPECT_EQ(util::error::NOT_FOUND,
-              db2.LookupEntry(key0, NULL).CanonicalCode());
-    EXPECT_EQ(util::Status::OK, db2.CreateEntry(key0, value0));
+    EXPECT_THAT(db2.LookupEntry(key0, NULL), StatusIs(util::error::NOT_FOUND));
+    EXPECT_OK(db2.CreateEntry(key0, value0));
     // Look it up to double-check that everything works.
     string lookup_result;
-    EXPECT_EQ(util::Status::OK, db2.LookupEntry(key0, &lookup_result));
+    EXPECT_OK(db2.LookupEntry(key0, &lookup_result));
     EXPECT_EQ(value0, lookup_result);
   }
 
   for (int i = op_count0; i < op_count1; ++i) {
     string db_dir = GetTemporaryDirectory();
     FileStorage db(db_dir, kStorageDepth, new FailingFilesystemOps(i));
-    EXPECT_EQ(util::Status::OK, db.CreateEntry(key0, value0));
+    EXPECT_OK(db.CreateEntry(key0, value0));
     EXPECT_DEATH_IF_SUPPORTED(db.CreateEntry(key1, value1), "");
     FileStorage db2(db_dir, kStorageDepth);
     // First entry should be there just fine.
     string lookup_result;
-    EXPECT_EQ(util::Status::OK, db2.LookupEntry(key0, &lookup_result));
+    EXPECT_OK(db2.LookupEntry(key0, &lookup_result));
     EXPECT_EQ(value0, lookup_result);
 
     // Second entry should not be there, and we should be able to insert it.
-    EXPECT_EQ(util::error::NOT_FOUND,
-              db2.LookupEntry(key1, NULL).CanonicalCode());
-    EXPECT_EQ(util::Status::OK, db2.CreateEntry(key1, value1));
+    EXPECT_THAT(db2.LookupEntry(key1, NULL), StatusIs(util::error::NOT_FOUND));
+    EXPECT_OK(db2.CreateEntry(key1, value1));
     // Look it up to double-check that everything works.
-    EXPECT_EQ(util::Status::OK, db2.LookupEntry(key1, &lookup_result));
+    EXPECT_OK(db2.LookupEntry(key1, &lookup_result));
     EXPECT_EQ(value1, lookup_result);
   }
 }
@@ -337,13 +333,13 @@ TEST_F(FailingFileStorageDeathTest, ResumeOnFailedUpdate) {
   string key("1234xyzw", 8);
   string value("unicorn", 7);
 
-  EXPECT_EQ(util::Status::OK, db.CreateEntry(key, value));
+  EXPECT_OK(db.CreateEntry(key, value));
   int op_count0 = failing_file_op->OpCount();
   ASSERT_GT(op_count0, 0);
 
   string new_value("Alice", 5);
 
-  EXPECT_EQ(util::Status::OK, db.UpdateEntry(key, new_value));
+  EXPECT_OK(db.UpdateEntry(key, new_value));
   int op_count1 = failing_file_op->OpCount();
   ASSERT_GT(op_count1, op_count0);
 
@@ -351,12 +347,12 @@ TEST_F(FailingFileStorageDeathTest, ResumeOnFailedUpdate) {
   for (int i = op_count0; i < op_count1; ++i) {
     string db_dir = GetTemporaryDirectory();
     FileStorage db(db_dir, kStorageDepth, new FailingFilesystemOps(i));
-    EXPECT_EQ(util::Status::OK, db.CreateEntry(key, value));
+    EXPECT_OK(db.CreateEntry(key, value));
     EXPECT_DEATH_IF_SUPPORTED(db.UpdateEntry(key, new_value), "");
     FileStorage db2(db_dir, kStorageDepth);
     // The entry should be there just fine...
     string lookup_result;
-    EXPECT_EQ(util::Status::OK, db2.LookupEntry(key, &lookup_result));
+    EXPECT_OK(db2.LookupEntry(key, &lookup_result));
     // ... but it should still have its old value.
     EXPECT_EQ(value, lookup_result);
   }

--- a/cpp/log/strict_consistent_store_test.cc
+++ b/cpp/log/strict_consistent_store_test.cc
@@ -9,6 +9,7 @@
 #include "util/mock_masterelection.h"
 #include "util/status.h"
 #include "util/statusor.h"
+#include "util/status_test_util.h"
 #include "util/testing.h"
 #include "util/util.h"
 
@@ -22,6 +23,7 @@ using testing::NiceMock;
 using testing::Return;
 using util::Status;
 using util::StatusOr;
+using util::testing::StatusIs;
 
 
 class StrictConsistentStoreTest : public ::testing::TestWithParam<bool> {
@@ -57,7 +59,7 @@ TEST_P(StrictConsistentStoreTest, TestNextAvailableSequenceNumber) {
     EXPECT_EQ(123, seq.ValueOrDie());
   } else {
     EXPECT_FALSE(seq.ok());
-    EXPECT_EQ(util::error::PERMISSION_DENIED, seq.status().CanonicalCode());
+    EXPECT_THAT(seq.status(), StatusIs(util::error::PERMISSION_DENIED));
   }
 }
 
@@ -74,10 +76,9 @@ TEST_P(StrictConsistentStoreTest, TestSetServingSTH) {
   util::Status status(strict_store_.SetServingSTH(sth));
 
   if (IsMaster()) {
-    EXPECT_TRUE(status.ok());
+    EXPECT_OK(status);
   } else {
-    EXPECT_FALSE(status.ok());
-    EXPECT_EQ(util::error::PERMISSION_DENIED, status.CanonicalCode());
+    EXPECT_THAT(status, StatusIs(util::error::PERMISSION_DENIED));
   }
 }
 
@@ -97,7 +98,7 @@ TEST_P(StrictConsistentStoreTest, TestUpdateSequenceMapping) {
     EXPECT_TRUE(status.ok());
   } else {
     EXPECT_FALSE(status.ok());
-    EXPECT_EQ(util::error::PERMISSION_DENIED, status.CanonicalCode());
+    EXPECT_THAT(status, StatusIs(util::error::PERMISSION_DENIED));
   }
 }
 
@@ -116,8 +117,7 @@ TEST_P(StrictConsistentStoreTest, TestClusterConfig) {
   if (IsMaster()) {
     EXPECT_TRUE(status.ok());
   } else {
-    EXPECT_FALSE(status.ok());
-    EXPECT_EQ(util::error::PERMISSION_DENIED, status.CanonicalCode());
+    EXPECT_THAT(status, StatusIs(util::error::PERMISSION_DENIED));
   }
 }
 

--- a/cpp/log/tree_signer_test.cc
+++ b/cpp/log/tree_signer_test.cc
@@ -17,6 +17,7 @@
 #include "proto/ct.pb.h"
 #include "util/fake_etcd.h"
 #include "util/mock_masterelection.h"
+#include "util/status_test_util.h"
 #include "util/sync_task.h"
 #include "util/testing.h"
 #include "util/thread_pool.h"
@@ -176,7 +177,7 @@ TYPED_TEST(TreeSignerTest, Sign) {
   this->test_signer_.CreateUnique(&logged_cert);
   this->AddPendingEntry(&logged_cert);
   // this->AddSequencedEntry(&logged_cert, 0);
-  EXPECT_EQ(util::Status::OK, this->tree_signer_->SequenceNewEntries());
+  EXPECT_OK(this->tree_signer_->SequenceNewEntries());
   EXPECT_EQ(TS::OK, this->tree_signer_->UpdateTree());
 
   const SignedTreeHead sth(this->tree_signer_->LatestSTH());
@@ -291,7 +292,7 @@ TYPED_TEST(TreeSignerTest, SequenceNewEntriesCleansUpOldSequenceMappings) {
   LoggedCertificate logged_cert;
   this->test_signer_.CreateUnique(&logged_cert);
   this->AddPendingEntry(&logged_cert);
-  EXPECT_EQ(util::Status::OK, this->tree_signer_->SequenceNewEntries());
+  EXPECT_OK(this->tree_signer_->SequenceNewEntries());
   EXPECT_EQ(TS::OK, this->tree_signer_->UpdateTree());
   EXPECT_EQ(Status::OK,
             this->store_->SetServingSTH(this->tree_signer_->LatestSTH()));
@@ -313,7 +314,7 @@ TYPED_TEST(TreeSignerTest, SequenceNewEntriesCleansUpOldSequenceMappings) {
   }
   this->DeletePendingEntry(logged_cert);
   LOG(INFO) << "2";
-  EXPECT_EQ(util::Status::OK, this->tree_signer_->SequenceNewEntries());
+  EXPECT_OK(this->tree_signer_->SequenceNewEntries());
 
   {
     EntryHandle<SequenceMapping> mapping;

--- a/cpp/net/url_fetcher_test.cc
+++ b/cpp/net/url_fetcher_test.cc
@@ -115,7 +115,7 @@ TEST_F(UrlFetcherTest, TestCertMatchesHost) {
   SyncTask task(&pool_);
   fetcher_->Fetch(req, &resp, task.task());
   task.Wait();
-  EXPECT_EQ(util::Status::OK, task.status());
+  EXPECT_OK(task.status());
   EXPECT_EQ(200, resp.status_code);
 }
 
@@ -153,7 +153,7 @@ TEST_F(UrlFetcherTest, TestStarMatchesSubdomain) {
   SyncTask task(&pool_);
   fetcher_->Fetch(req, &resp, task.task());
   task.Wait();
-  EXPECT_EQ(util::Status::OK, task.status());
+  EXPECT_OK(task.status());
   EXPECT_EQ(200, resp.status_code);
 }
 
@@ -179,7 +179,7 @@ TEST_F(UrlFetcherTest, TestSubdomainMatches) {
   SyncTask task(&pool_);
   fetcher_->Fetch(req, &resp, task.task());
   task.Wait();
-  EXPECT_EQ(util::Status::OK, task.status());
+  EXPECT_OK(task.status());
   EXPECT_EQ(200, resp.status_code);
 }
 
@@ -243,7 +243,7 @@ TEST_F(UrlFetcherTest, TestIpMatches) {
   SyncTask task(&pool_);
   fetcher_->Fetch(req, &resp, task.task());
   task.Wait();
-  EXPECT_EQ(util::Status::OK, task.status());
+  EXPECT_OK(task.status());
   EXPECT_EQ(200, resp.status_code);
 }
 

--- a/cpp/util/fake_etcd_test.cc
+++ b/cpp/util/fake_etcd_test.cc
@@ -430,7 +430,7 @@ TEST_F(FakeEtcdTest, DeleteNonExistent) {
   ++expected_stats["compareAndDeleteFail"];
 
   Status status(BlockingDelete("/potato", 42));
-  EXPECT_EQ(util::error::NOT_FOUND, status.CanonicalCode()) << status;
+  EXPECT_THAT(status, StatusIs(util::error::NOT_FOUND));
 
   map<string, int64_t> stats;
   ASSERT_OK(BlockingGetStats(&stats));

--- a/cpp/util/task_test.cc
+++ b/cpp/util/task_test.cc
@@ -7,6 +7,7 @@
 
 #include "base/notification.h"
 #include "util/executor.h"
+#include "util/status_test_util.h"
 #include "util/task.h"
 #include "util/testing.h"
 #include "util/thread_pool.h"
@@ -155,7 +156,7 @@ void WaitForReturnCallback(TypeParam* s, Notification* notifier) {
   EXPECT_FALSE(s->task()->IsActive());
   EXPECT_TRUE(s->task()->IsDone());
   EXPECT_FALSE(s->task()->CancelRequested());
-  EXPECT_EQ(util::Status::OK, s->task()->status());
+  EXPECT_OK(s->task()->status());
   s->ContinueDone();
   notifier->Notify();
 }


### PR DESCRIPTION
Update tests that were directly checking error codes to use StatusIs().
Update those explicitly testing for Status::OK to use EXPECT_OK.