### PR TITLE
fix GFM code blocks formatting in READMEs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,4 +19,5 @@ Nicholas Galbreath <nickg@client9.com>
 Oliver Weidner <Oliver.Weidner@gmail.com>
 Ruslan Kovalov <ruslan.kovalyov@gmail.com>
 Venafi, Inc.
+Vladimir Rutsky <vladimir@rutsky.org>
 Ximin Luo <infinity0@gmx.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -43,4 +43,5 @@ Paul Lietar <lietar@google.com>
 Pierre Phaneuf <pphaneuf@google.com>
 Rob Stradling <rob@comodo.com>
 Ruslan Kovalov <ruslan.kovalyov@gmail.com>
+Vladimir Rutsky <vladimir@rutsky.org>
 Ximin Luo <infinity0@gmx.com>

--- a/README.Fedora
+++ b/README.Fedora
@@ -16,7 +16,8 @@ different base system.
 
 Install Dependencies:
 
-```sudo dnf update
+```bash
+sudo dnf update
 sudo dnf install cmake gcc-g++ libevent-devel golang autoconf pkgconfig \
     json-c-devel gflags-devel glog-devel protobuf-devel leveldb-devel \
     openssl-devel gperftools-devel protobuf-compiler sqlite-devel ant \
@@ -31,54 +32,59 @@ Other Libraries
 The `gflags` in Fedora is v2.1 and is using the new default namespace option of
 ‘gflags’ rather than ‘google’ so we need to build our own version. 
 
-
-```git clone https://github.com/gflags/gflags.git
-    cd gflags
-    cmake -DGFLAGS_NAMESPACE:STRING=google \
-        -DCMAKE_CXX_FLAGS:STRING=-fPIC .
-    make
-    cd ..
+```bash
+git clone https://github.com/gflags/gflags.git
+cd gflags
+cmake -DGFLAGS_NAMESPACE:STRING=google \
+    -DCMAKE_CXX_FLAGS:STRING=-fPIC .
+make
+cd ..
 ```
 
 Next, we need `libevhtp` version `1.2.10` which is not packaged in Fedora, so
 we build from source:
 
-```wget https://github.com/ellzey/libevhtp/archive/1.2.10.zip
-   unzip 1.2.10.zip
-   cd libevhtp-1.2.10/
-   cmake -DEVHTP_DISABLE_REGEX:STRING=ON -DCMAKE_C_FLAGS:STRING=-fPIC .
-   make
-   cd ..
+```bash
+wget https://github.com/ellzey/libevhtp/archive/1.2.10.zip
+unzip 1.2.10.zip
+cd libevhtp-1.2.10/
+cmake -DEVHTP_DISABLE_REGEX:STRING=ON -DCMAKE_C_FLAGS:STRING=-fPIC .
+make
+cd ..
 ```
 
 And let's get our own Google Test / Google Mock as these vary in incompatible
 ways between packaged releases:
 
-```wget https://googlemock.googlecode.com/files/gmock-1.7.0.zip
-   unzip gmock-1.7.0.zip
+```bash
+wget https://googlemock.googlecode.com/files/gmock-1.7.0.zip
+unzip gmock-1.7.0.zip
 ```
 Now, clone the CT repo:
 
-```git clone https://github.com/google/certificate-transparency.git
-   cd certificate-transparency/
+```bash
+git clone https://github.com/google/certificate-transparency.git
+cd certificate-transparency/
 ```
 
 One-time setup for Go:
 
-```export GOPATH=$PWD/go
-   mkdir -p $GOPATH/src/github.com/google
-   ln -s $PWD $GOPATH/src/github.com/google
-   go get -v -d ./...
+```bash
+export GOPATH=$PWD/go
+mkdir -p $GOPATH/src/github.com/google
+ln -s $PWD $GOPATH/src/github.com/google
+go get -v -d ./...
 ```
 
 Build CT server C++ code:
 
-```./autogen.sh
-   ./configure GTEST_DIR=../gmock-1.7.0/gtest GMOCK_DIR=../gmock-1.7.0 \
-       CPPFLAGS="-I../libevhtp-1.2.10 -I../libevhtp-1.2.10/evthr \
-       -I../libevhtp-1.2.10/htparse -I../gflags/include" \
-        LDFLAGS=”-L../libevhtp-1.2.10 -L../gflags/lib”
-   make check 
+```bash
+./autogen.sh
+./configure GTEST_DIR=../gmock-1.7.0/gtest GMOCK_DIR=../gmock-1.7.0 \
+    CPPFLAGS="-I../libevhtp-1.2.10 -I../libevhtp-1.2.10/evthr \
+    -I../libevhtp-1.2.10/htparse -I../gflags/include" \
+    LDFLAGS=”-L../libevhtp-1.2.10 -L../gflags/lib”
+make check 
 ```
 
 The remainder of the Java, Go and Python steps should be very similar to those

--- a/README.md
+++ b/README.md
@@ -60,12 +60,14 @@ gclient config --name="certificate-transparency" https://github.com/google/certi
 When you issue the `gclient sync` command you may need to set compiler options
 in order to build successfully. If the build fails to work try using:
 
-```CXXFLAGS="-O2 -Wno-error=unused-variable" gclient sync
+```bash
+CXXFLAGS="-O2 -Wno-error=unused-variable" gclient sync
 ```
 
 If this gives an error about an unused typedef in a `glog` header file try this:
 
-```CXXFLAGS="-O2 -Wno-error=unused-variable -Wno-error=unused-local-typedefs" gclient sync
+```bash
+CXXFLAGS="-O2 -Wno-error=unused-variable -Wno-error=unused-local-typedefs" gclient sync
 ```
 
 When changing `CXXFLAGS` it's safer to remove the existing build directories


### PR DESCRIPTION
According to GitHub Flavored Markdown [documentation](https://help.github.com/articles/github-flavored-markdown/#fenced-code-blocks).