### PR TITLE
Updates to docs for gclient builds on more platforms

### DIFF
--- a/README.Fedora
+++ b/README.Fedora
@@ -1,5 +1,13 @@
 ## Quickstart on Fedora 22 ##
 
+Please attempt to use the GClient build as documented in the 
+[main readme](README.md) as this is an easier process and will be
+maintained in future.
+
+If GClient works and tests pass then the following procedures are not
+required.
+
+## Deprecated Manual Build Process ##
 
 Note: This assumes a Workstation install for x64. The additional dependency
 packages that need to be installed may vary if you are starting with a
@@ -8,70 +16,70 @@ different base system.
 
 Install Dependencies:
 
-
-sudo dnf update
+```sudo dnf update
 sudo dnf install cmake gcc-g++ libevent-devel golang autoconf pkgconfig \
     json-c-devel gflags-devel glog-devel protobuf-devel leveldb-devel \
     openssl-devel gperftools-devel protobuf-compiler sqlite-devel ant \
     java-1.8.0-openjdk-devel protobuf-java python-gflags protobuf-python \
-    python-ecdsa python-mock python-httplib2 git ldns-devel automake
-
+    python-ecdsa python-mock python-httplib2 git ldns-devel automake \
+    libtool shtool libunwind-devel
+```
 
 Other Libraries
 
 
-The gflags in Fedora is v2.1 and is using the new default namespace option of
+The `gflags` in Fedora is v2.1 and is using the new default namespace option of
 ‘gflags’ rather than ‘google’ so we need to build our own version. 
 
 
-    git clone https://github.com/gflags/gflags.git
+```git clone https://github.com/gflags/gflags.git
     cd gflags
     cmake -DGFLAGS_NAMESPACE:STRING=google \
         -DCMAKE_CXX_FLAGS:STRING=-fPIC .
     make
     cd ..
-
+```
 
 Next, we need `libevhtp` version `1.2.10` which is not packaged in Fedora, so
 we build from source:
 
-   wget https://github.com/ellzey/libevhtp/archive/1.2.10.zip
+```wget https://github.com/ellzey/libevhtp/archive/1.2.10.zip
    unzip 1.2.10.zip
    cd libevhtp-1.2.10/
    cmake -DEVHTP_DISABLE_REGEX:STRING=ON -DCMAKE_C_FLAGS:STRING=-fPIC .
    make
    cd ..
- 
+```
 
 And let's get our own Google Test / Google Mock as these vary in incompatible
 ways between packaged releases:
 
-   wget https://googlemock.googlecode.com/files/gmock-1.7.0.zip
+```wget https://googlemock.googlecode.com/files/gmock-1.7.0.zip
    unzip gmock-1.7.0.zip
-
+```
 Now, clone the CT repo:
 
-   git clone https://github.com/google/certificate-transparency.git
+```git clone https://github.com/google/certificate-transparency.git
    cd certificate-transparency/
-
+```
 
 One-time setup for Go:
 
-   export GOPATH=$PWD/go
+```export GOPATH=$PWD/go
    mkdir -p $GOPATH/src/github.com/google
    ln -s $PWD $GOPATH/src/github.com/google
    go get -v -d ./...
-
+```
 
 Build CT server C++ code:
 
-   ./autogen.sh
+```./autogen.sh
    ./configure GTEST_DIR=../gmock-1.7.0/gtest GMOCK_DIR=../gmock-1.7.0 \
        CPPFLAGS="-I../libevhtp-1.2.10 -I../libevhtp-1.2.10/evthr \
        -I../libevhtp-1.2.10/htparse -I../gflags/include" \
         LDFLAGS=”-L../libevhtp-1.2.10 -L../gflags/lib”
    make check 
-
+```
 
 The remainder of the Java, Go and Python steps should be very similar to those
-documented for Ubuntu in the main README.
+documented for Ubuntu in the [main readme file](README.md).

--- a/README.MacOS
+++ b/README.MacOS
@@ -1,4 +1,9 @@
-# Trusted root certificates
+## OSX Builds Now Use GClient ##
+
+We recommend that you use GClient to build on OSX. Please follow the 
+instructions in the [main readme](README.md) file.
+
+## Trusted root certificates ##
 
 The CT code requires a set of trusted root certificates in order to:
    1. Validate outbound HTTPS connections
@@ -45,3 +50,8 @@ security find-certificates -a -p /Library/Keychains/System.keychain > certs.pem
 security find-certificates -a -p /System/Library/Keychains/SystemRootCertificates.keychain >> certs.pem
 ```
 
+## Deprecated Build Process ##
+
+This may be out of date and is not guaranteed to work.
+
+gtest: install from source.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,88 @@
 certificate-transparency
 ========================
 
+#Auditing for TLS certificates#
+
 [![Build Status](https://travis-ci.org/google/certificate-transparency.svg?branch=master)](https://travis-ci.org/google/certificate-transparency)
 
-Auditing for TLS certificates.
 
-## Quickstart on Ubuntu ##
-The following steps will checkout the code and build it on a clean Ubuntu 14.04 LTS installation.  It has also been tested on an Ubuntu 15.04 installation.
+## Build With GClient ##
+
+This is now the recommended method for all supported platforms. It gives you 
+a reproducible build and avoids the need to build some dependencies manually.
+
+Known to work on FreeBSD 10, OS X (10.10) [tested with XCode + brew installation
+of deps listed below], and Ubuntu 14.04. Tested on Fedora 22 but may require
+manual override of compiler options as documented below. Tested on CentOS 7
+with similar caveats.
+
+### Install Dependencies ###
+
+Depending on which platform you have the exact packages required will vary.
+The following tools must be available for the GClient build to succeed:
+
+ - A working C++11 compiler.
+
+ - autoconf/automake etc.
+ - cmake
+ - git
+ - GNU make
+ - libtool
+ - shtool
+ - Tcl
+ - pkgconf
+ - python27
+ - [depot_tools](https://www.chromium.org/developers/how-tos/install-depot-tools)
+
+### Building with gclient ###
+
+```bash
+mkdir ct  # or whatever directory you prefer
+cd ct
+gclient config --name="certificate-transparency" https://github.com/google/certificate-transparency.git
+gclient sync
+# substitute gmake or gnumake below if that's what your platform calls it:
+make -C certificate-transparency check
+```
+
+If you're trying to clone from a branch on the CT repo then you'll need to
+substitute the following command for the `gclient config` command above,
+replacing `branch` as appropriate
+
+```bash
+gclient config --name="certificate-transparency" https://github.com/google/certificate-transparency.git@branch
+```
+
+### Platform Specific Notes ###
+
+#### Fedora / CentOS ####
+
+When you issue the `gclient sync` command you may need to set compiler options
+in order to build successfully. If the build fails to work try using:
+
+```CXXFLAGS="-O2 -Wno-error=unused-variable" gclient sync
+```
+
+If this gives an error about an unused typedef in a `glog` header file try this:
+
+```CXXFLAGS="-O2 -Wno-error=unused-variable -Wno-error=unused-local-typedefs" gclient sync
+```
+
+When changing `CXXFLAGS` it's safer to remove the existing build directories
+in case not all dependencies are properly accounted for and rebuilt. If 
+problems persist check that the Makefile in `certificate-transparency` 
+contains the options that were passed in `CXXFLAGS`.
+
+If there are still problems using GClient then an older style build can be
+attempted. The process should be similar to the one documented for Ubuntu
+below or in the [Fedora README](README.Fedora) depending on platform.
+
+## Deprecated: Quickstart on Ubuntu ##
+
+This should no longer be needed as the instructions above should work. But in
+case of difficulties the dependencies can be built manually. The following 
+steps will checkout the code and build it on a clean Ubuntu 14.04 LTS 
+installation.  It has also been tested on an Ubuntu 15.04 installation.
 
 First, install packaged dependencies:
 
@@ -64,53 +140,7 @@ Best and test Go code:
     go test -v ./go/...
 
 
-## Dependencies ##
-
- - A working C++11 compiler.
-
- - autoconf/automake etc.
- - cmake
- - git
- - GNU make
- - libtool
- - shtool
- - Tcl
- - pkgconf
- - python27
- - [depot_tools](https://www.chromium.org/developers/how-tos/install-depot-tools)
-
-## Building with gclient ##
-
-This is the recommended method for all platforms as it gives you a reproducible
-build.
-
-Known to work on FreeBSD 10, OS X (10.10) [tested with XCode + brew installation
-of above deps], and Ubuntu 14.04.
-
-```bash
-mkdir ct  # or whatever directory you prefer
-cd ct
-gclient config --name="certificate-transparency" git@github.com:google/certificate-transparency.git
-gclient sync
-# substitute gmake or gnumake below if that's that your platform calls it:
-make -C certificate-transparency check
-```
-
-If you're trying to clone from a branch on the CT repo then you'll need to
-substitute the following command for the `gclient config` command above,
-replacing `branch` as appropriate
-
-```bash
-gclient config --name="certificate-transparency" git@github.com:google/certificate-transparency.git@branch
-```
-
-To run any of the built binaries you'll need to:
-
-```bash
-export LD_LIBRARY_PATH=/path/to/ct/install/lib'
-```
-
-## Old Method ##
+## Deprecated: Older Build Method ##
 
  - [OpenSSL](https://www.openssl.org/source/), at least 1.0.0q,
    preferably 1.0.1l or 1.0.2 (and up)
@@ -174,7 +204,7 @@ platform we had to build from the source, specifically commit
   - pyasn1 and pyasn1-modules (optional, needed for `upload_server_cert.sh`)
   - [dnspython](http://www.dnspython.org/)
 
-## Building ##
+### Building ###
 
 You can build the log server with the following commands:
 


### PR DESCRIPTION
Update to build with GClient on F22 and CentOS 7 including potential flag changes to get around having -Werror set. Switch git checkouts in docs to https:// for more compatibility.