### PR TITLE
Python: Use flags only after initialization.

### DIFF
--- a/python/ct/client/log_client.py
+++ b/python/ct/client/log_client.py
@@ -200,8 +200,12 @@ def _parse_consistency_proof(response, servername):
 class RequestHandler(object):
     """HTTPS requests."""
     def __init__(self, connection_timeout=60, ca_bundle=None,
-                 num_retries=FLAGS.get_entries_max_retries):
-        self._http = httplib2.Http(timeout=connection_timeout, ca_certs=ca_bundle)
+                 num_retries=None):
+        self._http = httplib2.Http(
+            timeout=connection_timeout, ca_certs=ca_bundle)
+        # Explicitly check for None as num_retries being 0 is valid.
+        if num_retries is None:
+            num_retries = FLAGS.get_entries_max_retries
         self._num_retries = num_retries
 
     def __repr__(self):


### PR DESCRIPTION
Using FLAGS to get a default value for a method's parameter evlauates
it during import time, before FLAGS was actually initialized.