### PR TITLE
Fixes for signed / unsigned mismatches

### DIFF
--- a/cpp/fetcher/fetcher.cc
+++ b/cpp/fetcher/fetcher.cc
@@ -233,7 +233,7 @@ void FetchState::WriteToDatabase(int64_t index, Range* range,
     return;
   }
 
-  CHECK_GT(retval->size(), 0);
+  CHECK_GT(retval->size(), static_cast<size_t>(0));
 
   VLOG(1) << "received " << retval->size() << " entries at offset " << index;
   int64_t processed(0);

--- a/cpp/log/cluster_state_controller-inl.h
+++ b/cpp/log/cluster_state_controller-inl.h
@@ -301,7 +301,7 @@ void ClusterStateController<Logged>::OnClusterStateUpdated(
       }
     } else {
       VLOG(1) << "Node left: " << node_id;
-      CHECK_EQ(1, all_peers_.erase(node_id));
+      CHECK_EQ(static_cast<size_t>(1), all_peers_.erase(node_id));
       fetcher_->RemovePeer(node_id);
     }
   }

--- a/cpp/log/tree_signer-inl.h
+++ b/cpp/log/tree_signer-inl.h
@@ -189,7 +189,8 @@ util::Status TreeSigner<Logged>::SequenceNewEntries() {
   }
 
   // Sanity check: make sure no hashes above the serving_sth level vanished:
-  const uint64_t serving_tree_size(serving_sth.ValueOrDie().tree_size());
+  CHECK_LE(serving_sth.ValueOrDie().tree_size(), INT64_MAX);
+  const int64_t serving_tree_size(serving_sth.ValueOrDie().tree_size());
   for (const auto& s : sequenced_hashes) {
     if (!s.second.second /*present*/) {
       // if it disappeared, check it's underwater:
@@ -271,7 +272,9 @@ bool TreeSigner<Logged>::Append(const Logged& logged) {
   std::string serialized_leaf;
   CHECK(logged.SerializeForLeaf(&serialized_leaf));
 
-  CHECK_EQ(logged.sequence_number(), cert_tree_->LeafCount());
+  CHECK_LE(cert_tree_->LeafCount(), INT64_MAX);
+  CHECK_EQ(logged.sequence_number(),
+           static_cast<int64_t>(cert_tree_->LeafCount()));
   // Commit the sequence number of this certificate locally
   typename Database<Logged>::WriteResult db_result =
       db_->CreateSequencedEntry(logged);


### PR DESCRIPTION
I don't think these could manifest as bugs in practice as the tree could never get large enough in memory to overflow. Found by compilation with GCC 5.1 on F22.