### PR TITLE
Proto and serialization changes for V2 structures, should align with draft v10 rfc

### DIFF
--- a/cpp/log/etcd_consistent_store-inl.h
+++ b/cpp/log/etcd_consistent_store-inl.h
@@ -275,6 +275,10 @@ bool LeafEntriesMatch(const Logged& a, const Logged& b) {
     case ct::PRECERT_ENTRY:
       return a.entry().precert_entry().pre_certificate() ==
              b.entry().precert_entry().pre_certificate();
+    case ct::PRECERT_ENTRY_V2:
+      // TODO(mhs): V2 implementation required here
+      LOG(FATAL) << "CT V2 not yet implemented";
+      break;
     case ct::X_JSON_ENTRY:
       return a.entry().x_json_entry().json() ==
              b.entry().x_json_entry().json();

--- a/cpp/log/logged_entry.cc
+++ b/cpp/log/logged_entry.cc
@@ -2,6 +2,7 @@
 
 using ct::LogEntry;
 using ct::PreCert;
+using ct::CertInfo;
 using ct::SignedCertificateTimestamp;
 
 namespace cert_trans {
@@ -47,6 +48,12 @@ bool LoggedEntry::CopyFromClientLogEntry(const AsyncLogClient::Entry& entry) {
                                        .signed_entry()
                                        .precert()
                                        .tbs_certificate());
+      break;
+    }
+
+    case ct::PRECERT_ENTRY_V2: {
+      // TODO(mhs): V2 implementation here + other changes above
+      LOG(FATAL) << "CT V2 not yet implemented";
       break;
     }
 

--- a/cpp/log/logged_entry.h
+++ b/cpp/log/logged_entry.h
@@ -60,6 +60,10 @@ class LoggedEntry : public ct::LoggedEntryPB {
       case ct::PRECERT_ENTRY:
         return Serializer::SerializePrecertChainEntry(entry().precert_entry(),
                                                       dst) == Serializer::OK;
+      case ct::PRECERT_ENTRY_V2:
+        // TODO(mhs): V2 implementation needs to be provided.
+        LOG(FATAL) << "CT V2 not yet implemented";
+        break;
       case ct::X_JSON_ENTRY:
         dst->clear();
         return true;

--- a/cpp/proto/serializer_test.cc
+++ b/cpp/proto/serializer_test.cc
@@ -1,6 +1,7 @@
 /* -*- indent-tabs-mode: nil -*- */
 #include <gflags/gflags.h>
 #include <glog/logging.h>
+#include <google/protobuf/repeated_field.h>
 #include <gtest/gtest.h>
 #include <string>
 
@@ -18,9 +19,12 @@ using ct::MerkleTreeLeaf;
 using ct::PrecertChainEntry;
 using ct::SignedCertificateTimestamp;
 using ct::SignedCertificateTimestampList;
+using ct::SctExtension;
 using ct::SignedTreeHead;
+using ct::SthExtension;
 using ct::Version;
 using ct::X509ChainEntry;
+using google::protobuf::RepeatedPtrField;
 using std::string;
 
 // A slightly shorter notation for constructing binary blobs from test vectors.
@@ -32,6 +36,9 @@ string B(const string& hexstring) {
 string H(const string& byte_string) {
   return util::HexString(byte_string);
 }
+
+// This string must be 32 bytes long to be a valid log id
+static const char* kDUMMY_LOG_ID = "iamapublickeyshatwofivesixdigest";
 
 const char kDefaultSCTSignatureHexString[] =
     // hash algo, sig algo, 2 bytes
@@ -51,6 +58,51 @@ const char kDefaultSCTHexString[] =
     // extensions length, 2 bytes
     "0000"
     // extensions, 0 bytes
+    // hash algo, sig algo, 2 bytes
+    "0403"
+    // signature length, 2 bytes
+    "0009"
+    // signature, 9 bytes
+    "7369676e6174757265";
+
+const char kDefaultSCTHexStringV2[] =
+    // version, 1 byte
+    "01"
+    // keyid, 32 bytes
+    "69616d617075626c69636b657973686174776f66697665736978646967657374"
+    // timestamp, 8 bytes
+    "00000000000004d2"
+    // extensions length, 2 bytes
+    "0000"
+    // extensions, 0 bytes
+    // hash algo, sig algo, 2 bytes
+    "0403"
+    // signature length, 2 bytes
+    "0009"
+    // signature, 9 bytes
+    "7369676e6174757265";
+
+const char kDefaultSCTHexStringV2Extensions[] =
+    // version, 1 byte
+    "01"
+    // keyid, 32 bytes
+    "69616d617075626c69636b657973686174776f66697665736978646967657374"
+    // timestamp, 8 bytes
+    "00000000000004d2"
+    // extensions count 2 bytes
+    "0002"
+    // extension 1 type
+    "002a"
+    // extension 1 data length
+    "0009"
+    // extension 1 data "dontpanic"
+    "646f6e7470616e6963"
+    // extension 2 type
+    "0472"
+    // extension 2 data length
+    "0003"
+    // extension 2 data "thx"
+    "746878"
     // hash algo, sig algo, 2 bytes
     "0403"
     // signature length, 2 bytes
@@ -82,7 +134,74 @@ const char kDefaultCertSCTSignedHexString[] =
     "6365727469666963617465"
     // extensions length, 2 bytes
     "0000";
-// extensions, 0 bytes
+    // extensions, 0 bytes
+
+const char kDefaultCertSCTSignedHexStringExtensions[] =
+    // version, 1 byte
+    "00"
+    // signature type, 1 byte
+    "00"
+    // timestamp, 8 bytes
+    "00000000000004d2"
+    // entry type, 2 bytes
+    "0000"
+    // leaf certificate length, 3 bytes
+    "00000b"
+    // leaf certificate, 11 bytes
+    "6365727469666963617465"
+    // extensions length, 2 bytes
+    "0005"
+    // extension data "hello"
+    "68656c6c6f";
+
+const char kDefaultCertSCTSignedHexStringV2[] =
+    // version, 1 byte
+    "01"
+    // signature type, 1 byte
+    "00"
+    // timestamp, 8 bytes
+    "00000000000004d2"
+    // entry type, 2 bytes
+    "0000"
+    // keyid, 32 bytes
+    "69616d617075626c69636b657973686174776f66697665736978646967657374"
+    // leaf certificate length, 3 bytes
+    "00000c"
+    // leaf certificate, 12 bytes
+    "636572746966696361746532"
+    // extensions length, 2 bytes
+    "0000";
+    // extensions, 0 bytes
+
+const char kDefaultCertSCTSignedHexStringV2Extensions[] =
+    // version, 1 byte
+    "01"
+    // signature type, 1 byte
+    "00"
+    // timestamp, 8 bytes
+    "00000000000004d2"
+    // entry type, 2 bytes
+    "0000"
+    // keyid, 32 bytes
+    "69616d617075626c69636b657973686174776f66697665736978646967657374"
+    // leaf certificate length, 3 bytes
+    "00000c"
+    // leaf certificate, 12 bytes
+    "636572746966696361746532"
+    // extensions count 2 bytes
+    "0002"
+    // extension 1 type
+    "002a"
+    // extension 1 data length
+    "0009"
+    // extension 1 data "dontpanic"
+    "646f6e7470616e6963"
+    // extension 2 type
+    "0472"
+    // extension 2 data length
+    "0003"
+    // extension 2 data "thx"
+    "746878";
 
 const char kDefaultSignedCertEntryWithTypeHexString[] =
     // entry type, 2 bytes
@@ -99,7 +218,7 @@ const char kDefaultPrecertSCTSignedHexString[] =
     "00"
     // timestamp, 8 bytes
     "00000000000004d2"
-    // entry type, 2 bytes
+    // entry type, 2 bytes (PRECERT)
     "0001"
     // issuer key hash, 32 bytes
     "69616d617075626c69636b657973686174776f66697665736978646967657374"
@@ -109,7 +228,26 @@ const char kDefaultPrecertSCTSignedHexString[] =
     "746273"
     // extensions length, 2 bytes
     "0000";
-// extensions, 0 bytes
+    // extensions, 0 bytes
+
+const char kDefaultPrecertSCTSignedHexStringV2[] =
+    // version, 1 byte
+    "01"
+    // signature type, 1 byte
+    "00"
+    // timestamp, 8 bytes
+    "00000000000004d2"
+    // entry type, 2 bytes (PRECERT_V2)
+    "0002"
+    // issuer key hash, 32 bytes
+    "69616d617075626c69636b657973686174776f66697665736978646967657374"
+    // certificate length, 4 bytes
+    "000004"
+    // certificate, 4 bytes
+    "74627332"
+    // extensions length, 2 bytes
+    "0000";
+    // extensions, 0 bytes
 
 const char kDefaultSignedPrecertEntryWithTypeHexString[] =
     // entry type, 2 bytes
@@ -136,7 +274,56 @@ const char kDefaultCertSCTLeafHexString[] =
     "6365727469666963617465"
     // extensions length, 2 bytes
     "0000";
-// extensions, 0 bytes
+    // extensions, 0 bytes
+
+const char kDefaultCertSCTLeafHexStringV2[] =
+    // version, 1 byte
+    "01"
+    // leaf type, 1 byte
+    "00"
+    // timestamp, 8 bytes
+    "00000000000004d2"
+    // entry type, 2 bytes
+    "0000"
+    // issuer key hash, 32 bytes
+    "69616d617075626c69636b657973686174776f66697665736978646967657374"
+    // leaf certificate length, 3 bytes
+    "00000c"
+    // leaf certificate, 12 bytes
+    "636572746966696361746532"
+    // extensions length, 2 bytes
+    "0000";
+    // extensions, 0 bytes
+
+const char kDefaultCertSCTLeafHexStringV2Extensions[] =
+    // version, 1 byte
+    "01"
+    // leaf type, 1 byte
+    "00"
+    // timestamp, 8 bytes
+    "00000000000004d2"
+    // entry type, 2 bytes
+    "0000"
+    // issuer key hash, 32 bytes
+    "69616d617075626c69636b657973686174776f66697665736978646967657374"
+    // leaf certificate length, 3 bytes
+    "00000c"
+    // leaf certificate, 12 bytes
+    "636572746966696361746532"
+    // extensions count 2 bytes
+    "0002"
+    // extension 1 type
+    "002a"
+    // extension 1 data length
+    "0009"
+    // extension 1 data "dontpanic"
+    "646f6e7470616e6963"
+    // extension 2 type
+    "0472"
+    // extension 2 data length
+    "0003"
+    // extension 2 data "thx"
+    "746878";
 
 const char kDefaultPrecertSCTLeafHexString[] =
     // version, 1 byte
@@ -145,7 +332,7 @@ const char kDefaultPrecertSCTLeafHexString[] =
     "00"
     // timestamp, 8 bytes
     "00000000000004d2"
-    // entry type, 2 bytes
+    // entry type, 2 bytes (PRECERT)
     "0001"
     // issuer key hash, 32 bytes
     "69616d617075626c69636b657973686174776f66697665736978646967657374"
@@ -155,7 +342,26 @@ const char kDefaultPrecertSCTLeafHexString[] =
     "746273"
     // extensions length, 2 bytes
     "0000";
-// extensions, 0 bytes
+    // extensions, 0 bytes
+
+const char kDefaultPrecertSCTLeafHexStringV2[] =
+    // version, 1 byte
+    "01"
+    // leaf type, 1 byte
+    "00"
+    // timestamp, 8 bytes
+    "00000000000004d2"
+    // entry type, 2 bytes (PRECERT_V2)
+    "0002"
+    // issuer key hash, 32 bytes
+    "69616d617075626c69636b657973686174776f66697665736978646967657374"
+    // tbs certificate length, 4 bytes
+    "000004"
+    // leaf certificate, 4 bytes
+    "74627332"
+    // extensions length, 2 bytes
+    "0000";
+    // extensions, 0 bytes
 
 const char kDefaultSTHSignedHexString[] =
     // version, 1 byte
@@ -169,46 +375,189 @@ const char kDefaultSTHSignedHexString[] =
     // root hash, 32 bytes
     "696d757374626565786163746c7974686972747974776f62797465736c6f6e67";
 
+const char kDefaultSTHSignedHexStringV2[] =
+    // version, 1 byte
+    "01"
+    // signature type, 1 byte
+    "01"
+    // keyid, 32 bytes
+    "69616d617075626c69636b657973686174776f66697665736978646967657374"
+    // timestamp, 8 bytes
+    "0000000000000929"
+    // tree size, 8 bytes
+    "0000000000000006"
+    // root hash, 32 bytes
+    "696d757374626565786163746c7974686972747974776f62797465736c6f6e67"
+    // extensions length 2 bytes, no extension data
+    "0000";
+
+const char kDefaultSTHSignedHexStringV2Extensions[] =
+    // version, 1 byte
+    "01"
+    // signature type, 1 byte
+    "01"
+    // keyid, 32 bytes
+    "69616d617075626c69636b657973686174776f66697665736978646967657374"
+    // timestamp, 8 bytes
+    "0000000000000929"
+    // tree size, 8 bytes
+    "0000000000000006"
+    // root hash, 32 bytes
+    "696d757374626565786163746c7974686972747974776f62797465736c6f6e67"
+    // extensions count 2 bytes
+    "0002"
+    // extension 1 type
+    "002a"
+    // extension 1 data length
+    "0009"
+    // extension 1 data "dontpanic"
+    "646f6e7470616e6963"
+    // extension 2 type
+    "0472"
+    // extension 2 data length
+    "0003"
+    // extension 2 data "thx"
+    "746878";
+
 // TODO(ekasper): switch to real data here, too.
 class SerializerTest : public ::testing::Test {
  protected:
   SerializerTest()
-      : cert_entry_(), precert_entry_(), sct_(), sct_list_(), sth_() {
+      : cert_entry_(),
+        cert_entry_v2_(),
+        precert_entry_(),
+        precert_entry_v2_(),
+        sct_(),
+        sct_v2_(),
+        sct_v2_ext_(),
+        sct_v2_ext_badorder_(),
+        sct_list_(),
+        sct_list_v2_(),
+        sth_(),
+        sth_v2_(),
+        sth_v2_ext_(),
+        sth_v2_ext_badorder_() {
     cert_entry_.set_type(ct::X509_ENTRY);
     cert_entry_.mutable_x509_entry()->set_leaf_certificate("certificate");
+
+    cert_entry_v2_.set_type(ct::X509_ENTRY);
+    cert_entry_v2_.mutable_x509_entry()
+        ->mutable_cert_info()
+        ->set_tbs_certificate("certificate2");
+    cert_entry_v2_.mutable_x509_entry()
+        ->mutable_cert_info()
+        ->set_issuer_key_hash(kDUMMY_LOG_ID);
 
     precert_entry_.set_type(ct::PRECERT_ENTRY);
     precert_entry_.mutable_precert_entry()->set_pre_certificate("precert");
     precert_entry_.mutable_precert_entry()
         ->mutable_pre_cert()
-        ->set_issuer_key_hash("iamapublickeyshatwofivesixdigest");
+        ->set_issuer_key_hash(kDUMMY_LOG_ID);
     precert_entry_.mutable_precert_entry()
         ->mutable_pre_cert()
         ->set_tbs_certificate("tbs");
 
+    precert_entry_v2_.set_type(ct::PRECERT_ENTRY_V2);
+    precert_entry_v2_.mutable_precert_entry()->set_pre_certificate("precert2");
+    precert_entry_v2_.mutable_precert_entry()
+        ->mutable_cert_info()
+        ->set_issuer_key_hash(kDUMMY_LOG_ID);
+    precert_entry_v2_.mutable_precert_entry()
+        ->mutable_cert_info()
+        ->set_tbs_certificate("tbs2");
+
     sct_.set_version(ct::V1);
-    sct_.mutable_id()->set_key_id("iamapublickeyshatwofivesixdigest");
+    sct_.mutable_id()->set_key_id(kDUMMY_LOG_ID);
     sct_.set_timestamp(1234);
     sct_.mutable_signature()->set_hash_algorithm(DigitallySigned::SHA256);
     sct_.mutable_signature()->set_sig_algorithm(DigitallySigned::ECDSA);
     sct_.mutable_signature()->set_signature("signature");
     sct_list_.add_sct_list(B(kDefaultSCTHexString));
+
+    sct_v2_.set_version(ct::V2);
+    sct_v2_.mutable_id()->set_key_id(kDUMMY_LOG_ID);
+    sct_v2_.set_timestamp(1234);
+    sct_v2_.mutable_signature()->set_hash_algorithm(DigitallySigned::SHA256);
+    sct_v2_.mutable_signature()->set_sig_algorithm(DigitallySigned::ECDSA);
+    sct_v2_.mutable_signature()->set_signature("signature");
+    sct_list_v2_.add_sct_list(B(kDefaultSCTHexStringV2));
+
+    // create a v2 sct with extensions
+    sct_v2_ext_ = sct_v2_;
+    SctExtension* const sct_ext1 = sct_v2_ext_.add_sct_extension();
+    sct_ext1->set_sct_extension_type(42);
+    sct_ext1->set_sct_extension_data("dontpanic");
+
+    SctExtension* const sct_ext2 = sct_v2_ext_.add_sct_extension();
+    sct_ext2->set_sct_extension_type(1138);
+    sct_ext2->set_sct_extension_data("thx");
+
+    // create a v2 sct with extensions out of order and hence invalid
+    sct_v2_ext_badorder_ = sct_v2_;
+    SctExtension* const sct_ext1_bad =
+        sct_v2_ext_badorder_.add_sct_extension();
+    sct_ext1_bad->set_sct_extension_type(1138);
+    sct_ext1_bad->set_sct_extension_data("thx");
+
+    SctExtension* const sct_ext2_bad =
+        sct_v2_ext_badorder_.add_sct_extension();
+    sct_ext2_bad->set_sct_extension_type(42);
+    sct_ext2_bad->set_sct_extension_data("dontpanic");
+
     sth_.set_version(ct::V1);
-    sth_.mutable_id()->set_key_id("iamapublickeyshatwofivesixdigest");
+    sth_.mutable_id()->set_key_id(kDUMMY_LOG_ID);
     sth_.set_timestamp(2345);
     sth_.set_tree_size(6);
     sth_.set_sha256_root_hash("imustbeexactlythirtytwobyteslong");
     sth_.mutable_signature()->set_hash_algorithm(DigitallySigned::SHA256);
     sth_.mutable_signature()->set_sig_algorithm(DigitallySigned::ECDSA);
     sth_.mutable_signature()->set_signature("tree_signature");
+
+    sth_v2_.set_version(ct::V2);
+    sth_v2_.mutable_id()->set_key_id(kDUMMY_LOG_ID);
+    sth_v2_.set_timestamp(2345);
+    sth_v2_.set_tree_size(6);
+    sth_v2_.set_sha256_root_hash("imustbeexactlythirtytwobyteslong");
+    sth_v2_.mutable_signature()->set_hash_algorithm(DigitallySigned::SHA256);
+    sth_v2_.mutable_signature()->set_sig_algorithm(DigitallySigned::ECDSA);
+    sth_v2_.mutable_signature()->set_signature("tree_signature");
+
+    sth_v2_ext_ = sth_v2_;  // basically the same but with added extensions
+    SthExtension* const sth_ext1 = sth_v2_ext_.add_sth_extension();
+    sth_ext1->set_sth_extension_type(42);
+    sth_ext1->set_sth_extension_data("dontpanic");
+
+    SthExtension* const sth_ext2 = sth_v2_ext_.add_sth_extension();
+    sth_ext2->set_sth_extension_type(1138);
+    sth_ext2->set_sth_extension_data("thx");
+
+    // This sth has extensions out of order (invalid)
+    sth_v2_ext_badorder_ = sth_v2_;
+    SthExtension* const sth_ext1_bad_order =
+        sth_v2_ext_badorder_.add_sth_extension();
+    sth_ext1_bad_order->set_sth_extension_type(1138);
+    sth_ext1_bad_order->set_sth_extension_data("thx");
+
+    SthExtension* const sth_ext2_bad_order =
+        sth_v2_ext_badorder_.add_sth_extension();
+    sth_ext2_bad_order->set_sth_extension_type(42);
+    sth_ext2_bad_order->set_sth_extension_data("dontpanic");
   }
 
   const LogEntry& DefaultCertEntry() const {
     return cert_entry_;
   }
 
+  const LogEntry& DefaultCertEntryV2() const {
+    return cert_entry_v2_;
+  }
+
   const LogEntry& DefaultPrecertEntry() const {
     return precert_entry_;
+  }
+
+  const LogEntry& DefaultPrecertEntryV2() const {
+    return precert_entry_v2_;
   }
 
   uint64_t DefaultSCTTimestamp() const {
@@ -219,6 +568,10 @@ class SerializerTest : public ::testing::Test {
     return cert_entry_.x509_entry().leaf_certificate();
   }
 
+  string DefaultCertificateV2() const {
+    return cert_entry_v2_.x509_entry().cert_info().tbs_certificate();
+  }
+
   string DefaultIssuerKeyHash() const {
     return precert_entry_.precert_entry().pre_cert().issuer_key_hash();
   }
@@ -227,16 +580,44 @@ class SerializerTest : public ::testing::Test {
     return precert_entry_.precert_entry().pre_cert().tbs_certificate();
   }
 
+  string DefaultTbsCertificateV2() const {
+    return precert_entry_v2_.precert_entry().cert_info().tbs_certificate();
+  }
+
   string DefaultExtensions() const {
     return string();
+  }
+
+  const RepeatedPtrField<SthExtension>& DefaultSthExtensions() const {
+    return sth_v2_.sth_extension();
   }
 
   const SignedCertificateTimestamp& DefaultSCT() const {
     return sct_;
   }
 
+  const SignedCertificateTimestamp& DefaultSCTV2() const {
+    return sct_v2_;
+  }
+
+  const SignedCertificateTimestamp& DefaultSCTV2Ext() const {
+    return sct_v2_ext_;
+  }
+
+  const RepeatedPtrField<SctExtension>& DefaultSctExtensions() const {
+    return sct_v2_.sct_extension();
+  }
+
+  const SignedCertificateTimestamp& DefaultSCTV2ExtBadOrder() const {
+    return sct_v2_ext_badorder_;
+  }
+
   const SignedCertificateTimestampList& DefaultSCTList() const {
     return sct_list_;
+  }
+
+  const SignedCertificateTimestampList& DefaultSCTListV2() const {
+    return sct_list_v2_;
   }
 
   uint64_t DefaultSTHTimestamp() const {
@@ -254,6 +635,18 @@ class SerializerTest : public ::testing::Test {
 
   const SignedTreeHead& DefaultSTH() const {
     return sth_;
+  }
+
+  const SignedTreeHead& DefaultSTHV2() const {
+    return sth_v2_;
+  }
+
+  const SignedTreeHead& DefaultSTHV2Ext() const {
+    return sth_v2_ext_;
+  }
+
+  const SignedTreeHead& DefaultSTHV2ExtBadOrder() const {
+    return sth_v2_ext_badorder_;
   }
 
   const DigitallySigned& DefaultSCTSignature() const {
@@ -281,10 +674,19 @@ class SerializerTest : public ::testing::Test {
 
  private:
   LogEntry cert_entry_;
+  LogEntry cert_entry_v2_;
   LogEntry precert_entry_;
+  LogEntry precert_entry_v2_;
   SignedCertificateTimestamp sct_;
+  SignedCertificateTimestamp sct_v2_;
+  SignedCertificateTimestamp sct_v2_ext_;
+  SignedCertificateTimestamp sct_v2_ext_badorder_;
   SignedCertificateTimestampList sct_list_;
+  SignedCertificateTimestampList sct_list_v2_;
   SignedTreeHead sth_;
+  SignedTreeHead sth_v2_;
+  SignedTreeHead sth_v2_ext_;
+  SignedTreeHead sth_v2_ext_badorder_;
 };
 
 TEST_F(SerializerTest, SerializeDigitallySignedKatTest) {
@@ -317,7 +719,7 @@ TEST_F(SerializerTest, DeserializeSCTListKatTest) {
   EXPECT_EQ(string(kDefaultSCTHexString), H(sct_list.sct_list(0)));
 }
 
-TEST_F(SerializerTest, SerializeSCTSignatureInputKatTest) {
+TEST_F(SerializerTest, SerializeSCTSignatureInputKatTestV1) {
   string cert_result, precert_result;
   EXPECT_EQ(Serializer::OK, Serializer::SerializeV1CertSCTSignatureInput(
                                 DefaultSCTTimestamp(), DefaultCertificate(),
@@ -348,7 +750,39 @@ TEST_F(SerializerTest, SerializeSCTSignatureInputKatTest) {
   EXPECT_EQ(string(kDefaultPrecertSCTSignedHexString), H(precert_result));
 }
 
-TEST_F(SerializerTest, SerializeSCTMerkleTreeLeafKatTest) {
+TEST_F(SerializerTest, SerializeSCTSignatureInputKatTestV2) {
+  string cert_result, precert_result;
+  EXPECT_EQ(Serializer::OK,
+            Serializer::SerializeV2CertSCTSignatureInput(
+                DefaultSCTTimestamp(), DefaultIssuerKeyHash(),
+                DefaultCertificateV2(), DefaultSctExtensions(), &cert_result));
+  EXPECT_EQ(string(kDefaultCertSCTSignedHexStringV2), H(cert_result));
+
+  EXPECT_EQ(Serializer::OK, Serializer::SerializeV2PrecertSCTSignatureInput(
+                                DefaultSCTTimestamp(), DefaultIssuerKeyHash(),
+                                DefaultTbsCertificateV2(),
+                                DefaultSctExtensions(), &precert_result));
+  EXPECT_EQ(string(kDefaultPrecertSCTSignedHexStringV2), H(precert_result));
+
+  EXPECT_NE(cert_result, precert_result);
+
+  cert_result.clear();
+  precert_result.clear();
+
+  EXPECT_EQ(Serializer::OK,
+            Serializer::SerializeSCTSignatureInput(DefaultSCTV2(),
+                                                   DefaultCertEntryV2(),
+                                                   &cert_result));
+  EXPECT_EQ(string(kDefaultCertSCTSignedHexStringV2), H(cert_result));
+
+  EXPECT_EQ(Serializer::OK,
+            Serializer::SerializeSCTSignatureInput(DefaultSCTV2(),
+                                                   DefaultPrecertEntryV2(),
+                                                   &precert_result));
+  EXPECT_EQ(string(kDefaultPrecertSCTSignedHexStringV2), H(precert_result));
+}
+
+TEST_F(SerializerTest, SerializeSCTMerkleTreeLeafKatTestV1) {
   string cert_result, precert_result;
   EXPECT_EQ(Serializer::OK, Serializer::SerializeV1CertSCTMerkleTreeLeaf(
                                 DefaultSCTTimestamp(), DefaultCertificate(),
@@ -379,7 +813,39 @@ TEST_F(SerializerTest, SerializeSCTMerkleTreeLeafKatTest) {
   EXPECT_EQ(string(kDefaultPrecertSCTLeafHexString), H(precert_result));
 }
 
-TEST_F(SerializerTest, DeserializeMerkleTreeLeafKAT) {
+TEST_F(SerializerTest, SerializeSCTMerkleTreeLeafKatTestV2) {
+  string cert_result, precert_result;
+  EXPECT_EQ(Serializer::OK,
+            Serializer::SerializeV2CertSCTMerkleTreeLeaf(
+                DefaultSCTTimestamp(), DefaultIssuerKeyHash(),
+                DefaultCertificateV2(), DefaultSctExtensions(), &cert_result));
+  EXPECT_EQ(string(kDefaultCertSCTLeafHexStringV2), H(cert_result));
+
+  EXPECT_EQ(Serializer::OK, Serializer::SerializeV2PrecertSCTMerkleTreeLeaf(
+                                DefaultSCTTimestamp(), DefaultIssuerKeyHash(),
+                                DefaultTbsCertificateV2(),
+                                DefaultSctExtensions(), &precert_result));
+  EXPECT_EQ(string(kDefaultPrecertSCTLeafHexStringV2), H(precert_result));
+
+  EXPECT_NE(cert_result, precert_result);
+
+  cert_result.clear();
+  precert_result.clear();
+
+  EXPECT_EQ(Serializer::OK,
+            Serializer::SerializeSCTMerkleTreeLeaf(DefaultSCTV2(),
+                                                   DefaultCertEntryV2(),
+                                                   &cert_result));
+  EXPECT_EQ(string(kDefaultCertSCTLeafHexStringV2), H(cert_result));
+
+  EXPECT_EQ(Serializer::OK,
+            Serializer::SerializeSCTMerkleTreeLeaf(DefaultSCTV2(),
+                                                   DefaultPrecertEntryV2(),
+                                                   &precert_result));
+  EXPECT_EQ(string(kDefaultPrecertSCTLeafHexStringV2), H(precert_result));
+}
+
+TEST_F(SerializerTest, DeserializeMerkleTreeLeafKATV1Cert) {
   MerkleTreeLeaf leaf;
   EXPECT_EQ(Deserializer::OK, Deserializer::DeserializeMerkleTreeLeaf(
                                   B(kDefaultCertSCTLeafHexString), &leaf));
@@ -390,28 +856,72 @@ TEST_F(SerializerTest, DeserializeMerkleTreeLeafKAT) {
   EXPECT_EQ(leaf.timestamped_entry().signed_entry().x509(),
             DefaultCertEntry().x509_entry().leaf_certificate());
   EXPECT_FALSE(leaf.timestamped_entry().signed_entry().has_precert());
+}
 
-  MerkleTreeLeaf leaf2;
+TEST_F(SerializerTest, DeserializeMerkleTreeLeafKATV1Precert) {
+  MerkleTreeLeaf leaf;
   EXPECT_EQ(Deserializer::OK, Deserializer::DeserializeMerkleTreeLeaf(
-                                  B(kDefaultPrecertSCTLeafHexString), &leaf2));
-  EXPECT_EQ(leaf2.version(), ct::V1);
-  EXPECT_EQ(leaf2.type(), ct::TIMESTAMPED_ENTRY);
-  EXPECT_EQ(leaf2.timestamped_entry().timestamp(), DefaultSCTTimestamp());
-  EXPECT_EQ(leaf2.timestamped_entry().entry_type(), ct::PRECERT_ENTRY);
-  EXPECT_FALSE(leaf2.timestamped_entry().signed_entry().has_x509());
+                                  B(kDefaultPrecertSCTLeafHexString), &leaf));
+  EXPECT_EQ(leaf.version(), ct::V1);
+  EXPECT_EQ(leaf.type(), ct::TIMESTAMPED_ENTRY);
+  EXPECT_EQ(leaf.timestamped_entry().timestamp(), DefaultSCTTimestamp());
+  EXPECT_EQ(leaf.timestamped_entry().entry_type(), ct::PRECERT_ENTRY);
+  EXPECT_FALSE(leaf.timestamped_entry().signed_entry().has_x509());
   EXPECT_EQ(
-      leaf2.timestamped_entry().signed_entry().precert().issuer_key_hash(),
+      leaf.timestamped_entry().signed_entry().precert().issuer_key_hash(),
       DefaultIssuerKeyHash());
   EXPECT_EQ(
-      leaf2.timestamped_entry().signed_entry().precert().tbs_certificate(),
+      leaf.timestamped_entry().signed_entry().precert().tbs_certificate(),
       DefaultTbsCertificate());
 }
 
-TEST_F(SerializerTest, DeserializeSCTKatTest) {
+TEST_F(SerializerTest, DeserializeMerkleTreeLeafKATV2Cert) {
+  MerkleTreeLeaf leaf;
+  EXPECT_EQ(Deserializer::OK, Deserializer::DeserializeMerkleTreeLeaf(
+                                  B(kDefaultCertSCTLeafHexStringV2), &leaf));
+  EXPECT_EQ(leaf.version(), ct::V2);
+  EXPECT_EQ(leaf.type(), ct::TIMESTAMPED_ENTRY);
+  EXPECT_EQ(leaf.timestamped_entry().timestamp(), DefaultSCTTimestamp());
+  EXPECT_EQ(leaf.timestamped_entry().entry_type(), ct::X509_ENTRY);
+  EXPECT_EQ(
+      leaf.timestamped_entry().signed_entry().cert_info().tbs_certificate(),
+      DefaultCertEntryV2().x509_entry().cert_info().tbs_certificate());
+  EXPECT_EQ(
+      leaf.timestamped_entry().signed_entry().cert_info().issuer_key_hash(),
+      DefaultCertEntryV2().x509_entry().cert_info().issuer_key_hash());
+  EXPECT_FALSE(leaf.timestamped_entry().signed_entry().has_precert());
+}
+
+TEST_F(SerializerTest, DeserializeMerkleTreeLeafKATV2Precert) {
+  MerkleTreeLeaf leaf;
+  EXPECT_EQ(Deserializer::OK,
+            Deserializer::DeserializeMerkleTreeLeaf(
+                B(kDefaultPrecertSCTLeafHexStringV2), &leaf));
+  EXPECT_EQ(leaf.version(), ct::V2);
+  EXPECT_EQ(leaf.type(), ct::TIMESTAMPED_ENTRY);
+  EXPECT_EQ(leaf.timestamped_entry().timestamp(), DefaultSCTTimestamp());
+  EXPECT_EQ(leaf.timestamped_entry().entry_type(), ct::PRECERT_ENTRY_V2);
+  EXPECT_FALSE(leaf.timestamped_entry().signed_entry().has_x509());
+  EXPECT_EQ(
+      leaf.timestamped_entry().signed_entry().cert_info().issuer_key_hash(),
+      DefaultIssuerKeyHash());
+  EXPECT_EQ(
+      leaf.timestamped_entry().signed_entry().cert_info().tbs_certificate(),
+      DefaultTbsCertificateV2());
+}
+
+TEST_F(SerializerTest, DeserializeSCTKatTestV1) {
   string token = B(kDefaultSCTHexString);
   SignedCertificateTimestamp sct;
   EXPECT_EQ(Deserializer::OK, Deserializer::DeserializeSCT(token, &sct));
   CompareSCT(DefaultSCT(), sct);
+}
+
+TEST_F(SerializerTest, DeserializeSCTKatTestV2) {
+  string token = B(kDefaultSCTHexStringV2);
+  SignedCertificateTimestamp sct;
+  EXPECT_EQ(Deserializer::OK, Deserializer::DeserializeSCT(token, &sct));
+  CompareSCT(DefaultSCTV2(), sct);
 }
 
 TEST_F(SerializerTest, DeserializeDigitallySignedKatTest) {
@@ -586,7 +1096,7 @@ TEST_F(SerializerTest, DeserializeSCTTooLong) {
             Deserializer::DeserializeSCT(token, &sct));
 }
 
-TEST_F(SerializerTest, SerializeSTHSignatureInputKatTest) {
+TEST_F(SerializerTest, SerializeSTHSignatureInputKatTestV1) {
   string result;
   EXPECT_EQ(Serializer::OK,
             Serializer::SerializeSTHSignatureInput(DefaultSTH(), &result));
@@ -599,7 +1109,44 @@ TEST_F(SerializerTest, SerializeSTHSignatureInputKatTest) {
   EXPECT_EQ(string(kDefaultSTHSignedHexString), H(result));
 }
 
-TEST_F(SerializerTest, SerializeSTHSignatureInputBadHash) {
+TEST_F(SerializerTest, SerializeSTHSignatureInputKatTestV2) {
+  string result;
+  EXPECT_EQ(Serializer::OK,
+            Serializer::SerializeSTHSignatureInput(DefaultSTHV2(), &result));
+  EXPECT_EQ(string(kDefaultSTHSignedHexStringV2), H(result));
+
+  result.clear();
+  EXPECT_EQ(Serializer::OK,
+            Serializer::SerializeV2STHSignatureInput(
+                DefaultSTHTimestamp(), DefaultTreeSize(), DefaultRootHash(),
+                DefaultSthExtensions(), kDUMMY_LOG_ID, &result));
+  EXPECT_EQ(string(kDefaultSTHSignedHexStringV2), H(result));
+}
+
+TEST_F(SerializerTest, SerializeSTHSignatureInputKatTestV2InvalidLogId) {
+  string result;
+  EXPECT_EQ(Serializer::INVALID_KEYID_LENGTH,
+            Serializer::SerializeV2STHSignatureInput(
+                DefaultSTHTimestamp(), DefaultTreeSize(), DefaultRootHash(),
+                DefaultSthExtensions(), "this isn't 32 bytes long", &result));
+}
+
+TEST_F(SerializerTest, SerializeSTHSignatureInputKatTestV2WithExtensions) {
+  string result;
+  SignedTreeHead sth(DefaultSTHV2Ext());
+  EXPECT_EQ(Serializer::OK,
+            Serializer::SerializeSTHSignatureInput(sth, &result));
+  EXPECT_EQ(string(kDefaultSTHSignedHexStringV2Extensions), H(result));
+
+  result.clear();
+  EXPECT_EQ(Serializer::OK,
+            Serializer::SerializeV2STHSignatureInput(
+                DefaultSTHTimestamp(), DefaultTreeSize(), DefaultRootHash(),
+                DefaultSTHV2Ext().sth_extension(), kDUMMY_LOG_ID, &result));
+  EXPECT_EQ(string(kDefaultSTHSignedHexStringV2Extensions), H(result));
+}
+
+TEST_F(SerializerTest, SerializeSTHSignatureInputBadHashV1) {
   SignedTreeHead sth(DefaultSTH());
   sth.set_sha256_root_hash("thisisnotthirtytwobyteslong");
   string result;
@@ -607,7 +1154,22 @@ TEST_F(SerializerTest, SerializeSTHSignatureInputBadHash) {
             Serializer::SerializeSTHSignatureInput(sth, &result));
 }
 
-TEST_F(SerializerTest, SerializeSCTWithExtensionsTest) {
+TEST_F(SerializerTest, SerializeSTHSignatureInputBadHashV2) {
+  SignedTreeHead sth(DefaultSTHV2());
+  sth.set_sha256_root_hash("thisisnotthirtytwobyteslong");
+  string result;
+  EXPECT_EQ(Serializer::INVALID_HASH_LENGTH,
+            Serializer::SerializeSTHSignatureInput(sth, &result));
+}
+
+TEST_F(SerializerTest, SerializeSTHSignatureInputExtBadOrderV2) {
+  string result;
+  EXPECT_EQ(Serializer::EXTENSIONS_NOT_ORDERED,
+            Serializer::SerializeSTHSignatureInput(DefaultSTHV2ExtBadOrder(),
+                                                   &result));
+}
+
+TEST_F(SerializerTest, SerializeSCTWithExtensionsTestV1) {
   SignedCertificateTimestamp sct(DefaultSCT());
   sct.set_extensions("hello");
   string result;
@@ -615,13 +1177,27 @@ TEST_F(SerializerTest, SerializeSCTWithExtensionsTest) {
   EXPECT_NE(string(kDefaultSCTHexString), H(result));
 }
 
-TEST_F(SerializerTest, SerializeSCTSignatureInputWithExtensionsTest) {
+TEST_F(SerializerTest, SerializeSCTWithExtensionsTestV2) {
+  SignedCertificateTimestamp sct(DefaultSCTV2Ext());
+  string result;
+  EXPECT_EQ(Serializer::OK, Serializer::SerializeSCT(sct, &result));
+  EXPECT_EQ(string(kDefaultSCTHexStringV2Extensions), H(result));
+}
+
+TEST_F(SerializerTest, SerializeSCTWithExtensionsTestV2BadOrder) {
+  SignedCertificateTimestamp sct(DefaultSCTV2ExtBadOrder());
+  string result;
+  EXPECT_EQ(Serializer::EXTENSIONS_NOT_ORDERED,
+            Serializer::SerializeSCT(sct, &result));
+}
+
+TEST_F(SerializerTest, SerializeSCTSignatureInputWithExtensionsTestV1) {
   string result;
   EXPECT_EQ(Serializer::OK,
             Serializer::SerializeV1CertSCTSignatureInput(DefaultSCTTimestamp(),
                                                          DefaultCertificate(),
                                                          "hello", &result));
-  EXPECT_NE(string(kDefaultCertSCTSignedHexString), H(result));
+  EXPECT_EQ(string(kDefaultCertSCTSignedHexStringExtensions), H(result));
 
   result.clear();
   SignedCertificateTimestamp sct(DefaultSCT());
@@ -629,10 +1205,26 @@ TEST_F(SerializerTest, SerializeSCTSignatureInputWithExtensionsTest) {
   EXPECT_EQ(Serializer::OK,
             Serializer::SerializeSCTSignatureInput(sct, DefaultCertEntry(),
                                                    &result));
-  EXPECT_NE(string(kDefaultCertSCTSignedHexString), H(result));
+  EXPECT_EQ(string(kDefaultCertSCTSignedHexStringExtensions), H(result));
 }
 
-TEST_F(SerializerTest, SerializeSCTMerkleTreeLeafWithExtensionsTest) {
+TEST_F(SerializerTest, SerializeSCTSignatureInputWithExtensionsTestV2) {
+  string result;
+  EXPECT_EQ(Serializer::OK, Serializer::SerializeV2CertSCTSignatureInput(
+                                DefaultSCTTimestamp(), DefaultIssuerKeyHash(),
+                                DefaultCertificateV2(),
+                                DefaultSCTV2Ext().sct_extension(), &result));
+  EXPECT_EQ(string(kDefaultCertSCTSignedHexStringV2Extensions), H(result));
+
+  result.clear();
+  SignedCertificateTimestamp sct(DefaultSCTV2Ext());
+  EXPECT_EQ(Serializer::OK,
+            Serializer::SerializeSCTSignatureInput(sct, DefaultCertEntryV2(),
+                                                   &result));
+  EXPECT_EQ(string(kDefaultCertSCTSignedHexStringV2Extensions), H(result));
+}
+
+TEST_F(SerializerTest, SerializeSCTMerkleTreeLeafWithExtensionsTestV1) {
   string result;
   EXPECT_EQ(Serializer::OK,
             Serializer::SerializeV1CertSCTMerkleTreeLeaf(DefaultSCTTimestamp(),
@@ -649,9 +1241,36 @@ TEST_F(SerializerTest, SerializeSCTMerkleTreeLeafWithExtensionsTest) {
   EXPECT_NE(string(kDefaultCertSCTLeafHexString), H(result));
 }
 
-TEST_F(SerializerTest, SerializeDeserializeSCTAddExtensions) {
+TEST_F(SerializerTest, SerializeSCTMerkleTreeLeafWithExtensionsTestV2) {
+  string result;
+  EXPECT_EQ(Serializer::OK, Serializer::SerializeV2CertSCTMerkleTreeLeaf(
+                                DefaultSCTTimestamp(), DefaultIssuerKeyHash(),
+                                DefaultCertificateV2(),
+                                DefaultSCTV2Ext().sct_extension(), &result));
+  EXPECT_EQ(string(kDefaultCertSCTLeafHexStringV2Extensions), H(result));
+
+  result.clear();
+  SignedCertificateTimestamp sct(DefaultSCTV2Ext());
+  EXPECT_EQ(Serializer::OK,
+            Serializer::SerializeSCTMerkleTreeLeaf(sct, DefaultCertEntryV2(),
+                                                   &result));
+  EXPECT_EQ(string(kDefaultCertSCTLeafHexStringV2Extensions), H(result));
+}
+
+TEST_F(SerializerTest, SerializeDeserializeSCTAddExtensionsV1) {
   SignedCertificateTimestamp sct(DefaultSCT());
   sct.set_extensions("hello");
+
+  string result;
+  EXPECT_EQ(Serializer::OK, Serializer::SerializeSCT(sct, &result));
+
+  SignedCertificateTimestamp read_sct;
+  EXPECT_EQ(Deserializer::OK, Deserializer::DeserializeSCT(result, &read_sct));
+  CompareSCT(sct, read_sct);
+}
+
+TEST_F(SerializerTest, SerializeDeserializeSCTAddExtensionsV2) {
+  SignedCertificateTimestamp sct(DefaultSCTV2Ext());
 
   string result;
   EXPECT_EQ(Serializer::OK, Serializer::SerializeSCT(sct, &result));

--- a/proto/ct.proto
+++ b/proto/ct.proto
@@ -38,14 +38,20 @@ message DigitallySigned {
 enum LogEntryType {
   X509_ENTRY = 0;
   PRECERT_ENTRY = 1;
+  PRECERT_ENTRY_V2 = 2;
   // Not part of the I-D, and outside the valid range.
   X_JSON_ENTRY = 32768;  // Experimental, don't rely on this!
   UNKNOWN_ENTRY_TYPE = 65536;
 }
 
 message X509ChainEntry {
+  // For V1 this entry just includes the certificate in the leaf_certificate
+  // field
   // <1..2^24-1>
   optional bytes leaf_certificate = 1;
+  // For V2 it includes the cert and key hash using CertInfo. The
+  // leaf_certificate field is not used
+  optional CertInfo cert_info = 3;
   // <0..2^24-1>
   // A chain from the leaf to a trusted root
   // (excluding leaf and possibly root).
@@ -57,8 +63,16 @@ message X509ChainEntry {
 //   opaque issuer_key_hash[32];
 //   TBSCertificate tbs_certificate;
 // } PreCert;
-// TODO(benl, ekasper): call this something more original in the I-D.
+// Retained for V1 API compatibility. May be removed in a future release.
 message PreCert {
+  optional bytes issuer_key_hash = 1;
+  optional bytes tbs_certificate = 2;
+}
+
+// In V2 this is used for both certificates and precertificates in SCTs. It
+// replaces PreCert and has the same structure. The older message remains for
+// compatibility with existing code that depends on this proto.
+message CertInfo {
   optional bytes issuer_key_hash = 1;
   optional bytes tbs_certificate = 2;
 }
@@ -74,6 +88,9 @@ message PrecertChainEntry {
   // Store it alongside the entry data so that the signers don't have to
   // parse certificates to recompute it.
   optional PreCert pre_cert = 3;
+  // As above for V2 messages. Only one of these fields will be set in a
+  // valid message
+  optional CertInfo cert_info = 4;
 }
 
 message XJSONEntry {
@@ -99,6 +116,7 @@ enum SignatureType {
 
 enum Version {
   V1 = 0;
+  V2 = 1;
   // Not part of the I-D, and outside the valid range.
   UNKNOWN_VERSION = 256;
 }
@@ -108,6 +126,13 @@ message LogID {
   optional bytes key_id = 1;
 }
 
+message SctExtension {
+  // Valid range is 0-65534
+  optional uint32 sct_extension_type = 1;
+  // Data is opaque and type specific. <0..2^16-1> bytes
+  optional bytes sct_extension_data = 2;
+}
+
 // TODO(ekasper): implement support for id.
 message SignedCertificateTimestamp {
   optional Version version = 1 [ default = UNKNOWN_VERSION ];
@@ -115,7 +140,10 @@ message SignedCertificateTimestamp {
   // UTC time in milliseconds, since January 1, 1970, 00:00.
   optional uint64 timestamp = 3;
   optional DigitallySigned signature = 4;
+  // V1 extensions
   optional bytes extensions = 5;
+  // V2 extensions <0..2^16-1>. Must be ordered by type (lowest first)
+  repeated SctExtension sct_extension = 6;
 }
 
 message SignedCertificateTimestampList {
@@ -129,16 +157,23 @@ enum MerkleLeafType {
 }
 
 message SignedEntry {
+  // For V1 signed entries either the x509 or precert field will be set
   optional bytes x509 = 1;
   optional PreCert precert = 2;
   optional bytes json = 3;
+  // For V2 all entries use the CertInfo field and the above fields are
+  // not set
+  optional CertInfo cert_info = 4;
 }
 
 message TimestampedEntry {
   optional uint64 timestamp = 1;
   optional LogEntryType entry_type = 2;
   optional SignedEntry signed_entry = 3;
+  // V1 extensions
   optional bytes extensions = 4;
+  // V2 extensions <0..2^16-1>. Must be ordered by type (lowest first)
+  repeated SctExtension sct_extension = 5;
 }
 
 // Stuff that's hashed into a Merkle leaf.
@@ -187,6 +222,13 @@ message LoggedEntryPB {
   required Contents contents = 3;
 }
 
+message SthExtension {
+  // Valid range is 0-65534
+  optional uint32 sth_extension_type = 1;
+  // Data is opaque and type specific <0..2^16-1> bytes
+  optional bytes sth_extension_data = 2;
+}
+
 message SignedTreeHead {
   // The version of the tree head signature.
   // (Note that each leaf has its own version, so a V2 tree
@@ -197,6 +239,8 @@ message SignedTreeHead {
   optional int64 tree_size = 4;
   optional bytes sha256_root_hash = 5;
   optional DigitallySigned signature = 6;
+  // Only supported in V2. <0..2^16-1>
+  repeated SthExtension sth_extension = 7;
 }
 
 // Stuff the SSL client spits out from a connection.


### PR DESCRIPTION
Updates serialization to provide V2 functionality. Main differences are that STHs can have extensions and that log entries for certs now have the same structure as precerts (see CertInfo draft doc). As an additional complication the older structures are retained in the proto and code to avoid breaking V1 APIs in other languages.

Mods outside serialization are just placeholders to avoid compiler issues. Adds tests for new stuff and strengthens some old ones. This is unfortunately fiddly code to work with and there is a reasonable chance that an error has crept in somewhere.