### PR TITLE
Try not to clobber OpenSSL's cert lookup paths.

### DIFF
--- a/README.MacOS
+++ b/README.MacOS
@@ -1,8 +1,47 @@
-gtest: install from source.
+# Trusted root certificates
 
-glog: brew install glog (note: this may cause linking problems if
-installed before gflags, so possibly first do: brew install gflags)
+The CT code requires a set of trusted root certificates in order to:
+   1. Validate outbound HTTPS connections
+   2. (In the case of the log-server) decide whether to accept a certificate
+      chain for inclusion.
 
-protocol buffers: brew install protobuf
+On OSX, the system version of OpenSSL (0.9.8gz at time of writing) contains
+Apple-provided patches which intercept failed chain validations and re-attempts
+them using roots obtained from the system keychain. Since we use a much more
+recent (and unpatched) version of OpenSSL this behaviour is unsupported and so
+a PEM file containing the trusted root certs must be used.
 
-json-c: brew install json-c
+## Specifying root certificates to be used
+
+To use a certificate PEM bundle file with the CT C++ code, the following
+methods may be used:
+
+### For verifying outbound HTTPS connections:
+
+Either set the
+`--trusted_roots_certs' flag, or the `SSL_CERT_FILE` environment variable, to
+point to the location of the PEM file containing the root certificates to be
+used to verify the outbound HTTPS connection.
+
+### Incoming inclusion requests (ct-server only)
+
+Set the `--trusted_cert_file` flag to point to the location of the PEM file
+containing the set of root certificates whose chains should be accepted for
+inclusion into the log.
+
+## Sources of trusted roots
+
+Obviously the choice of root certificates to trust for outbound HTTPS
+connections and incoming inclusion requests are a matter of operating policy,
+but it is often useful to have a set of common roots for testing and
+development at the very least.
+
+While OSX ships with a set of common trusted roots, they are not directly
+available to OpenSSL and must be exported from the keychain first.  This can be
+achieved with the following command:
+
+```bash
+security find-certificates -a -p /Library/Keychains/System.keychain > certs.pem
+security find-certificates -a -p /System/Library/Keychains/SystemRootCertificates.keychain >> certs.pem
+```
+

--- a/build/Makefile.openssl
+++ b/build/Makefile.openssl
@@ -1,3 +1,7 @@
+# Grab the openssldir of the system version of openssl in order to try to have
+# our version re-use the system caroots by default.
+OPENSSLDIR := $(shell openssl version -d | awk '{ print $$2 }')
+
 all: $(INSTALL_DIR)/bin/openssl
 
 $(INSTALL_DIR)/bin/openssl: Makefile
@@ -7,6 +11,6 @@ $(INSTALL_DIR)/bin/openssl: Makefile
 
 Makefile: config Configure Makefile.org
 	# Force a 64 bit build on MacOS
-	KERNEL_BITS=64 ./config --openssldir=$(INSTALL_DIR) no-shared enable-static-engine -fPIC
+	KERNEL_BITS=64 ./config --install_prefix=$(INSTALL_DIR) --prefix=/ --libdir=lib --openssldir=$(OPENSSLDIR) no-shared enable-static-engine -fPIC
 	# just to be sure we don't have dregs left over
 	$(MAKE) clean


### PR DESCRIPTION
This seems to use the system CA certs on Ubuntu and FreeBSD now.

Addresses #979 