### PR TITLE
Improves Python certificate scanning resiliency

### DIFF
--- a/python/ct/client/db_reporter_test.py
+++ b/python/ct/client/db_reporter_test.py
@@ -14,6 +14,15 @@ class DbReporterTest(unittest.TestCase):
             reporter.report()
             self.assertEqual(db.store_certs_desc.call_count, 10 * j)
 
+    def test_db_raising_does_not_stall_reporter(self):
+        db = mock.Mock()
+        db.store_certs_desc.side_effect = [ValueError("Boom!"), None]
+
+        reporter = db_reporter.CertDBCertificateReport(db, 1, checks=[])
+        reporter._batch_scanned_callback([(None, None, None)])
+        reporter._batch_scanned_callback([(None, None, None)])
+        reporter.report()
+        self.assertEqual(db.store_certs_desc.call_count, 2)
 
 if __name__ == '__main__':
-  unittest.main()
+    unittest.main()


### PR DESCRIPTION
CertificateReport will no longer stop scanning all of the certificates in a batch and discard the results if one certificate results in an unexpected exception being raised. Instead, it will log the exception and continue scanning the rest of the certificates. The reporters have also been made more resilient to exceptions - their writer threads are less likely to die due to unexpected exceptions and may now be restarted.