### PR TITLE
Rename LoggedCertificate to LoggedEntry

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -77,7 +77,7 @@ TESTS = \
 	cpp/log/frontend_test \
 	cpp/log/log_lookup_test \
 	cpp/log/log_signer_test \
-	cpp/log/logged_certificate_test \
+	cpp/log/logged_entry_test \
 	cpp/log/signer_verifier_test \
 	cpp/log/strict_consistent_store_test \
 	cpp/log/tree_signer_test \
@@ -144,7 +144,7 @@ cpp_libcore_a_SOURCES = \
 	cpp/log/log_lookup_cert.cc \
 	cpp/log/log_signer.cc \
 	cpp/log/log_verifier.cc \
-	cpp/log/logged_certificate.cc \
+	cpp/log/logged_entry.cc \
 	cpp/log/signer.cc \
 	cpp/log/sqlite_db_cert.cc \
 	cpp/log/strict_consistent_store_cert.cc \
@@ -483,13 +483,13 @@ cpp_log_log_signer_test_SOURCES = \
 	cpp/proto/serializer.cc \
 	cpp/util/util.cc
 
-cpp_log_logged_certificate_test_LDADD = \
+cpp_log_logged_entry_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \
 	$(libevent_LIBS) \
 	-lprotobuf
-cpp_log_logged_certificate_test_SOURCES = \
-	cpp/log/logged_certificate_test.cc \
+cpp_log_logged_entry_test_SOURCES = \
+	cpp/log/logged_entry_test.cc \
 	cpp/proto/serializer.cc \
 	cpp/util/util.cc
 

--- a/cpp/client/ssl_client.cc
+++ b/cpp/client/ssl_client.cc
@@ -233,7 +233,7 @@ int SSLClient::VerifyCallback(X509_STORE_CTX* ctx, void* arg) {
     } else {
       args->ct_data.mutable_reconstructed_entry()->CopyFrom(entry);
       args->ct_data.set_certificate_sha256_hash(
-          Sha256Hasher::Sha256Digest(Serializer::LeafCertificate(entry)));
+          Sha256Hasher::Sha256Digest(Serializer::LeafData(entry)));
       // Only writes the checkpoint if verification succeeds.
       // Note: an optimized client could only verify the signature if it's
       // a certificate it hasn't seen before.

--- a/cpp/fetcher/continuous_fetcher.cc
+++ b/cpp/fetcher/continuous_fetcher.cc
@@ -31,7 +31,7 @@ namespace {
 class ContinuousFetcherImpl : public ContinuousFetcher {
  public:
   ContinuousFetcherImpl(libevent::Base* base, Executor* executor,
-                        Database<LoggedCertificate>* db,
+                        Database<LoggedEntry>* db,
                         const LogVerifier* log_verifier, bool fetch_scts);
 
   void AddPeer(const string& node_id, const shared_ptr<Peer>& peer) override;
@@ -44,7 +44,7 @@ class ContinuousFetcherImpl : public ContinuousFetcher {
 
   libevent::Base* const base_;
   Executor* const executor_;
-  Database<LoggedCertificate>* const db_;
+  Database<LoggedEntry>* const db_;
   const LogVerifier* const log_verifier_;
   const bool fetch_scts_;
 
@@ -59,7 +59,7 @@ class ContinuousFetcherImpl : public ContinuousFetcher {
 
 
 ContinuousFetcherImpl::ContinuousFetcherImpl(
-    libevent::Base* base, Executor* executor, Database<LoggedCertificate>* db,
+    libevent::Base* base, Executor* executor, Database<LoggedEntry>* db,
     const LogVerifier* const log_verifier, bool fetch_scts)
     : base_(CHECK_NOTNULL(base)),
       executor_(CHECK_NOTNULL(executor)),
@@ -164,7 +164,7 @@ void ContinuousFetcherImpl::FetchDelayDone(Task* task) {
 
 // static
 unique_ptr<ContinuousFetcher> ContinuousFetcher::New(
-    libevent::Base* base, Executor* executor, Database<LoggedCertificate>* db,
+    libevent::Base* base, Executor* executor, Database<LoggedEntry>* db,
     const LogVerifier* log_verifier, bool fetch_scts) {
   return unique_ptr<ContinuousFetcher>(
       new ContinuousFetcherImpl(base, executor, db, log_verifier, fetch_scts));

--- a/cpp/fetcher/continuous_fetcher.h
+++ b/cpp/fetcher/continuous_fetcher.h
@@ -10,7 +10,7 @@
 #include "base/macros.h"
 #include "fetcher/peer.h"
 #include "log/database.h"
-#include "log/logged_certificate.h"
+#include "log/logged_entry.h"
 #include "util/executor.h"
 #include "util/libevent_wrapper.h"
 #include "util/task.h"
@@ -24,7 +24,7 @@ class ContinuousFetcher {
  public:
   static std::unique_ptr<ContinuousFetcher> New(
       libevent::Base* base, util::Executor* executor,
-      Database<LoggedCertificate>* db, const LogVerifier* log_verifier,
+      Database<LoggedEntry>* db, const LogVerifier* log_verifier,
       bool fetch_scts);
 
   virtual ~ContinuousFetcher() = default;

--- a/cpp/fetcher/fetcher.h
+++ b/cpp/fetcher/fetcher.h
@@ -5,7 +5,7 @@
 
 #include "fetcher/peer_group.h"
 #include "log/database.h"
-#include "log/logged_certificate.h"
+#include "log/logged_entry.h"
 #include "util/task.h"
 
 class LogVerifier;
@@ -13,7 +13,7 @@ class LogVerifier;
 namespace cert_trans {
 
 
-void FetchLogEntries(Database<LoggedCertificate>* db,
+void FetchLogEntries(Database<LoggedEntry>* db,
                      std::unique_ptr<PeerGroup> peer_group,
                      const LogVerifier* log_verifier, util::Task* task);
 

--- a/cpp/fetcher/remote_peer.cc
+++ b/cpp/fetcher/remote_peer.cc
@@ -8,7 +8,6 @@
 #include "monitoring/monitoring.h"
 #include "util/util.h"
 
-using cert_trans::LoggedCertificate;
 using ct::SignedTreeHead;
 using std::bind;
 using std::chrono::seconds;

--- a/cpp/fetcher/remote_peer.h
+++ b/cpp/fetcher/remote_peer.h
@@ -7,8 +7,6 @@
 
 namespace cert_trans {
 
-class LoggedCertificate;
-
 
 class RemotePeer : public Peer {
  public:

--- a/cpp/fetcher/remote_peer_test.cc
+++ b/cpp/fetcher/remote_peer_test.cc
@@ -189,13 +189,13 @@ class RemotePeerTest : public ::testing::Test {
   shared_ptr<libevent::Base> base_;
   libevent::EventPumpThread event_pump_;
   FakeEtcdClient etcd_client_;
-  TestDB<LevelDB<LoggedCertificate>> test_db_;
+  TestDB<LevelDB<LoggedEntry>> test_db_;
   ThreadPool pool_;
   NiceMock<MockMasterElection> election_;
-  cert_trans::EtcdConsistentStore<LoggedCertificate> store_;
+  cert_trans::EtcdConsistentStore<LoggedEntry> store_;
   TestSigner test_signer_;
   unique_ptr<LogSigner> log_signer_;
-  TreeSigner<LoggedCertificate> tree_signer_;
+  TreeSigner<LoggedEntry> tree_signer_;
   SyncTask task_;
   MockUrlFetcher fetcher_;
   unique_ptr<RemotePeer> peer_;

--- a/cpp/log/cluster_state_controller_cert.cc
+++ b/cpp/log/cluster_state_controller_cert.cc
@@ -1,6 +1,6 @@
 #include "log/cluster_state_controller-inl.h"
-#include "log/logged_certificate.h"
+#include "log/logged_entry.h"
 
 namespace cert_trans {
-template class ClusterStateController<LoggedCertificate>;
+template class ClusterStateController<LoggedEntry>;
 }  // namespace cert_trans

--- a/cpp/log/database_large_test.cc
+++ b/cpp/log/database_large_test.cc
@@ -11,7 +11,7 @@
 #include "log/file_db.h"
 #include "log/file_storage.h"
 #include "log/leveldb_db.h"
-#include "log/logged_certificate.h"
+#include "log/logged_entry.h"
 #include "log/sqlite_db.h"
 #include "log/test_db.h"
 #include "log/test_signer.h"
@@ -26,10 +26,10 @@ DEFINE_int32(database_size, 100,
 
 namespace {
 
-using cert_trans::LoggedCertificate;
+using cert_trans::LoggedEntry;
 using std::string;
 
-typedef Database<LoggedCertificate> DB;
+typedef Database<LoggedEntry> DB;
 
 template <class T>
 class LargeDBTest : public ::testing::Test {
@@ -41,7 +41,7 @@ class LargeDBTest : public ::testing::Test {
   }
 
   void FillDatabase(int entries) {
-    LoggedCertificate logged_cert;
+    LoggedEntry logged_cert;
     for (int i = 0; i < entries; ++i) {
       test_signer_.CreateUniqueFakeSignature(&logged_cert);
       logged_cert.set_sequence_number(i);
@@ -51,7 +51,7 @@ class LargeDBTest : public ::testing::Test {
 
   int ReadAllSequencedEntries(int num) {
     std::set<string>::const_iterator it;
-    LoggedCertificate lookup_cert;
+    LoggedEntry lookup_cert;
     for (int i = 0; i < num; ++i) {
       EXPECT_EQ(DB::LOOKUP_OK, this->db()->LookupByIndex(i, &lookup_cert));
     }
@@ -66,8 +66,8 @@ class LargeDBTest : public ::testing::Test {
   TestSigner test_signer_;
 };
 
-typedef testing::Types<FileDB<LoggedCertificate>, SQLiteDB<LoggedCertificate>,
-                       LevelDB<LoggedCertificate>> Databases;
+typedef testing::Types<FileDB<LoggedEntry>, SQLiteDB<LoggedEntry>,
+                       LevelDB<LoggedEntry>> Databases;
 
 TYPED_TEST_CASE(LargeDBTest, Databases);
 

--- a/cpp/log/etcd_consistent_store-inl.h
+++ b/cpp/log/etcd_consistent_store-inl.h
@@ -9,7 +9,6 @@
 
 #include "base/notification.h"
 #include "log/etcd_consistent_store.h"
-#include "log/logged_certificate.h"
 #include "monitoring/event_metric.h"
 #include "monitoring/latency.h"
 #include "monitoring/monitoring.h"

--- a/cpp/log/etcd_consistent_store_cert.cc
+++ b/cpp/log/etcd_consistent_store_cert.cc
@@ -1,7 +1,7 @@
 #include <gflags/gflags.h>
 
 #include "log/etcd_consistent_store-inl.h"
-#include "log/logged_certificate.h"
+#include "log/logged_entry.h"
 
 // This needs to be quite frequent since the number of entries which can be
 // added every second can be pretty high.
@@ -11,5 +11,5 @@ DEFINE_int32(node_state_ttl_seconds, 60,
              "TTL in seconds on the node state files.");
 
 namespace cert_trans {
-template class EtcdConsistentStore<LoggedCertificate>;
+template class EtcdConsistentStore<LoggedEntry>;
 }  // namespace cert_trans

--- a/cpp/log/file_db_cert.cc
+++ b/cpp/log/file_db_cert.cc
@@ -1,4 +1,4 @@
 #include "log/file_db-inl.h"
-#include "log/logged_certificate.h"
+#include "log/logged_entry.h"
 
-template class FileDB<cert_trans::LoggedCertificate>;
+template class FileDB<cert_trans::LoggedEntry>;

--- a/cpp/log/frontend_signer.h
+++ b/cpp/log/frontend_signer.h
@@ -6,7 +6,7 @@
 
 #include "base/macros.h"
 #include "log/consistent_store.h"
-#include "log/logged_certificate.h"
+#include "log/logged_entry.h"
 
 template <class Logged>
 class Database;
@@ -20,10 +20,9 @@ class Status;
 class FrontendSigner {
  public:
   // Does not take ownership of |db|, |store| or |signer|.
-  FrontendSigner(
-      Database<cert_trans::LoggedCertificate>* db,
-      cert_trans::ConsistentStore<cert_trans::LoggedCertificate>* store,
-      LogSigner* signer);
+  FrontendSigner(Database<cert_trans::LoggedEntry>* db,
+                 cert_trans::ConsistentStore<cert_trans::LoggedEntry>* store,
+                 LogSigner* signer);
 
   // Log the entry if it's not already in the database,
   // and return either a new timestamp-signature pair,
@@ -36,8 +35,8 @@ class FrontendSigner {
   void TimestampAndSign(const ct::LogEntry& entry,
                         ct::SignedCertificateTimestamp* sct) const;
 
-  Database<cert_trans::LoggedCertificate>* const db_;
-  cert_trans::ConsistentStore<cert_trans::LoggedCertificate>* const store_;
+  Database<cert_trans::LoggedEntry>* const db_;
+  cert_trans::ConsistentStore<cert_trans::LoggedEntry>* const store_;
   LogSigner* const signer_;
 
   DISALLOW_COPY_AND_ASSIGN(FrontendSigner);

--- a/cpp/log/leveldb_db_cert.cc
+++ b/cpp/log/leveldb_db_cert.cc
@@ -1,4 +1,4 @@
-#include "log/logged_certificate.h"
+#include "log/logged_entry.h"
 #include "log/leveldb_db-inl.h"
 
-template class LevelDB<cert_trans::LoggedCertificate>;
+template class LevelDB<cert_trans::LoggedEntry>;

--- a/cpp/log/log_lookup_cert.cc
+++ b/cpp/log/log_lookup_cert.cc
@@ -1,4 +1,4 @@
 #include "log/log_lookup-inl.h"
-#include "log/logged_certificate.h"
+#include "log/logged_entry.h"
 
-template class LogLookup<cert_trans::LoggedCertificate>;
+template class LogLookup<cert_trans::LoggedEntry>;

--- a/cpp/log/logged_certificate_test.cc
+++ b/cpp/log/logged_certificate_test.cc
@@ -1,7 +1,0 @@
-#include "log/logged_certificate.h"
-
-#include <gtest/gtest.h>
-
-typedef testing::Types<cert_trans::LoggedCertificate> TestType;
-
-#include "log/logged_test-inl.h"

--- a/cpp/log/logged_entry.cc
+++ b/cpp/log/logged_entry.cc
@@ -1,4 +1,4 @@
-#include "log/logged_certificate.h"
+#include "log/logged_entry.h"
 
 using ct::LogEntry;
 using ct::PreCert;
@@ -7,8 +7,7 @@ using ct::SignedCertificateTimestamp;
 namespace cert_trans {
 
 
-bool LoggedCertificate::CopyFromClientLogEntry(
-    const AsyncLogClient::Entry& entry) {
+bool LoggedEntry::CopyFromClientLogEntry(const AsyncLogClient::Entry& entry) {
   if (entry.leaf.timestamped_entry().entry_type() != ct::X509_ENTRY &&
       entry.leaf.timestamped_entry().entry_type() != ct::PRECERT_ENTRY) {
     LOG(INFO) << "unsupported entry_type: "

--- a/cpp/log/logged_entry_test.cc
+++ b/cpp/log/logged_entry_test.cc
@@ -1,0 +1,7 @@
+#include "log/logged_entry.h"
+
+#include <gtest/gtest.h>
+
+typedef testing::Types<cert_trans::LoggedEntry> TestType;
+
+#include "log/logged_test-inl.h"

--- a/cpp/log/sqlite_db_cert.cc
+++ b/cpp/log/sqlite_db_cert.cc
@@ -1,4 +1,4 @@
-#include "log/logged_certificate.h"
+#include "log/logged_entry.h"
 #include "log/sqlite_db-inl.h"
 
-template class SQLiteDB<cert_trans::LoggedCertificate>;
+template class SQLiteDB<cert_trans::LoggedEntry>;

--- a/cpp/log/strict_consistent_store_cert.cc
+++ b/cpp/log/strict_consistent_store_cert.cc
@@ -1,6 +1,6 @@
-#include "log/logged_certificate.h"
+#include "log/logged_entry.h"
 #include "log/strict_consistent_store-inl.h"
 
 namespace cert_trans {
-template class StrictConsistentStore<LoggedCertificate>;
+template class StrictConsistentStore<LoggedEntry>;
 }  // namespace cert_trans

--- a/cpp/log/strict_consistent_store_test.cc
+++ b/cpp/log/strict_consistent_store_test.cc
@@ -4,7 +4,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "log/logged_certificate.h"
+#include "log/logged_entry.h"
 #include "log/mock_consistent_store.h"
 #include "util/mock_masterelection.h"
 #include "util/status.h"
@@ -29,7 +29,7 @@ using util::testing::StatusIs;
 class StrictConsistentStoreTest : public ::testing::TestWithParam<bool> {
  public:
   StrictConsistentStoreTest()
-      : peer_(new NiceMock<MockConsistentStore<LoggedCertificate>>()),
+      : peer_(new NiceMock<MockConsistentStore<LoggedEntry>>()),
         strict_store_(&election_, peer_) {
     ON_CALL(election_, IsMaster()).WillByDefault(Return(IsMaster()));
   }
@@ -41,8 +41,8 @@ class StrictConsistentStoreTest : public ::testing::TestWithParam<bool> {
 
   NiceMock<MockMasterElection> election_;
   // strict_store_ takes ownership of this:
-  NiceMock<MockConsistentStore<LoggedCertificate>>* peer_;
-  StrictConsistentStore<LoggedCertificate> strict_store_;
+  NiceMock<MockConsistentStore<LoggedEntry>>* peer_;
+  StrictConsistentStore<LoggedEntry> strict_store_;
 };
 
 

--- a/cpp/log/test_db.h
+++ b/cpp/log/test_db.h
@@ -9,14 +9,14 @@
 #include "log/file_db.h"
 #include "log/file_storage.h"
 #include "log/leveldb_db.h"
-#include "log/logged_certificate.h"
+#include "log/logged_entry.h"
 #include "log/sqlite_db.h"
 
 static const unsigned kCertStorageDepth = 3;
 static const unsigned kTreeStorageDepth = 8;
 
 template <>
-void TestDB<FileDB<cert_trans::LoggedCertificate> >::Setup() {
+void TestDB<FileDB<cert_trans::LoggedEntry> >::Setup() {
   std::string certs_dir = tmp_.TmpStorageDir() + "/certs";
   std::string tree_dir = tmp_.TmpStorageDir() + "/tree";
   std::string meta_dir = tmp_.TmpStorageDir() + "/meta";
@@ -24,51 +24,51 @@ void TestDB<FileDB<cert_trans::LoggedCertificate> >::Setup() {
   CHECK_ERR(mkdir(tree_dir.c_str(), 0700));
   CHECK_ERR(mkdir(meta_dir.c_str(), 0700));
 
-  db_.reset(new FileDB<cert_trans::LoggedCertificate>(
+  db_.reset(new FileDB<cert_trans::LoggedEntry>(
       new cert_trans::FileStorage(certs_dir, kCertStorageDepth),
       new cert_trans::FileStorage(tree_dir, kTreeStorageDepth),
       new cert_trans::FileStorage(meta_dir, 0)));
 }
 
 template <>
-FileDB<cert_trans::LoggedCertificate>*
-TestDB<FileDB<cert_trans::LoggedCertificate> >::SecondDB() {
+FileDB<cert_trans::LoggedEntry>*
+TestDB<FileDB<cert_trans::LoggedEntry> >::SecondDB() {
   std::string certs_dir = this->tmp_.TmpStorageDir() + "/certs";
   std::string tree_dir = this->tmp_.TmpStorageDir() + "/tree";
   std::string meta_dir = this->tmp_.TmpStorageDir() + "/meta";
-  return new FileDB<cert_trans::LoggedCertificate>(
+  return new FileDB<cert_trans::LoggedEntry>(
       new cert_trans::FileStorage(certs_dir, kCertStorageDepth),
       new cert_trans::FileStorage(tree_dir, kTreeStorageDepth),
       new cert_trans::FileStorage(meta_dir, 0));
 }
 
 template <>
-void TestDB<SQLiteDB<cert_trans::LoggedCertificate> >::Setup() {
-  db_.reset(new SQLiteDB<cert_trans::LoggedCertificate>(tmp_.TmpStorageDir() +
-                                                        "/sqlite"));
+void TestDB<SQLiteDB<cert_trans::LoggedEntry> >::Setup() {
+  db_.reset(
+      new SQLiteDB<cert_trans::LoggedEntry>(tmp_.TmpStorageDir() + "/sqlite"));
 }
 
 template <>
-SQLiteDB<cert_trans::LoggedCertificate>*
-TestDB<SQLiteDB<cert_trans::LoggedCertificate> >::SecondDB() {
-  return new SQLiteDB<cert_trans::LoggedCertificate>(tmp_.TmpStorageDir() +
-                                                     "/sqlite");
+SQLiteDB<cert_trans::LoggedEntry>*
+TestDB<SQLiteDB<cert_trans::LoggedEntry> >::SecondDB() {
+  return new SQLiteDB<cert_trans::LoggedEntry>(tmp_.TmpStorageDir() +
+                                               "/sqlite");
 }
 
 template <>
-void TestDB<LevelDB<cert_trans::LoggedCertificate> >::Setup() {
-  db_.reset(new LevelDB<cert_trans::LoggedCertificate>(tmp_.TmpStorageDir() +
-                                                       "/leveldb"));
+void TestDB<LevelDB<cert_trans::LoggedEntry> >::Setup() {
+  db_.reset(
+      new LevelDB<cert_trans::LoggedEntry>(tmp_.TmpStorageDir() + "/leveldb"));
 }
 
 template <>
-LevelDB<cert_trans::LoggedCertificate>*
-TestDB<LevelDB<cert_trans::LoggedCertificate> >::SecondDB() {
+LevelDB<cert_trans::LoggedEntry>*
+TestDB<LevelDB<cert_trans::LoggedEntry> >::SecondDB() {
   // LevelDB won't allow the same DB to be opened concurrently so we have to
   // close the original.
   db_.reset();
-  return new LevelDB<cert_trans::LoggedCertificate>(tmp_.TmpStorageDir() +
-                                                    "/leveldb");
+  return new LevelDB<cert_trans::LoggedEntry>(tmp_.TmpStorageDir() +
+                                              "/leveldb");
 }
 
 // Not a Database; we just use the same template for setup.

--- a/cpp/log/test_signer.cc
+++ b/cpp/log/test_signer.cc
@@ -10,7 +10,7 @@
 #include <string>
 
 #include "log/log_signer.h"
-#include "log/logged_certificate.h"
+#include "log/logged_entry.h"
 #include "log/signer.h"
 #include "log/verifier.h"
 #include "merkletree/serial_hasher.h"
@@ -20,7 +20,7 @@
 #include "util/util.h"
 
 using cert_trans::Signer;
-using cert_trans::LoggedCertificate;
+using cert_trans::LoggedEntry;
 using cert_trans::Verifier;
 using ct::DigitallySigned;
 using ct::LogEntry;
@@ -269,7 +269,7 @@ void TestSigner::SetPrecertDefaults(SignedCertificateTimestamp* sct) {
 }
 
 // static
-void TestSigner::SetDefaults(LoggedCertificate* logged_cert) {
+void TestSigner::SetDefaults(LoggedEntry* logged_cert) {
   // Some time in September 2012.
   SetDefaults(logged_cert->mutable_sct());
   SetDefaults(logged_cert->mutable_entry());
@@ -352,7 +352,7 @@ void TestSigner::CreateUnique(LogEntry* entry) {
   }
 }
 
-void TestSigner::CreateUnique(LoggedCertificate* logged_cert) {
+void TestSigner::CreateUnique(LoggedEntry* logged_cert) {
   FillData(logged_cert);
   logged_cert->set_sequence_number(rand());
 
@@ -361,7 +361,7 @@ void TestSigner::CreateUnique(LoggedCertificate* logged_cert) {
                logged_cert->entry(), logged_cert->mutable_sct()));
 }
 
-void TestSigner::CreateUniqueFakeSignature(LoggedCertificate* logged_cert) {
+void TestSigner::CreateUniqueFakeSignature(LoggedEntry* logged_cert) {
   FillData(logged_cert);
 
   logged_cert->mutable_sct()->mutable_signature()->set_hash_algorithm(
@@ -433,8 +433,8 @@ void TestSigner::TestEqualSCTs(const SignedCertificateTimestamp& sct0,
 }
 
 // static
-void TestSigner::TestEqualLoggedCerts(const LoggedCertificate& c0,
-                                      const LoggedCertificate& c1) {
+void TestSigner::TestEqualLoggedCerts(const LoggedEntry& c0,
+                                      const LoggedEntry& c1) {
   TestEqualEntries(c0.entry(), c1.entry());
   TestEqualSCTs(c0.sct(), c1.sct());
 
@@ -455,7 +455,7 @@ void TestSigner::TestEqualTreeHeads(const SignedTreeHead& sth0,
   TestEqualDigitallySigned(sth0.signature(), sth1.signature());
 }
 
-void TestSigner::FillData(LoggedCertificate* logged_cert) {
+void TestSigner::FillData(LoggedEntry* logged_cert) {
   logged_cert->mutable_sct()->set_version(ct::V1);
   logged_cert->mutable_sct()->mutable_id()->set_key_id(B(kKeyID));
   logged_cert->mutable_sct()->set_timestamp(util::TimeInMilliseconds());
@@ -465,7 +465,7 @@ void TestSigner::FillData(LoggedCertificate* logged_cert) {
 
   CHECK_EQ(logged_cert->Hash(),
            Sha256Hasher::Sha256Digest(
-               Serializer::LeafCertificate(logged_cert->entry())));
+               Serializer::LeafData(logged_cert->entry())));
   string serialized_leaf;
   CHECK_EQ(Serializer::OK,
            Serializer::SerializeSCTMerkleTreeLeaf(logged_cert->sct(),

--- a/cpp/log/test_signer.h
+++ b/cpp/log/test_signer.h
@@ -9,7 +9,7 @@
 #include "merkletree/tree_hasher.h"
 
 namespace cert_trans {
-class LoggedCertificate;
+class LoggedEntry;
 class Signer;
 class Verifier;
 }
@@ -42,7 +42,7 @@ class TestSigner {
 
   // For KAT tests: a logged cert with a valid hash and signature.
   // TODO(ekasper): add an intermediate for better coverage.
-  static void SetDefaults(cert_trans::LoggedCertificate* logged_cert);
+  static void SetDefaults(cert_trans::LoggedEntry* logged_cert);
 
   // For KAT tests: a tree head with a valid signature.
   // Uses SHA256 for the tree hash.
@@ -68,11 +68,11 @@ class TestSigner {
   // signature - valid signature from the default signer
   // hash - valid sha256 hash of the leaf certificate
   // sequence number - cleared
-  void CreateUnique(cert_trans::LoggedCertificate* logged_cert);
+  void CreateUnique(cert_trans::LoggedEntry* logged_cert);
 
   // Same as above but set the default signature to avoid overhead from
   // signing.
-  void CreateUniqueFakeSignature(cert_trans::LoggedCertificate* logged_cert);
+  void CreateUniqueFakeSignature(cert_trans::LoggedEntry* logged_cert);
 
   // Generates a randomized entry as follows:
   // timestamp - current
@@ -99,8 +99,8 @@ class TestSigner {
   static void TestEqualSCTs(const ct::SignedCertificateTimestamp& sct0,
                             const ct::SignedCertificateTimestamp& sct1);
 
-  static void TestEqualLoggedCerts(const cert_trans::LoggedCertificate& c1,
-                                   const cert_trans::LoggedCertificate& c2);
+  static void TestEqualLoggedCerts(const cert_trans::LoggedEntry& c1,
+                                   const cert_trans::LoggedEntry& c2);
 
   static void TestEqualTreeHeads(const ct::SignedTreeHead& sth1,
                                  const ct::SignedTreeHead& sth2);
@@ -108,7 +108,7 @@ class TestSigner {
 
  private:
   // Fill everything apart from the signature.
-  void FillData(cert_trans::LoggedCertificate* logged_cert);
+  void FillData(cert_trans::LoggedEntry* logged_cert);
 
   LogSigner* default_signer_;
   // ct::SignedCertificateTimestamp default_sct_;

--- a/cpp/log/tree_signer_cert.cc
+++ b/cpp/log/tree_signer_cert.cc
@@ -1,6 +1,6 @@
-#include "log/logged_certificate.h"
+#include "log/logged_entry.h"
 #include "log/tree_signer-inl.h"
 
 namespace cert_trans {
-template class TreeSigner<cert_trans::LoggedCertificate>;
+template class TreeSigner<cert_trans::LoggedEntry>;
 }  // namespace cert_trans

--- a/cpp/monitor/database.cc
+++ b/cpp/monitor/database.cc
@@ -6,7 +6,7 @@
 namespace monitor {
 
 Database::WriteResult Database::CreateEntry(
-    const cert_trans::LoggedCertificate& logged) {
+    const cert_trans::LoggedEntry& logged) {
   std::string leaf;
   if (!logged.SerializeForLeaf(&leaf))
     return this->SERIALIZE_FAILED;
@@ -14,7 +14,7 @@ Database::WriteResult Database::CreateEntry(
   TreeHasher hasher(new Sha256Hasher);
   std::string leaf_hash = hasher.HashLeaf(leaf);
 
-  std::string cert = Serializer::LeafCertificate(logged.entry());
+  std::string cert = Serializer::LeafData(logged.entry());
 
   std::string cert_chain;
   if (!logged.SerializeExtraData(&cert_chain))

--- a/cpp/monitor/database.h
+++ b/cpp/monitor/database.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 
 #include "base/macros.h"
-#include "log/logged_certificate.h"
+#include "log/logged_entry.h"
 
 namespace monitor {
 
@@ -68,11 +68,11 @@ class Database {
   // Attempt to create a new entry. The caller has to ensure
   // everything itself (i.e. no UNIQUE constraints).  Do preprocessing
   // here independent from database implementation.
-  // cert_trans::LoggedCertificate is here only for being a container
+  // cert_trans::LoggedEntry is here only for being a container
   // for SignedCertificateTimestamp and LogEntry built in
   // GetEntries().  The latter two contain all information from the
   // RFC compliant get-entries response from the log server.
-  WriteResult CreateEntry(const cert_trans::LoggedCertificate& logged);
+  WriteResult CreateEntry(const cert_trans::LoggedEntry& logged);
 
   virtual WriteResult WriteSTH(const ct::SignedTreeHead& sth);
 

--- a/cpp/monitor/database_test.cc
+++ b/cpp/monitor/database_test.cc
@@ -9,7 +9,7 @@
 
 namespace {
 
-using cert_trans::LoggedCertificate;
+using cert_trans::LoggedEntry;
 using ct::SignedTreeHead;
 using std::string;
 
@@ -92,7 +92,7 @@ TYPED_TEST(DBTest, LookupLatestWrittenSTH) {
 }
 
 TYPED_TEST(DBTest, WriteEntryAndLookupHash) {
-  LoggedCertificate logged;
+  LoggedEntry logged;
   this->test_signer_.CreateUnique(&logged);
 
   EXPECT_EQ(DB::WRITE_OK, this->db()->CreateEntry(logged));

--- a/cpp/monitor/monitor.cc
+++ b/cpp/monitor/monitor.cc
@@ -171,7 +171,7 @@ Monitor::GetResult Monitor::GetEntries(int get_first, int get_last) {
 
     db_->BeginTransaction();
     for (size_t i = 0; i < entries.size(); i++) {
-      cert_trans::LoggedCertificate logged;
+      cert_trans::LoggedEntry logged;
       CHECK(logged.CopyFromClientLogEntry(entries.at(i)));
       CHECK_EQ(db_->CreateEntry(logged), Database::WRITE_OK);
     }

--- a/cpp/proto/serializer.cc
+++ b/cpp/proto/serializer.cc
@@ -57,7 +57,7 @@ Serializer::SerializeResult Serializer::CheckLogEntryFormat(
 }
 
 // static
-string Serializer::LeafCertificate(const LogEntry& entry) {
+string Serializer::LeafData(const LogEntry& entry) {
   switch (entry.type()) {
     case ct::X509_ENTRY:
       CHECK(entry.x509_entry().has_leaf_certificate())

--- a/cpp/proto/serializer.h
+++ b/cpp/proto/serializer.h
@@ -65,7 +65,7 @@ class Serializer {
   static SerializeResult CheckLogEntryFormat(const ct::LogEntry& entry);
 
   // Helper method to hide some of the ugly select logic.
-  static std::string LeafCertificate(const ct::LogEntry& entry);
+  static std::string LeafData(const ct::LogEntry& entry);
 
   static SerializeResult SerializeV1CertSCTSignatureInput(
       uint64_t timestamp, const std::string& certificate,

--- a/cpp/server/ct-dns-server.cc
+++ b/cpp/server/ct-dns-server.cc
@@ -5,14 +5,14 @@
 #include <string>
 
 #include "log/log_lookup.h"
-#include "log/logged_certificate.h"
+#include "log/logged_entry.h"
 #include "log/sqlite_db.h"
 #include "proto/ct.pb.h"
 #include "server/event.h"
 #include "util/init.h"
 #include "util/util.h"
 
-using cert_trans::LoggedCertificate;
+using cert_trans::LoggedEntry;
 using ct::SignedTreeHead;
 using google::RegisterFlagValidator;
 using std::string;
@@ -39,7 +39,7 @@ static const bool domain_dummy =
 
 class CTUDPDNSServer : public UDPServer {
  public:
-  CTUDPDNSServer(const string& domain, SQLiteDB<LoggedCertificate>* db,
+  CTUDPDNSServer(const string& domain, SQLiteDB<LoggedEntry>* db,
                  EventLoop* loop, int fd)
       : UDPServer(loop, fd), domain_(domain), lookup_(db), db_(db) {
   }
@@ -165,7 +165,7 @@ class CTUDPDNSServer : public UDPServer {
 
   string LeafHash(const string& index_str) const {
     int index = atoi(index_str.c_str());
-    LoggedCertificate cert;
+    LoggedEntry cert;
     if (db_->LookupByIndex(index, &cert) != db_->LOOKUP_OK)
       return "No such index";
     return util::ToBase64(lookup_.LeafHash(cert));
@@ -231,8 +231,8 @@ class CTUDPDNSServer : public UDPServer {
   }
 
   string domain_;
-  LogLookup<LoggedCertificate> lookup_;
-  SQLiteDB<LoggedCertificate>* const db_;
+  LogLookup<LoggedEntry> lookup_;
+  SQLiteDB<LoggedEntry>* const db_;
 };
 
 class Keyboard : public Server {
@@ -270,7 +270,7 @@ int main(int argc, char* argv[]) {
   // TODO(pphaneuf): This current *has* to be SQLite, because it
   // depends on sharing the database with a ct-server that will
   // populate it (which FileDB does not support).
-  SQLiteDB<LoggedCertificate> db(FLAGS_db);
+  SQLiteDB<LoggedEntry> db(FLAGS_db);
 
   EventLoop loop;
 

--- a/cpp/server/handler.h
+++ b/cpp/server/handler.h
@@ -23,7 +23,7 @@ class CertChecker;
 template <class T>
 class ClusterStateController;
 class JsonOutput;
-class LoggedCertificate;
+class LoggedEntry;
 class PreCertChain;
 class Proxy;
 class ThreadPool;
@@ -35,10 +35,9 @@ class HttpHandler {
   // this instance. The "frontend" parameter can be NULL, in which
   // case this server will not accept "add-chain" and "add-pre-chain"
   // requests.
-  HttpHandler(JsonOutput* json_output,
-              LogLookup<LoggedCertificate>* log_lookup,
-              const ReadOnlyDatabase<LoggedCertificate>* db,
-              const ClusterStateController<LoggedCertificate>* controller,
+  HttpHandler(JsonOutput* json_output, LogLookup<LoggedEntry>* log_lookup,
+              const ReadOnlyDatabase<LoggedEntry>* db,
+              const ClusterStateController<LoggedEntry>* controller,
               const CertChecker* cert_checker, Frontend* frontend,
               Proxy* proxy, ThreadPool* pool, libevent::Base* event_base);
   ~HttpHandler();
@@ -73,9 +72,9 @@ class HttpHandler {
   void UpdateNodeStaleness();
 
   JsonOutput* const output_;
-  LogLookup<LoggedCertificate>* const log_lookup_;
-  const ReadOnlyDatabase<LoggedCertificate>* const db_;
-  const ClusterStateController<LoggedCertificate>* const controller_;
+  LogLookup<LoggedEntry>* const log_lookup_;
+  const ReadOnlyDatabase<LoggedEntry>* const db_;
+  const ClusterStateController<LoggedEntry>* const controller_;
   const CertChecker* const cert_checker_;
   Frontend* const frontend_;
   Proxy* const proxy_;

--- a/cpp/tools/clustertool-inl.h
+++ b/cpp/tools/clustertool-inl.h
@@ -9,7 +9,7 @@
 
 #include "util/etcd.h"
 #include "log/etcd_consistent_store.h"
-#include "log/logged_certificate.h"
+#include "log/logged_entry.h"
 #include "log/log_signer.h"
 #include "log/sqlite_db.h"
 #include "log/strict_consistent_store.h"
@@ -29,7 +29,7 @@ template <class Logged>
 util::Status InitLog(const ct::ClusterConfig& cluster_config,
                      TreeSigner<Logged>* tree_signer,
                      ConsistentStore<Logged>* consistent_store) {
-  if (tree_signer->UpdateTree() != TreeSigner<LoggedCertificate>::OK) {
+  if (tree_signer->UpdateTree() != TreeSigner<LoggedEntry>::OK) {
     return util::Status(util::error::UNKNOWN, "Failed to Update Tree");
   }
 

--- a/cpp/tools/dump_cert.cc
+++ b/cpp/tools/dump_cert.cc
@@ -16,7 +16,7 @@ namespace {
 
 void DumpLoggedCert(const char* filename) {
   ifstream input(filename);
-  ct::LoggedCertificatePB pb;
+  ct::LoggedEntryPB pb;
   CHECK(pb.ParseFromIstream(&input));
 
   if (pb.has_sequence_number())

--- a/proto/ct.proto
+++ b/proto/ct.proto
@@ -167,7 +167,8 @@ message ShortMerkleAuditProof {
 // for logging entries and tree head state.                                   //
 ////////////////////////////////////////////////////////////////////////////////
 
-message LoggedCertificatePB {
+// TODO(alcutter): Come up with a better name :/
+message LoggedEntryPB {
   optional int64 sequence_number = 1;
   optional bytes merkle_leaf_hash = 2;
   message Contents {


### PR DESCRIPTION
Just a mechanical rename of `LoggedCertificate` to `LoggedEntry` to prepare the way for logging other things.