### PR TITLE
Put LogLookup in the cert_trans namespace.

### DIFF
--- a/cpp/log/log_lookup-inl.h
+++ b/cpp/log/log_lookup-inl.h
@@ -19,12 +19,14 @@
 #include "proto/serializer.h"
 #include "util/util.h"
 
+namespace cert_trans {
+
 
 static const int kCtimeBufSize = 26;
 
 
 template <class Logged>
-LogLookup<Logged>::LogLookup(cert_trans::ReadOnlyDatabase* db)
+LogLookup<Logged>::LogLookup(ReadOnlyDatabase* db)
     : db_(CHECK_NOTNULL(db)),
       cert_tree_(new Sha256Hasher),
       latest_tree_head_(),
@@ -98,8 +100,8 @@ void LogLookup<Logged>::UpdateFromSTH(const ct::SignedTreeHead& sth) {
             << " new log entries";
   latest_tree_head_.CopyFrom(sth);
 
-  const time_t last_update(static_cast<time_t>(
-      latest_tree_head_.timestamp() / cert_trans::kNumMillisPerSecond));
+  const time_t last_update(static_cast<time_t>(latest_tree_head_.timestamp() /
+                                               kNumMillisPerSecond));
   char buf[kCtimeBufSize];
   LOG(INFO) << "Tree successfully updated at " << ctime_r(&last_update, buf);
 }
@@ -221,5 +223,7 @@ int64_t LogLookup<Logged>::GetIndexInternal(
   return it->second;
 }
 
+
+}  // namespace cert_trans
 
 #endif  // CERT_TRANS_LOG_LOG_LOOKUP_INL_H_

--- a/cpp/log/log_lookup.h
+++ b/cpp/log/log_lookup.h
@@ -13,13 +13,16 @@
 #include "merkletree/merkle_tree.h"
 #include "proto/ct.pb.h"
 
+namespace cert_trans {
+
+
 // Lookups into the database. Read-only, so could also be a mirror.
 // Keeps the entire Merkle Tree in memory to serve audit proofs.
 template <class Logged>
 class LogLookup {
  public:
   // The constructor loads the content from the database.
-  explicit LogLookup(cert_trans::ReadOnlyDatabase* db);
+  explicit LogLookup(ReadOnlyDatabase* db);
   ~LogLookup();
 
   enum LookupResult {
@@ -76,12 +79,16 @@ class LogLookup {
   // a shorter prefix (possibly with a multimap).
   std::map<std::string, int64_t> leaf_index_;
 
-  cert_trans::ReadOnlyDatabase* const db_;
+  ReadOnlyDatabase* const db_;
   MerkleTree cert_tree_;
   ct::SignedTreeHead latest_tree_head_;
 
-  const cert_trans::Database::NotifySTHCallback update_from_sth_cb_;
+  const Database::NotifySTHCallback update_from_sth_cb_;
 
   DISALLOW_COPY_AND_ASSIGN(LogLookup);
 };
+
+
+}  // namespace cert_trans
+
 #endif

--- a/cpp/log/log_lookup_cert.cc
+++ b/cpp/log/log_lookup_cert.cc
@@ -1,4 +1,6 @@
 #include "log/log_lookup-inl.h"
 #include "log/logged_entry.h"
 
-template class LogLookup<cert_trans::LoggedEntry>;
+namespace cert_trans {
+template class LogLookup<LoggedEntry>;
+}

--- a/cpp/log/log_lookup_test.cc
+++ b/cpp/log/log_lookup_test.cc
@@ -32,6 +32,7 @@ using cert_trans::EntryHandle;
 using cert_trans::EtcdClient;
 using cert_trans::FakeEtcdClient;
 using cert_trans::FileDB;
+using cert_trans::LogLookup;
 using cert_trans::LoggedEntry;
 using cert_trans::MockMasterElection;
 using cert_trans::SQLiteDB;

--- a/cpp/server/ct-dns-server.cc
+++ b/cpp/server/ct-dns-server.cc
@@ -12,6 +12,7 @@
 #include "util/init.h"
 #include "util/util.h"
 
+using cert_trans::LogLookup;
 using cert_trans::LoggedEntry;
 using cert_trans::SQLiteDB;
 using ct::SignedTreeHead;

--- a/cpp/server/ct-mirror.cc
+++ b/cpp/server/ct-mirror.cc
@@ -16,7 +16,6 @@
 #include <string>
 #include <unistd.h>
 
-
 #include "config.h"
 #include "client/async_log_client.h"
 #include "fetcher/continuous_fetcher.h"
@@ -108,6 +107,7 @@ using cert_trans::Gauge;
 using cert_trans::HttpHandler;
 using cert_trans::Latency;
 using cert_trans::LevelDB;
+using cert_trans::LogLookup;
 using cert_trans::LoggedEntry;
 using cert_trans::MasterElection;
 using cert_trans::PeriodicClosure;

--- a/cpp/server/handler.h
+++ b/cpp/server/handler.h
@@ -12,8 +12,6 @@
 #include "util/task.h"
 
 class Frontend;
-template <class T>
-class LogLookup;
 
 namespace cert_trans {
 
@@ -21,6 +19,8 @@ class CertChain;
 class CertChecker;
 template <class T>
 class ClusterStateController;
+template <class T>
+class LogLookup;
 class LoggedEntry;
 class PreCertChain;
 class Proxy;


### PR DESCRIPTION
I thought it was going to save some trouble, didn't really, but now it's done, so why not?