### PR TITLE
Factor out cert handler

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -201,6 +201,7 @@ cpp_server_ct_mirror_SOURCES = \
 	cpp/fetcher/remote_peer.cc \
 	cpp/proto/serializer.cc \
 	cpp/server/ct-mirror.cc \
+	cpp/server/certificate_handler.cc \
 	cpp/server/handler.cc \
 	cpp/server/json_output.cc \
 	cpp/server/metrics.cc \
@@ -226,6 +227,7 @@ cpp_server_ct_server_SOURCES = \
 	cpp/client/async_log_client.cc \
 	cpp/proto/serializer.cc \
 	cpp/server/ct-server.cc \
+	cpp/server/certificate_handler.cc \
 	cpp/server/handler.cc \
 	cpp/server/json_output.cc \
 	cpp/server/metrics.cc \

--- a/cpp/log/cert_submission_handler.cc
+++ b/cpp/log/cert_submission_handler.cc
@@ -23,7 +23,7 @@ using util::StatusOr;
 
 // TODO(ekasper): handle Cert errors consistently and log some errors here
 // if they fail.
-CertSubmissionHandler::CertSubmissionHandler(CertChecker* cert_checker)
+CertSubmissionHandler::CertSubmissionHandler(const CertChecker* cert_checker)
     : cert_checker_(CHECK_NOTNULL(cert_checker)) {
 }
 
@@ -76,7 +76,8 @@ bool CertSubmissionHandler::X509ChainToEntry(const CertChain& chain,
 }
 
 Status CertSubmissionHandler::ProcessX509Submission(CertChain* chain,
-                                                    LogEntry* entry) {
+                                                    LogEntry* entry) const {
+  entry->set_type(ct::X509_ENTRY);
   if (!chain->IsLoaded())
     return Status(util::error::INVALID_ARGUMENT, "empty submission");
 
@@ -99,12 +100,12 @@ Status CertSubmissionHandler::ProcessX509Submission(CertChain* chain,
     }
     x509_entry->add_certificate_chain(der_cert);
   }
-  entry->set_type(ct::X509_ENTRY);
   return Status::OK;
 }
 
 Status CertSubmissionHandler::ProcessPreCertSubmission(PreCertChain* chain,
-                                                       LogEntry* entry) {
+                                                       LogEntry* entry) const {
+  entry->set_type(ct::PRECERT_ENTRY);
   PrecertChainEntry* precert_entry = entry->mutable_precert_entry();
   const Status status(cert_checker_->CheckPreCertChain(
       chain, precert_entry->mutable_pre_cert()->mutable_issuer_key_hash(),
@@ -125,7 +126,6 @@ Status CertSubmissionHandler::ProcessPreCertSubmission(PreCertChain* chain,
       return Status(util::error::INTERNAL, "could not DER-encode the chain");
     precert_entry->add_precertificate_chain(der_cert);
   }
-  entry->set_type(ct::PRECERT_ENTRY);
   return Status::OK;
 }
 

--- a/cpp/log/cert_submission_handler.h
+++ b/cpp/log/cert_submission_handler.h
@@ -16,14 +16,14 @@
 class CertSubmissionHandler {
  public:
   // Does not take ownership of the cert_checker.
-  explicit CertSubmissionHandler(cert_trans::CertChecker* cert_checker);
+  explicit CertSubmissionHandler(const cert_trans::CertChecker* cert_checker);
 
   // These may change |chain|.
   // TODO(pphaneuf): These could return StatusOr<ct::LogEntry>.
   util::Status ProcessX509Submission(cert_trans::CertChain* chain,
-                                     ct::LogEntry* entry);
+                                     ct::LogEntry* entry) const;
   util::Status ProcessPreCertSubmission(cert_trans::PreCertChain* chain,
-                                        ct::LogEntry* entry);
+                                        ct::LogEntry* entry) const;
 
   // For clients, to reconstruct the bytestring under the signature
   // from the observed chain. Does not check whether the entry
@@ -38,7 +38,7 @@ class CertSubmissionHandler {
  private:
   static bool SerializedTbs(const cert_trans::Cert& cert, std::string* result);
 
-  cert_trans::CertChecker* const cert_checker_;
+  const cert_trans::CertChecker* const cert_checker_;
 
   DISALLOW_COPY_AND_ASSIGN(CertSubmissionHandler);
 };

--- a/cpp/log/frontend.h
+++ b/cpp/log/frontend.h
@@ -6,7 +6,7 @@
 #include <mutex>
 
 #include "base/macros.h"
-#include "log/cert_submission_handler.h"
+#include "log/cert.h"
 #include "log/submit_result.h"
 #include "proto/ct.pb.h"
 
@@ -19,27 +19,16 @@ class Status;
 // Frontend for accepting new submissions.
 class Frontend {
  public:
-  // Takes ownership of the handler and signer.
-  Frontend(CertSubmissionHandler* handler, FrontendSigner* signer);
+  // Takes ownership of the signer.
+  Frontend(FrontendSigner* signer);
   ~Frontend();
-
-  // Note that these might change the |chain|.
-  util::Status QueueX509Entry(cert_trans::CertChain* chain,
-                              ct::SignedCertificateTimestamp* sct);
-  util::Status QueuePreCertEntry(cert_trans::PreCertChain* chain,
-                                 ct::SignedCertificateTimestamp* sct);
-
-  const std::multimap<std::string, const cert_trans::Cert*>& GetRoots() const {
-    return handler_->GetRoots();
-  }
-
- private:
-  const std::unique_ptr<CertSubmissionHandler> handler_;
-  const std::unique_ptr<FrontendSigner> signer_;
 
   util::Status QueueProcessedEntry(util::Status pre_status,
                                    const ct::LogEntry& entry,
                                    ct::SignedCertificateTimestamp* sct);
+
+ private:
+  const std::unique_ptr<FrontendSigner> signer_;
 
   DISALLOW_COPY_AND_ASSIGN(Frontend);
 };

--- a/cpp/server/certificate_handler.cc
+++ b/cpp/server/certificate_handler.cc
@@ -1,0 +1,181 @@
+#include <functional>
+
+#include "log/frontend.h"
+#include "server/certificate_handler.h"
+#include "server/json_output.h"
+#include "util/json_wrapper.h"
+#include "util/status.h"
+#include "util/thread_pool.h"
+
+namespace cert_trans {
+
+using ct::LogEntry;
+using ct::SignedCertificateTimestamp;
+using std::bind;
+using std::make_shared;
+using std::multimap;
+using std::placeholders::_1;
+using std::shared_ptr;
+using std::string;
+using std::unique_ptr;
+using util::Status;
+
+
+namespace {
+
+
+bool ExtractChain(JsonOutput* output, evhttp_request* req, CertChain* chain) {
+  if (evhttp_request_get_command(req) != EVHTTP_REQ_POST) {
+    output->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
+    return false;
+  }
+
+  // TODO(pphaneuf): Should we check that Content-Type says
+  // "application/json", as recommended by RFC4627?
+  JsonObject json_body(evhttp_request_get_input_buffer(req));
+  if (!json_body.Ok() || !json_body.IsType(json_type_object)) {
+    output->SendError(req, HTTP_BADREQUEST, "Unable to parse provided JSON.");
+    return false;
+  }
+
+  JsonArray json_chain(json_body, "chain");
+  if (!json_chain.Ok()) {
+    output->SendError(req, HTTP_BADREQUEST, "Unable to parse provided JSON.");
+    return false;
+  }
+
+  VLOG(2) << "ExtractChain chain:\n" << json_chain.DebugString();
+
+  for (int i = 0; i < json_chain.Length(); ++i) {
+    JsonString json_cert(json_chain, i);
+    if (!json_cert.Ok()) {
+      output->SendError(req, HTTP_BADREQUEST,
+                        "Unable to parse provided JSON.");
+      return false;
+    }
+
+    unique_ptr<Cert> cert(new Cert);
+    cert->LoadFromDerString(json_cert.FromBase64());
+    if (!cert->IsLoaded()) {
+      output->SendError(req, HTTP_BADREQUEST,
+                        "Unable to parse provided chain.");
+      return false;
+    }
+
+    chain->AddCert(cert.release());
+  }
+
+  return true;
+}
+
+
+}  // namespace
+
+
+CertificateHttpHandler::CertificateHttpHandler(
+    LogLookup<LoggedEntry>* log_lookup,
+    const ReadOnlyDatabase<LoggedEntry>* db,
+    const ClusterStateController<LoggedEntry>* controller,
+    const CertChecker* cert_checker, Frontend* frontend, ThreadPool* pool,
+    libevent::Base* event_base)
+    : HttpHandler(log_lookup, db, controller, pool, event_base),
+      cert_checker_(CHECK_NOTNULL(cert_checker)),
+      submission_handler_(cert_checker_),
+      frontend_(frontend) {
+}
+
+
+void CertificateHttpHandler::AddHandlers(libevent::HttpServer* server) {
+  // TODO(alcutter): Support this for mirrors too
+  if (cert_checker_) {
+    // Don't really need to proxy this one, but may as well just to keep
+    // everything tidy:
+    AddProxyWrappedHandler(server, "/ct/v1/get-roots",
+                           bind(&CertificateHttpHandler::GetRoots, this, _1));
+  }
+  if (frontend_) {
+    // Proxy the add-* calls too, technically we could serve them, but a
+    // more up-to-date node will have a better chance of handling dupes
+    // correctly, rather than bloating the tree.
+    AddProxyWrappedHandler(server, "/ct/v1/add-chain",
+                           bind(&CertificateHttpHandler::AddChain, this, _1));
+    AddProxyWrappedHandler(server, "/ct/v1/add-pre-chain",
+                           bind(&CertificateHttpHandler::AddPreChain, this,
+                                _1));
+  }
+}
+
+
+void CertificateHttpHandler::GetRoots(evhttp_request* req) const {
+  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
+    return output_->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
+  }
+
+  JsonArray roots;
+  multimap<string, const Cert*>::const_iterator it;
+  for (it = cert_checker_->GetTrustedCertificates().begin();
+       it != cert_checker_->GetTrustedCertificates().end(); ++it) {
+    string cert;
+    if (it->second->DerEncoding(&cert) != util::Status::OK) {
+      LOG(ERROR) << "Cert encoding failed";
+      return output_->SendError(req, HTTP_INTERNAL, "Serialisation failed.");
+    }
+    roots.AddBase64(cert);
+  }
+
+  JsonObject json_reply;
+  json_reply.Add("certificates", roots);
+
+  output_->SendJsonReply(req, HTTP_OK, json_reply);
+}
+
+
+void CertificateHttpHandler::AddChain(evhttp_request* req) {
+  const shared_ptr<CertChain> chain(make_shared<CertChain>());
+  if (!ExtractChain(output_, req, chain.get())) {
+    return;
+  }
+
+  pool_->Add(
+      bind(&CertificateHttpHandler::BlockingAddChain, this, req, chain));
+}
+
+
+void CertificateHttpHandler::AddPreChain(evhttp_request* req) {
+  const shared_ptr<PreCertChain> chain(make_shared<PreCertChain>());
+  if (!ExtractChain(output_, req, chain.get())) {
+    return;
+  }
+
+  pool_->Add(
+      bind(&CertificateHttpHandler::BlockingAddPreChain, this, req, chain));
+}
+
+
+void CertificateHttpHandler::BlockingAddChain(
+    evhttp_request* req, const shared_ptr<CertChain>& chain) const {
+  SignedCertificateTimestamp sct;
+
+  LogEntry entry;
+  const Status status(frontend_->QueueProcessedEntry(
+      submission_handler_.ProcessX509Submission(chain.get(), &entry), entry,
+      &sct));
+
+  AddEntryReply(req, status, sct);
+}
+
+
+void CertificateHttpHandler::BlockingAddPreChain(
+    evhttp_request* req, const shared_ptr<PreCertChain>& chain) const {
+  SignedCertificateTimestamp sct;
+
+  LogEntry entry;
+  const Status status(frontend_->QueueProcessedEntry(
+      submission_handler_.ProcessPreCertSubmission(chain.get(), &entry), entry,
+      &sct));
+
+  AddEntryReply(req, status, sct);
+}
+
+
+}  // namespace cert_trans

--- a/cpp/server/certificate_handler.h
+++ b/cpp/server/certificate_handler.h
@@ -1,0 +1,50 @@
+#ifndef CERT_TRANS_SERVER_CERTIFICATE_HANDLER_H_
+#define CERT_TRANS_SERVER_CERTIFICATE_HANDLER_H_
+
+#include "log/cert_submission_handler.h"
+#include "log/logged_entry.h"
+#include "server/handler.h"
+
+namespace cert_trans {
+
+
+class CertificateHttpHandler : public HttpHandler {
+ public:
+  // Does not take ownership of its parameters, which must outlive
+  // this instance. The |frontend| and |cert_checker| parameters can be NULL,
+  // in which case this server will not accept "add-chain" and "add-pre-chain"
+  // requests.
+  CertificateHttpHandler(LogLookup<LoggedEntry>* log_lookup,
+                         const ReadOnlyDatabase<LoggedEntry>* db,
+                         const ClusterStateController<LoggedEntry>* controller,
+                         const CertChecker* cert_checker, Frontend* frontend,
+                         ThreadPool* pool, libevent::Base* event_base);
+
+  ~CertificateHttpHandler() = default;
+
+ protected:
+  void AddHandlers(libevent::HttpServer* server) override;
+
+ private:
+  const CertChecker* const cert_checker_;
+  const CertSubmissionHandler submission_handler_;
+  Frontend* const frontend_;
+
+  void GetEntries(evhttp_request* req) const;
+  void GetRoots(evhttp_request* req) const;
+  void AddChain(evhttp_request* req);
+  void AddPreChain(evhttp_request* req);
+
+  void BlockingAddChain(evhttp_request* req,
+                        const std::shared_ptr<CertChain>& chain) const;
+  void BlockingAddPreChain(evhttp_request* req,
+                           const std::shared_ptr<PreCertChain>& chain) const;
+
+  DISALLOW_COPY_AND_ASSIGN(CertificateHttpHandler);
+};
+
+
+}  // namespace cert_trans
+
+
+#endif  // CERT_TRANS_SERVER_CERTIFICATE_HANDLER_H_

--- a/cpp/server/handler.cc
+++ b/cpp/server/handler.cc
@@ -1,26 +1,24 @@
 #include "server/handler.h"
 
 #include <algorithm>
-#include <event2/buffer.h>
-#include <event2/http.h>
-#include <event2/keyvalq_struct.h>
 #include <functional>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
-#include <map>
 #include <memory>
+#include <mutex>
+#include <stdint.h>
 #include <stdlib.h>
+#include <string>
 #include <utility>
 #include <vector>
 
 #include "log/cert.h"
 #include "log/cert_checker.h"
 #include "log/cluster_state_controller.h"
-#include "log/frontend.h"
 #include "log/log_lookup.h"
 #include "log/logged_entry.h"
-#include "monitoring/monitoring.h"
 #include "monitoring/latency.h"
+#include "monitoring/monitoring.h"
 #include "server/json_output.h"
 #include "server/proxy.h"
 #include "util/json_wrapper.h"
@@ -47,9 +45,9 @@ using std::chrono::seconds;
 using std::lock_guard;
 using std::make_shared;
 using std::multimap;
+using std::min;
 using std::mutex;
 using std::placeholders::_1;
-using std::shared_ptr;
 using std::string;
 using std::unique_ptr;
 using std::vector;
@@ -68,92 +66,18 @@ static Latency<milliseconds, string> http_server_request_latency_ms(
     "Total request latency in ms broken down by path");
 
 
-bool ExtractChain(JsonOutput* output, evhttp_request* req, CertChain* chain) {
-  if (evhttp_request_get_command(req) != EVHTTP_REQ_POST) {
-    output->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
-    return false;
-  }
-
-  // TODO(pphaneuf): Should we check that Content-Type says
-  // "application/json", as recommended by RFC4627?
-  JsonObject json_body(evhttp_request_get_input_buffer(req));
-  if (!json_body.Ok() || !json_body.IsType(json_type_object)) {
-    output->SendError(req, HTTP_BADREQUEST, "Unable to parse provided JSON.");
-    return false;
-  }
-
-  JsonArray json_chain(json_body, "chain");
-  if (!json_chain.Ok()) {
-    output->SendError(req, HTTP_BADREQUEST, "Unable to parse provided JSON.");
-    return false;
-  }
-
-  VLOG(2) << "ExtractChain chain:\n" << json_chain.DebugString();
-
-  for (int i = 0; i < json_chain.Length(); ++i) {
-    JsonString json_cert(json_chain, i);
-    if (!json_cert.Ok()) {
-      output->SendError(req, HTTP_BADREQUEST,
-                        "Unable to parse provided JSON.");
-      return false;
-    }
-
-    unique_ptr<Cert> cert(new Cert);
-    cert->LoadFromDerString(json_cert.FromBase64());
-    if (!cert->IsLoaded()) {
-      output->SendError(req, HTTP_BADREQUEST,
-                        "Unable to parse provided chain.");
-      return false;
-    }
-
-    chain->AddCert(cert.release());
-  }
-
-  return true;
-}
-
-
-void AddChainReply(JsonOutput* output, evhttp_request* req,
-                   const util::Status& add_status,
-                   const SignedCertificateTimestamp& sct) {
-  if (!add_status.ok() &&
-      add_status.CanonicalCode() != util::error::ALREADY_EXISTS) {
-    VLOG(1) << "error adding chain: " << add_status;
-    const int response_code(add_status.CanonicalCode() ==
-                                    util::error::RESOURCE_EXHAUSTED
-                                ? HTTP_SERVUNAVAIL
-                                : HTTP_BADREQUEST);
-    return output->SendError(req, response_code, add_status.error_message());
-  }
-
-  JsonObject json_reply;
-  json_reply.Add("sct_version", static_cast<int64_t>(0));
-  json_reply.AddBase64("id", sct.id().key_id());
-  json_reply.Add("timestamp", sct.timestamp());
-  json_reply.Add("extensions", "");
-  json_reply.Add("signature", sct.signature());
-
-  output->SendJsonReply(req, HTTP_OK, json_reply);
-}
-
-
 }  // namespace
 
 
-HttpHandler::HttpHandler(JsonOutput* output,
-                         LogLookup<LoggedEntry>* log_lookup,
+HttpHandler::HttpHandler(LogLookup<LoggedEntry>* log_lookup,
                          const ReadOnlyDatabase<LoggedEntry>* db,
                          const ClusterStateController<LoggedEntry>* controller,
-                         const CertChecker* cert_checker, Frontend* frontend,
-                         Proxy* proxy, ThreadPool* pool,
-                         libevent::Base* event_base)
-    : output_(CHECK_NOTNULL(output)),
+                         ThreadPool* pool, libevent::Base* event_base)
+    : output_(nullptr),
       log_lookup_(CHECK_NOTNULL(log_lookup)),
       db_(CHECK_NOTNULL(db)),
       controller_(CHECK_NOTNULL(controller)),
-      cert_checker_(cert_checker),
-      frontend_(frontend),
-      proxy_(CHECK_NOTNULL(proxy)),
+      proxy_(nullptr),
       pool_(CHECK_NOTNULL(pool)),
       event_base_(CHECK_NOTNULL(event_base)),
       task_(pool_),
@@ -179,6 +103,29 @@ void StatsHandlerInterceptor(const string& path,
   cb(req);
 }
 
+
+void HttpHandler::AddEntryReply(evhttp_request* req,
+                                const util::Status& add_status,
+                                const SignedCertificateTimestamp& sct) const {
+  if (!add_status.ok() &&
+      add_status.CanonicalCode() != util::error::ALREADY_EXISTS) {
+    VLOG(1) << "error adding chain: " << add_status;
+    const int response_code(add_status.CanonicalCode() ==
+                                    util::error::RESOURCE_EXHAUSTED
+                                ? HTTP_SERVUNAVAIL
+                                : HTTP_BADREQUEST);
+    return output_->SendError(req, response_code, add_status.error_message());
+  }
+
+  JsonObject json_reply;
+  json_reply.Add("sct_version", static_cast<int64_t>(0));
+  json_reply.AddBase64("id", sct.id().key_id());
+  json_reply.Add("timestamp", sct.timestamp());
+  json_reply.Add("extensions", "");
+  json_reply.Add("signature", sct.signature());
+
+  output_->SendJsonReply(req, HTTP_OK, json_reply);
+}
 
 void HttpHandler::ProxyInterceptor(
     const libevent::HttpServer::HandlerCallback& local_handler,
@@ -214,13 +161,6 @@ void HttpHandler::Add(libevent::HttpServer* server) {
   // that they should be spun off to the thread pool.
   AddProxyWrappedHandler(server, "/ct/v1/get-entries",
                          bind(&HttpHandler::GetEntries, this, _1));
-  // TODO(alcutter): Support this for mirrors too
-  if (cert_checker_) {
-    // Don't really need to proxy this one, but may as well just to keep
-    // everything tidy:
-    AddProxyWrappedHandler(server, "/ct/v1/get-roots",
-                           bind(&HttpHandler::GetRoots, this, _1));
-  }
   AddProxyWrappedHandler(server, "/ct/v1/get-proof-by-hash",
                          bind(&HttpHandler::GetProof, this, _1));
   AddProxyWrappedHandler(server, "/ct/v1/get-sth",
@@ -228,15 +168,20 @@ void HttpHandler::Add(libevent::HttpServer* server) {
   AddProxyWrappedHandler(server, "/ct/v1/get-sth-consistency",
                          bind(&HttpHandler::GetConsistency, this, _1));
 
-  if (frontend_) {
-    // Proxy the add-* calls too, technically we could serve them, but a
-    // more up-to-date node will have a better chance of handling dupes
-    // correctly, rather than bloating the tree.
-    AddProxyWrappedHandler(server, "/ct/v1/add-chain",
-                           bind(&HttpHandler::AddChain, this, _1));
-    AddProxyWrappedHandler(server, "/ct/v1/add-pre-chain",
-                           bind(&HttpHandler::AddPreChain, this, _1));
-  }
+  // Now add any sub-class handlers.
+  AddHandlers(server);
+}
+
+
+void HttpHandler::SetOutput(JsonOutput* output) {
+  LOG_IF(FATAL, output_) << "Attempting to re-add a HttpHandler.";
+  output_ = CHECK_NOTNULL(output);
+}
+
+
+void HttpHandler::SetProxy(Proxy* proxy) {
+  LOG_IF(FATAL, proxy_) << "Attempting to re-add a HttpHandler.";
+  proxy_ = CHECK_NOTNULL(proxy);
 }
 
 
@@ -268,30 +213,6 @@ void HttpHandler::GetEntries(evhttp_request* req) const {
   const bool include_scts(libevent::GetBoolParam(query, "include_scts"));
 
   BlockingGetEntries(req, start, end, include_scts);
-}
-
-
-void HttpHandler::GetRoots(evhttp_request* req) const {
-  if (evhttp_request_get_command(req) != EVHTTP_REQ_GET) {
-    return output_->SendError(req, HTTP_BADMETHOD, "Method not allowed.");
-  }
-
-  JsonArray roots;
-  multimap<string, const Cert*>::const_iterator it;
-  for (it = cert_checker_->GetTrustedCertificates().begin();
-       it != cert_checker_->GetTrustedCertificates().end(); ++it) {
-    string cert;
-    if (it->second->DerEncoding(&cert) != util::Status::OK) {
-      LOG(ERROR) << "Cert encoding failed";
-      return output_->SendError(req, HTTP_INTERNAL, "Serialisation failed.");
-    }
-    roots.AddBase64(cert);
-  }
-
-  JsonObject json_reply;
-  json_reply.Add("certificates", roots);
-
-  output_->SendJsonReply(req, HTTP_OK, json_reply);
 }
 
 
@@ -395,46 +316,26 @@ void HttpHandler::GetConsistency(evhttp_request* req) const {
 }
 
 
-void HttpHandler::AddChain(evhttp_request* req) {
-  const shared_ptr<CertChain> chain(make_shared<CertChain>());
-  if (!ExtractChain(output_, req, chain.get())) {
-    return;
-  }
-
-  pool_->Add(bind(&HttpHandler::BlockingAddChain, this, req, chain));
-}
-
-
-void HttpHandler::AddPreChain(evhttp_request* req) {
-  const shared_ptr<PreCertChain> chain(make_shared<PreCertChain>());
-  if (!ExtractChain(output_, req, chain.get())) {
-    return;
-  }
-
-  pool_->Add(bind(&HttpHandler::BlockingAddPreChain, this, req, chain));
-}
-
-
 void HttpHandler::BlockingGetEntries(evhttp_request* req, int64_t start,
                                      int64_t end, bool include_scts) const {
   JsonArray json_entries;
   auto it(db_->ScanEntries(start));
   for (int64_t i = start; i <= end; ++i) {
-    LoggedEntry cert;
+    LoggedEntry entry;
 
-    if (!it->GetNextEntry(&cert) || cert.sequence_number() != i) {
+    if (!it->GetNextEntry(&entry) || entry.sequence_number() != i) {
       break;
     }
 
     string leaf_input;
     string extra_data;
     string sct_data;
-    if (!cert.SerializeForLeaf(&leaf_input) ||
-        !cert.SerializeExtraData(&extra_data) ||
+    if (!entry.SerializeForLeaf(&leaf_input) ||
+        !entry.SerializeExtraData(&extra_data) ||
         (include_scts &&
-         Serializer::SerializeSCT(cert.sct(), &sct_data) != Serializer::OK)) {
+         Serializer::SerializeSCT(entry.sct(), &sct_data) != Serializer::OK)) {
       LOG(WARNING) << "Failed to serialize entry @ " << i << ":\n"
-                   << cert.DebugString();
+                   << entry.DebugString();
       return output_->SendError(req, HTTP_INTERNAL, "Serialization failed.");
     }
 
@@ -459,28 +360,6 @@ void HttpHandler::BlockingGetEntries(evhttp_request* req, int64_t start,
   json_reply.Add("entries", json_entries);
 
   output_->SendJsonReply(req, HTTP_OK, json_reply);
-}
-
-
-void HttpHandler::BlockingAddChain(evhttp_request* req,
-                                   const shared_ptr<CertChain>& chain) const {
-  SignedCertificateTimestamp sct;
-
-  AddChainReply(output_, req,
-                CHECK_NOTNULL(frontend_)
-                    ->QueueX509Entry(CHECK_NOTNULL(chain.get()), &sct),
-                sct);
-}
-
-
-void HttpHandler::BlockingAddPreChain(
-    evhttp_request* req, const shared_ptr<PreCertChain>& chain) const {
-  SignedCertificateTimestamp sct;
-
-  AddChainReply(output_, req,
-                CHECK_NOTNULL(frontend_)
-                    ->QueuePreCertEntry(CHECK_NOTNULL(chain.get()), &sct),
-                sct);
 }
 
 

--- a/cpp/server/handler.h
+++ b/cpp/server/handler.h
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <string>
 
+#include "proto/ct.pb.h"
 #include "util/libevent_wrapper.h"
 #include "util/sync_task.h"
 #include "util/task.h"
@@ -32,21 +33,27 @@ class ThreadPool;
 class HttpHandler {
  public:
   // Does not take ownership of its parameters, which must outlive
-  // this instance. The "frontend" parameter can be NULL, in which
-  // case this server will not accept "add-chain" and "add-pre-chain"
-  // requests.
-  HttpHandler(JsonOutput* json_output, LogLookup<LoggedEntry>* log_lookup,
+  // this instance.
+  HttpHandler(LogLookup<LoggedEntry>* log_lookup,
               const ReadOnlyDatabase<LoggedEntry>* db,
               const ClusterStateController<LoggedEntry>* controller,
-              const CertChecker* cert_checker, Frontend* frontend,
-              Proxy* proxy, ThreadPool* pool, libevent::Base* event_base);
+              ThreadPool* pool, libevent::Base* event_base);
   ~HttpHandler();
 
   void Add(libevent::HttpServer* server);
 
- private:
+  void SetOutput(JsonOutput* json_output);
+  void SetProxy(Proxy* proxy);
+
+ protected:
+  // Implemented by subclasses which want to add their own extra http handlers.
+  virtual void AddHandlers(libevent::HttpServer* server) = 0;
+
+  void AddEntryReply(evhttp_request* req, const util::Status& add_status,
+                     const ct::SignedCertificateTimestamp& sct) const;
+
   void ProxyInterceptor(
-      const libevent::HttpServer::HandlerCallback& next_handler,
+      const libevent::HttpServer::HandlerCallback& local_handler,
       evhttp_request* request);
 
   void AddProxyWrappedHandler(
@@ -54,30 +61,21 @@ class HttpHandler {
       const libevent::HttpServer::HandlerCallback& local_handler);
 
   void GetEntries(evhttp_request* req) const;
-  void GetRoots(evhttp_request* req) const;
   void GetProof(evhttp_request* req) const;
   void GetSTH(evhttp_request* req) const;
   void GetConsistency(evhttp_request* req) const;
-  void AddChain(evhttp_request* req);
-  void AddPreChain(evhttp_request* req);
 
   void BlockingGetEntries(evhttp_request* req, int64_t start, int64_t end,
                           bool include_scts) const;
-  void BlockingAddChain(evhttp_request* req,
-                        const std::shared_ptr<CertChain>& chain) const;
-  void BlockingAddPreChain(evhttp_request* req,
-                           const std::shared_ptr<PreCertChain>& chain) const;
 
   bool IsNodeStale() const;
   void UpdateNodeStaleness();
 
-  JsonOutput* const output_;
+  JsonOutput* output_;
   LogLookup<LoggedEntry>* const log_lookup_;
   const ReadOnlyDatabase<LoggedEntry>* const db_;
   const ClusterStateController<LoggedEntry>* const controller_;
-  const CertChecker* const cert_checker_;
-  Frontend* const frontend_;
-  Proxy* const proxy_;
+  Proxy* proxy_;
   ThreadPool* const pool_;
   libevent::Base* const event_base_;
 


### PR DESCRIPTION
This one is mostly just moving stuff around; pulling out the CT/certificate specific stuff from `handler.cc` and putting it in a subclass, then there's also the changes to support registering these handler subclasses with the `Server` rather than the server creating the handler instance(s).

I'm not super happy with the current state of the Server interface, but I think that's a job for another day.  