### PR TITLE
Untangle the server / handler registration a bit.

### DIFF
--- a/cpp/server/ct-mirror.cc
+++ b/cpp/server/ct-mirror.cc
@@ -390,7 +390,9 @@ int main(int argc, char* argv[]) {
                                  nullptr /* checker */, nullptr /* Frontend */,
                                  &internal_pool, event_base.get());
 
-  server.RegisterHandler(&handler);
+  // Connect the handler, proxy and server together
+  handler.SetProxy(server.proxy());
+  handler.Add(server.http_server());
 
   if (stand_alone_mode) {
     // Set up a simple single-node mirror environment for testing.

--- a/cpp/server/ct-server.cc
+++ b/cpp/server/ct-server.cc
@@ -412,7 +412,9 @@ int main(int argc, char* argv[]) {
                                  server.cluster_state_controller(), &checker,
                                  &frontend, &internal_pool, event_base.get());
 
-  server.RegisterHandler(&handler);
+  // Connect the handler, proxy and server together
+  handler.SetProxy(server.proxy());
+  handler.Add(server.http_server());
 
   TreeSigner<LoggedEntry> tree_signer(
       std::chrono::duration<double>(FLAGS_guard_window_seconds), db,

--- a/cpp/server/server.cc
+++ b/cpp/server/server.cc
@@ -14,7 +14,6 @@
 #include "log/cluster_state_controller.h"
 #include "log/etcd_consistent_store.h"
 #include "monitoring/monitoring.h"
-#include "server/handler.h"
 #include "util/thread_pool.h"
 #include "util/uuid.h"
 
@@ -154,14 +153,6 @@ Server::~Server() {
 }
 
 
-void Server::RegisterHandler(HttpHandler* handler) {
-  CHECK_NOTNULL(handler);
-  // Configure the handler to use our JSON output and proxy instances:
-  handler->SetProxy(proxy_.get());
-  handler->Add(&http_server_);
-}
-
-
 bool Server::IsMaster() const {
   return election_.IsMaster();
 }
@@ -189,6 +180,16 @@ LogLookup* Server::log_lookup() {
 
 ContinuousFetcher* Server::continuous_fetcher() {
   return fetcher_.get();
+}
+
+
+Proxy* Server::proxy() {
+  return proxy_.get();
+}
+
+
+libevent::HttpServer* Server::http_server() {
+  return &http_server_;
 }
 
 

--- a/cpp/server/server.h
+++ b/cpp/server/server.h
@@ -27,7 +27,6 @@ class ContinuousFetcher;
 class Database;
 class EtcdClient;
 class GCMExporter;
-class HttpHandler;
 class LogLookup;
 class LogSigner;
 class LoggedEntry;
@@ -63,14 +62,14 @@ class Server {
          const LogVerifier* log_verifier);
   ~Server();
 
-  void RegisterHandler(HttpHandler* handler);
-
   bool IsMaster() const;
   MasterElection* election();
   ConsistentStore<LoggedEntry>* consistent_store();
   ClusterStateController<LoggedEntry>* cluster_state_controller();
   LogLookup* log_lookup();
   ContinuousFetcher* continuous_fetcher();
+  Proxy* proxy();
+  libevent::HttpServer* http_server();
 
   void Initialise(bool is_mirror);
   void WaitForReplication() const;

--- a/cpp/server/xjson-server.cc
+++ b/cpp/server/xjson-server.cc
@@ -339,7 +339,9 @@ int main(int argc, char* argv[]) {
                            server.cluster_state_controller(), &frontend,
                            &internal_pool, event_base.get());
 
-  server.RegisterHandler(&handler);
+  // Connect the handler, proxy and server together
+  handler.SetProxy(server.proxy());
+  handler.Add(server.http_server());
 
   TreeSigner<LoggedEntry> tree_signer(
       std::chrono::duration<double>(FLAGS_guard_window_seconds), &db,


### PR DESCRIPTION
Remove RegisterHandler and have the servers do the same thing with one
less layer of indirection. Server no longer refers to HttpHandler purely
for this.