### PR TITLE
Remove use of obsolete member __state_file in __repr__ and __str__

### DIFF
--- a/python/ct/client/monitor.py
+++ b/python/ct/client/monitor.py
@@ -51,14 +51,12 @@ class Monitor(object):
         self._unverified_tree.load(self.__state.unverified_tree)
 
     def __repr__(self):
-        return "%r(%r, %r, %r, %r)" % (self.__class__.__name__, self.__client,
-                                       self.__verifier, self.__db,
-                                       self.__state_file)
+        return "%r(%r, %r, %r)" % (self.__class__.__name__, self.__client,
+                                   self.__verifier, self.__db)
 
     def __str__(self):
-        return "%s(%s, %s, %s, %s)" % (self.__class__.__name__, self.__client,
-                                       self.__verifier, self.__db,
-                                       self.__state_file)
+        return "%s(%s, %s, %s)" % (self.__class__.__name__, self.__client,
+                                   self.__verifier, self.__db)
 
     def __update_state(self, new_state):
         """Update state and write to disk."""


### PR DESCRIPTION
str(some monitor) and repr(some monitor) failed because they referenced a class member removed some time ago.  updated to remove those refs.