### PR TITLE
Prevents Log Observer's Monitor getting quietly wedged when entry scanning fails unexpectedly.

### DIFF
--- a/python/ct/client/log_client.py
+++ b/python/ct/client/log_client.py
@@ -872,18 +872,19 @@ class EntryProducer(object):
     def resumeProducing(self):
         if self._paused and not self._stopped:
             self._paused = False
-            self.produce()
+            d = self.produce()
+            d.addErrback(self.finishProducing)
 
     def stopProducing(self):
         self._paused = True
         self._stopped = True
 
-    def finishProducing(self, success=True):
+    def finishProducing(self, failure=None):
         self.stopProducing()
-        if success:
-          self._done.callback(self._end - self._start + 1)
+        if failure is None:
+            self._done.callback(self._end - self._start + 1)
         else:
-          self._done.callback(None)
+            self._done.errback(failure)
 
 
 class AsyncLogClient(object):


### PR DESCRIPTION
The Log Observer could get wedged if an exception was raised during log entry scanning.
This exception would be logged, but the scan would never be retried and Monitor would never attempt 
to get a new STH or new log entries. The error would likely go unnoticed for some time, at which point it would be challenging to discover the original cause.

The first commit in this PR prevents the Log Observer becoming wedged, but does nothing to deal with the original cause. The second commit ensures that Monitor is notified when the producer stops producing log entries (e.g. due to an exception being raised). The final commit re-introduces wedging in the case of an unexpected scanning error, but in such a way that the scanning is retried and so the error should be much more visible. This promotes fixing the error, at which point the Log Observer will become unwedged.