### PR TITLE
Fixup cms.h file include that was overlooked in cert_checker.cc

### DIFF
--- a/cpp/log/cert_checker.cc
+++ b/cpp/log/cert_checker.cc
@@ -5,7 +5,6 @@
 #include <memory>
 #include <openssl/asn1.h>
 #include <openssl/bio.h>
-#include <openssl/cms.h>
 #include <openssl/pem.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>


### PR DESCRIPTION
Fix include of cms.h that was left behind.