### PR TITLE
Certinfo refactor in advance of V2 serialization support

### DIFF
--- a/build/Makefile.glog
+++ b/build/Makefile.glog
@@ -1,6 +1,6 @@
 UNAME := $(shell uname)
 ifeq ($(UNAME),FreeBSD)
-EXTRA_LDFLAGS="-lexecinfo"
+EXTRA_LDFLAGS="-lexecinfo -lunwind"
 endif
 
 all: Makefile

--- a/build/Makefile.glog
+++ b/build/Makefile.glog
@@ -1,6 +1,6 @@
 UNAME := $(shell uname)
 ifeq ($(UNAME),FreeBSD)
-EXTRA_LDFLAGS="-lexecinfo -lunwind"
+EXTRA_LDFLAGS="-lexecinfo"
 endif
 
 all: Makefile

--- a/cpp/client/ct.cc
+++ b/cpp/client/ct.cc
@@ -875,7 +875,7 @@ void GetEntries() {
                ct::PRECERT_ENTRY);
       WriteCertificate(entry->leaf.timestamped_entry()
                            .signed_entry()
-                           .precert()
+                           .cert_info()
                            .tbs_certificate(),
                        e, 0, "pre");
       const ct::PrecertChainEntry& precertchain = entry->entry.precert_entry();

--- a/cpp/log/logged_entry.cc
+++ b/cpp/log/logged_entry.cc
@@ -1,7 +1,7 @@
 #include "log/logged_entry.h"
 
 using ct::LogEntry;
-using ct::PreCert;
+using ct::CertInfo;
 using ct::SignedCertificateTimestamp;
 
 namespace cert_trans {
@@ -37,15 +37,15 @@ bool LoggedEntry::CopyFromClientLogEntry(const AsyncLogClient::Entry& entry) {
     }
 
     case ct::PRECERT_ENTRY: {
-      PreCert* const precert(
+      CertInfo* const precert(
           log_entry->mutable_precert_entry()->mutable_pre_cert());
       precert->set_issuer_key_hash(entry.leaf.timestamped_entry()
                                        .signed_entry()
-                                       .precert()
+                                       .cert_info()
                                        .issuer_key_hash());
       precert->set_tbs_certificate(entry.leaf.timestamped_entry()
                                        .signed_entry()
-                                       .precert()
+                                       .cert_info()
                                        .tbs_certificate());
       break;
     }

--- a/cpp/proto/serializer.cc
+++ b/cpp/proto/serializer.cc
@@ -740,12 +740,12 @@ Deserializer::DeserializeResult Deserializer::ReadMerkleTreeLeaf(
     string issuer_key_hash;
     if (!ReadFixedBytes(32, &issuer_key_hash))
       return INPUT_TOO_SHORT;
-    entry->mutable_signed_entry()->mutable_precert()->set_issuer_key_hash(
+    entry->mutable_signed_entry()->mutable_cert_info()->set_issuer_key_hash(
         issuer_key_hash);
     string tbs_certificate;
     if (!ReadVarBytes(Serializer::kMaxCertificateLength, &tbs_certificate))
       return INPUT_TOO_SHORT;
-    entry->mutable_signed_entry()->mutable_precert()->set_tbs_certificate(
+    entry->mutable_signed_entry()->mutable_cert_info()->set_tbs_certificate(
         tbs_certificate);
   }
 

--- a/cpp/proto/serializer_test.cc
+++ b/cpp/proto/serializer_test.cc
@@ -389,7 +389,8 @@ TEST_F(SerializerTest, DeserializeMerkleTreeLeafKAT) {
   EXPECT_EQ(leaf.timestamped_entry().entry_type(), ct::X509_ENTRY);
   EXPECT_EQ(leaf.timestamped_entry().signed_entry().x509(),
             DefaultCertEntry().x509_entry().leaf_certificate());
-  EXPECT_FALSE(leaf.timestamped_entry().signed_entry().has_precert());
+  // V1 X509 entries do not use the CertInfo structure
+  EXPECT_FALSE(leaf.timestamped_entry().signed_entry().has_cert_info());
 
   MerkleTreeLeaf leaf2;
   EXPECT_EQ(Deserializer::OK, Deserializer::DeserializeMerkleTreeLeaf(
@@ -400,10 +401,10 @@ TEST_F(SerializerTest, DeserializeMerkleTreeLeafKAT) {
   EXPECT_EQ(leaf2.timestamped_entry().entry_type(), ct::PRECERT_ENTRY);
   EXPECT_FALSE(leaf2.timestamped_entry().signed_entry().has_x509());
   EXPECT_EQ(
-      leaf2.timestamped_entry().signed_entry().precert().issuer_key_hash(),
+      leaf2.timestamped_entry().signed_entry().cert_info().issuer_key_hash(),
       DefaultIssuerKeyHash());
   EXPECT_EQ(
-      leaf2.timestamped_entry().signed_entry().precert().tbs_certificate(),
+      leaf2.timestamped_entry().signed_entry().cert_info().tbs_certificate(),
       DefaultTbsCertificate());
 }
 

--- a/java/src/org/certificatetransparency/ctlog/serialization/Deserializer.java
+++ b/java/src/org/certificatetransparency/ctlog/serialization/Deserializer.java
@@ -118,7 +118,7 @@ public class Deserializer {
 
     } else if (entryType == Ct.LogEntryType.PRECERT_ENTRY) {
       Ct.PrecertChainEntry preCertChain = parsePrecerChainEntry(extraData,
-        treeLeaf.getTimestampedEntry().getSignedEntry().getPrecert());
+        treeLeaf.getTimestampedEntry().getSignedEntry().getCertInfo());
        logEntryBuilder.setPrecertEntry(preCertChain);
 
     } else {
@@ -176,19 +176,19 @@ public class Deserializer {
       signedEntryBuilder.setX509(x509);
 
     } else if (entryType == Ct.LogEntryType.PRECERT_ENTRY_VALUE) {
-      Ct.PreCert.Builder preCertBuilder = Ct.PreCert.newBuilder();
+      Ct.PreCert.Builder certInfoBuilder = Ct.CertInfo.newBuilder();
 
       byte[] arr = readFixedLength(in, 32);
-      preCertBuilder.setIssuerKeyHash(ByteString.copyFrom(arr));
+      certInfoBuilder.setIssuerKeyHash(ByteString.copyFrom(arr));
 
       // set tbs certificate
       arr = readFixedLength(in, 2);
       int length = (int) readNumber(in, 2);
 
-      preCertBuilder.setTbsCertificate(ByteString.copyFrom(readFixedLength(in, length)));
-      preCertBuilder.build();
+      certInfoBuilder.setTbsCertificate(ByteString.copyFrom(readFixedLength(in, length)));
+      certInfoBuilder.build();
 
-      signedEntryBuilder.setPrecert(preCertBuilder);
+      signedEntryBuilder.setPrecert(certInfoBuilder);
     } else {
       throw new SerializationException(String.format("Unknown entry type: %d", entryType));
     }
@@ -230,7 +230,7 @@ public class Deserializer {
    * @param preCert Precertificate.
    * @return {@link Ct.PrecertChainEntry} proto object.
    */
-  public static Ct.PrecertChainEntry parsePrecerChainEntry(InputStream in, Ct.PreCert preCert) {
+  public static Ct.PrecertChainEntry parsePrecerChainEntry(InputStream in, Ct.CertInfo preCert) {
     Ct.PrecertChainEntry.Builder preCertChain = Ct.PrecertChainEntry.newBuilder();
     preCertChain.setPreCert(preCert);
 

--- a/proto/ct.proto
+++ b/proto/ct.proto
@@ -51,13 +51,16 @@ message X509ChainEntry {
   repeated bytes certificate_chain = 2;
 }
 
+// In V1 this structure was called PreCert and only used for precertificates.
+// In V2 they have been unified and both log entry types use this.
+//
 // opaque TBSCertificate<1..2^16-1>;
 // struct {
 //   opaque issuer_key_hash[32];
 //   TBSCertificate tbs_certificate;
-// } PreCert;
+// } CertInfo;
 // TODO(benl, ekasper): call this something more original in the I-D.
-message PreCert {
+message CertInfo {
   optional bytes issuer_key_hash = 1;
   optional bytes tbs_certificate = 2;
 }
@@ -72,7 +75,7 @@ message PrecertChainEntry {
   // PreCert input to the SCT. Can be computed from the above.
   // Store it alongside the entry data so that the signers don't have to
   // parse certificates to recompute it.
-  optional PreCert pre_cert = 3;
+  optional CertInfo pre_cert = 3;
 }
 
 message LogEntry {
@@ -120,9 +123,14 @@ enum MerkleLeafType {
   UNKNOWN_LEAF_TYPE = 256;
 }
 
+// In V1 the x509 field was used to store the certificate and the signed
+// entry format differed from V2. In V2 entries the same structures are
+// used for both entry types and x509 is ignored. This complicates the
+// code but allows for existing saved protos to be read by a V1 implementation.
 message SignedEntry {
+  // This field will only be set for an X509 V1 entry
   optional bytes x509 = 1;
-  optional PreCert precert = 2;
+  optional CertInfo cert_info = 2;
 }
 
 message TimestampedEntry {


### PR DESCRIPTION
Rename PreCert to CertInfo as in draft RFC as in v2 it will be used for both certs and precerts in signed entries. Unfortunately can't use CertInfo exclusively in SignedEntry proto as this would be incompatible with the format of existing saved proto instances.