### PR TITLE
Change back from glog to just assert() in merkletree.

### DIFF
--- a/cpp/merkletree/compact_merkle_tree.cc
+++ b/cpp/merkletree/compact_merkle_tree.cc
@@ -1,6 +1,6 @@
 #include "merkletree/compact_merkle_tree.h"
 
-#include <glog/logging.h>
+#include <assert.h>
 #include <stddef.h>
 #include <string>
 #include <vector>
@@ -80,7 +80,7 @@ CompactMerkleTree::CompactMerkleTree(MerkleTree& model, SerialHasher* hasher)
       }
       level++;
     }
-    CHECK(i == path.end()) << "Failed to consume all proof nodes";
+    assert(i == path.end());
   }
 
   // Now tree_ should contain a representation of the tree state just before
@@ -88,9 +88,9 @@ CompactMerkleTree::CompactMerkleTree(MerkleTree& model, SerialHasher* hasher)
   // here, which will perform any recalculations necessary to reach the final
   // tree.
   PushBack(0, model.LeafHash(model.LeafCount()));
-  CHECK_EQ(model.CurrentRoot(), CurrentRoot());
-  CHECK_EQ(model.LeafCount(), LeafCount());
-  CHECK_EQ(model.LevelCount(), LevelCount());
+  assert(model.CurrentRoot() == CurrentRoot());
+  assert(model.LeafCount() == LeafCount());
+  assert(model.LevelCount() ==LevelCount());
 }
 
 
@@ -128,7 +128,7 @@ string CompactMerkleTree::CurrentRoot() {
 }
 
 void CompactMerkleTree::PushBack(size_t level, string node) {
-  CHECK_EQ(node.size(), treehasher_.DigestSize());
+  assert(node.size() == treehasher_.DigestSize());
   if (tree_.size() <= level) {
     // First node at a new level.
     tree_.push_back(node);

--- a/cpp/merkletree/merkle_tree.cc
+++ b/cpp/merkletree/merkle_tree.cc
@@ -1,6 +1,6 @@
 #include "merkletree/merkle_tree.h"
 
-#include <glog/logging.h>
+#include <assert.h>
 #include <stddef.h>
 #include <string>
 #include <vector>
@@ -110,8 +110,8 @@ string MerkleTree::UpdateToSnapshot(size_t snapshot) {
     return Node(0, 0);
   if (snapshot == leaves_processed_)
     return Root();
-  CHECK_LE(snapshot, LeafCount());
-  CHECK_GT(snapshot, leaves_processed_);
+  assert(snapshot <= LeafCount());
+  assert(snapshot > leaves_processed_);
 
   // Update tree, moving up level-by-level.
   size_t level = 0;
@@ -171,7 +171,7 @@ string MerkleTree::RecomputePastSnapshot(size_t snapshot, size_t node_level,
     return Root();
   }
 
-  CHECK_LT(snapshot, leaves_processed_);
+  assert(snapshot < leaves_processed_);
 
   // Recompute nodes on the path of the last leaf.
   while (MerkleTreeMath::IsRightChild(last_node)) {
@@ -249,34 +249,34 @@ std::vector<string> MerkleTree::PathFromNodeToRootAtSnapshot(size_t node,
 }
 
 string MerkleTree::Node(size_t level, size_t index) const {
-  CHECK_GT(NodeCount(level), index);
+  assert(NodeCount(level) > index);
   return tree_[level].substr(index * treehasher_.DigestSize(),
                              treehasher_.DigestSize());
 }
 
 string MerkleTree::Root() const {
-  CHECK_EQ(tree_.back().size(), treehasher_.DigestSize());
+  assert(tree_.back().size() == treehasher_.DigestSize());
   return tree_.back();
 }
 
 size_t MerkleTree::NodeCount(size_t level) const {
-  CHECK_GT(LazyLevelCount(), level);
+  assert(LazyLevelCount() > level);
   return tree_[level].size() / treehasher_.DigestSize();
 }
 
 string MerkleTree::LastNode(size_t level) const {
-  CHECK_GE(NodeCount(level), 1U);
+  assert(NodeCount(level) >= 1U);
   return tree_[level].substr(tree_[level].size() - treehasher_.DigestSize());
 }
 
 void MerkleTree::PopBack(size_t level) {
-  CHECK_GE(NodeCount(level), 1U);
+  assert(NodeCount(level) >= 1U);
   tree_[level].erase(tree_[level].size() - treehasher_.DigestSize());
 }
 
 void MerkleTree::PushBack(size_t level, string node) {
-  CHECK_EQ(node.size(), treehasher_.DigestSize());
-  CHECK_GT(LazyLevelCount(), level);
+  assert(node.size() == treehasher_.DigestSize());
+  assert(LazyLevelCount() > level);
   tree_[level].append(node);
 }
 

--- a/cpp/merkletree/tree_hasher.cc
+++ b/cpp/merkletree/tree_hasher.cc
@@ -1,6 +1,6 @@
 #include "merkletree/tree_hasher.h"
 
-#include <glog/logging.h>
+#include <assert.h>
 
 #include "merkletree/serial_hasher.h"
 
@@ -21,7 +21,8 @@ std::string EmptyHash(SerialHasher* hasher) {
 }  // namespace
 
 TreeHasher::TreeHasher(SerialHasher* hasher)
-    : hasher_(CHECK_NOTNULL(hasher)), empty_hash_(EmptyHash(hasher_.get())) {
+    : hasher_(hasher), empty_hash_(EmptyHash(hasher_.get())) {
+  assert(hasher_);
 }
 
 string TreeHasher::HashLeaf(const string& data) const {

--- a/go/merkletree/merkle_tree.go
+++ b/go/merkletree/merkle_tree.go
@@ -1,7 +1,7 @@
 package merkletree
 
 /*
-#cgo LDFLAGS: -lcrypto -lglog
+#cgo LDFLAGS: -lcrypto
 #cgo CPPFLAGS: -I../../cpp
 #cgo CXXFLAGS: -std=c++11
 #include "merkle_tree_go.h"

--- a/go/merkletree/merkle_tree_go.cc
+++ b/go/merkletree/merkle_tree_go.cc
@@ -1,9 +1,9 @@
 #include "merkletree/merkle_tree.h"
 
+#include <assert.h>
 #include <cstdlib>
 #include <cstring>
 #include <vector>
-#include <glog/logging.h>
 
 #include "_cgo_export.h"
 #include "merkle_tree_go.h"
@@ -14,13 +14,16 @@ extern "C" {
 // safety.  Hopefully these should all be optimized away into oblivion
 // by the compiler.
 static inline MerkleTree* MT(TREE tree) {
-  return static_cast<MerkleTree*>(CHECK_NOTNULL(tree));
+  assert(tree);
+  return static_cast<MerkleTree*>(tree);
 }
 static inline Sha256Hasher* H(HASHER hasher) {
-  return static_cast<Sha256Hasher*>(CHECK_NOTNULL(hasher));
+  assert(hasher);
+  return static_cast<Sha256Hasher*>(hasher);
 }
 static inline GoSlice* BS(BYTE_SLICE slice) {
-  return static_cast<GoSlice*>(CHECK_NOTNULL(slice));
+  assert(slice);
+  return static_cast<GoSlice*>(slice);
 }
 
 HASHER NewSha256Hasher() {
@@ -51,7 +54,7 @@ bool LeafHash(TREE tree, BYTE_SLICE out, size_t leaf) {
     return false;
   }
   const std::string& hash = t->LeafHash(leaf);
-  CHECK_EQ(nodesize, hash.size());
+  assert(nodesize == hash.size());
   memcpy(slice->data, hash.data(), nodesize);
   slice->len = nodesize;
   return true;
@@ -83,7 +86,7 @@ bool CurrentRoot(TREE tree, BYTE_SLICE out) {
     return false;
   }
   const std::string& hash = t->CurrentRoot();
-  CHECK_EQ(nodesize, hash.size());
+  assert(nodesize == hash.size());
   memcpy(slice->data, hash.data(), nodesize);
   slice->len = nodesize;
   return true;
@@ -97,7 +100,7 @@ bool RootAtSnapshot(TREE tree, BYTE_SLICE out, size_t snapshot) {
     return false;
   }
   const std::string& hash = t->RootAtSnapshot(snapshot);
-  CHECK_EQ(nodesize, hash.size());
+  assert(nodesize == hash.size());
   memcpy(slice->data, hash.data(), nodesize);
   slice->len = nodesize;
   return true;
@@ -108,15 +111,15 @@ bool RootAtSnapshot(TREE tree, BYTE_SLICE out, size_t snapshot) {
 // |num_copied| is set to the number of entries copied.
 bool CopyNodesToSlice(const std::vector<std::string>& path, GoSlice* dst,
                       size_t nodesize, size_t* num_copied) {
-  CHECK_NOTNULL(dst);
-  CHECK_NOTNULL(num_copied);
+  assert(dst);
+  assert(num_copied);
   if (dst->cap < path.size() * nodesize) {
     *num_copied = 0;
     return false;
   }
   char* e = static_cast<char*>(dst->data);
   for (int i = 0; i < path.size(); ++i) {
-    CHECK_EQ(nodesize, path[i].size());
+    assert(nodesize == path[i].size());
     memcpy(e, path[i].data(), nodesize);
     e += nodesize;
   }


### PR DESCRIPTION
This is to keep the dependencies as minimal as possible for the Go wrapper.