### PR TITLE
Fix up a couple of test flakes

### DIFF
--- a/cpp/log/cluster_state_controller_test.cc
+++ b/cpp/log/cluster_state_controller_test.cc
@@ -379,7 +379,7 @@ TEST_F(ClusterStateControllerTest, TestUsesLargestSTHWithIdenticalTimestamp) {
   cns3.mutable_newest_sth()->set_timestamp(1004);
   cns3.mutable_newest_sth()->set_tree_size(999);
   store3_->SetClusterNodeState(cns3);
-  sleep(1);
+  sleep(2);
 
   util::StatusOr<SignedTreeHead> sth(controller50.GetCalculatedServingSTH());
   EXPECT_EQ(cns2.newest_sth().tree_size(), sth.ValueOrDie().tree_size());


### PR DESCRIPTION
There are a bunch of `sleep()` sync things which are brittle, but it's pretty complicated to hang off of any event which guarantees that the prior stuff has completed.