### PR TITLE
Refactoring to pull out code + flags that creates a database

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -215,8 +215,9 @@ cpp_server_ct_mirror_SOURCES = \
   cpp/client/async_log_client.cc \
 	cpp/server/ct-mirror.cc \
 	cpp/server/certificate_handler.cc \
+	cpp/server/handler.cc \
 	cpp/server/json_output.cc \
-	cpp/server/handler.cc
+	cpp/server/server_helper.cc
 
 cpp_server_ct_server_LDADD = \
 	cpp/libcore.a \
@@ -228,8 +229,9 @@ cpp_server_ct_server_SOURCES = \
   cpp/client/async_log_client.cc \
 	cpp/server/ct-server.cc \
 	cpp/server/certificate_handler.cc \
+	cpp/server/handler.cc \
 	cpp/server/json_output.cc \
-	cpp/server/handler.cc
+	cpp/server/server_helper.cc
 
 cpp_server_xjson_server_LDADD = \
 	cpp/libcore.a \
@@ -241,6 +243,7 @@ cpp_server_xjson_server_SOURCES = \
   cpp/client/async_log_client.cc \
 	cpp/server/handler.cc \
 	cpp/server/json_output.cc \
+	cpp/server/server_helper.cc \
 	cpp/server/xjson-server.cc \
 	cpp/server/x_json_handler.cc \
 	cpp/util/json_wrapper.cc

--- a/cpp/server/ct-server.cc
+++ b/cpp/server/ct-server.cc
@@ -32,6 +32,7 @@
 #include "server/certificate_handler.h"
 #include "server/metrics.h"
 #include "server/server.h"
+#include "server/server_helper.h"
 #include "util/etcd.h"
 #include "util/fake_etcd.h"
 #include "util/init.h"
@@ -46,21 +47,6 @@ DEFINE_int32(port, 9999, "Server port");
 DEFINE_string(key, "", "PEM-encoded server private key file");
 DEFINE_string(trusted_cert_file, "",
               "File for trusted CA certificates, in concatenated PEM format");
-// TODO(alcutter): Just specify a root dir with a single flag.
-DEFINE_string(cert_dir, "", "Storage directory for certificates");
-DEFINE_string(tree_dir, "", "Storage directory for trees");
-DEFINE_string(meta_dir, "", "Storage directory for meta info");
-DEFINE_string(sqlite_db, "",
-              "SQLite database for certificate and tree storage");
-DEFINE_string(leveldb_db, "",
-              "LevelDB database for certificate and tree storage");
-// TODO(ekasper): sanity-check these against the directory structure.
-DEFINE_int32(cert_storage_depth, 0,
-             "Subdirectory depth for certificates; if the directory is not "
-             "empty, must match the existing depth.");
-DEFINE_int32(tree_storage_depth, 0,
-             "Subdirectory depth for tree signatures; if the directory is not "
-             "empty, must match the existing depth");
 DEFINE_int32(log_stats_frequency_seconds, 3600,
              "Interval for logging summary statistics. Approximate: the "
              "server will log statistics if in the beginning of its select "
@@ -111,6 +97,7 @@ using cert_trans::ReadPrivateKey;
 using cert_trans::SQLiteDB;
 using cert_trans::ScopedLatency;
 using cert_trans::Server;
+using cert_trans::ServerHelper;
 using cert_trans::SplitHosts;
 using cert_trans::ThreadPool;
 using cert_trans::TreeSigner;
@@ -180,33 +167,6 @@ static const bool key_dummy = RegisterFlagValidator(&FLAGS_key, &ValidateRead);
 
 static const bool cert_dummy =
     RegisterFlagValidator(&FLAGS_trusted_cert_file, &ValidateRead);
-
-static bool ValidateWrite(const char* flagname, const string& path) {
-  if (path != "" && access(path.c_str(), W_OK) != 0) {
-    std::cout << "Cannot modify " << flagname << " at " << path << std::endl;
-    return false;
-  }
-  return true;
-}
-
-static const bool cert_dir_dummy =
-    RegisterFlagValidator(&FLAGS_cert_dir, &ValidateWrite);
-
-static const bool tree_dir_dummy =
-    RegisterFlagValidator(&FLAGS_tree_dir, &ValidateWrite);
-
-static bool ValidateIsNonNegative(const char* flagname, int value) {
-  if (value < 0) {
-    std::cout << flagname << " must not be negative" << std::endl;
-    return false;
-  }
-  return true;
-}
-
-static const bool c_st_dummy =
-    RegisterFlagValidator(&FLAGS_cert_storage_depth, &ValidateIsNonNegative);
-static const bool t_st_dummy =
-    RegisterFlagValidator(&FLAGS_tree_storage_depth, &ValidateIsNonNegative);
 
 static bool ValidateIsPositive(const char* flagname, int value) {
   if (value <= 0) {
@@ -350,29 +310,9 @@ int main(int argc, char* argv[]) {
   CHECK(checker.LoadTrustedCertificates(FLAGS_trusted_cert_file))
       << "Could not load CA certs from " << FLAGS_trusted_cert_file;
 
-  if (!FLAGS_sqlite_db.empty() + !FLAGS_leveldb_db.empty() +
-          (!FLAGS_cert_dir.empty() | !FLAGS_tree_dir.empty()) !=
-      1) {
-    std::cerr << "Must only specify one database type.";
-    exit(1);
-  }
-
-  if (FLAGS_sqlite_db.empty() && FLAGS_leveldb_db.empty()) {
-    CHECK_NE(FLAGS_cert_dir, FLAGS_tree_dir)
-        << "Certificate directory and tree directory must differ";
-  }
-
-  Database* db;
-
-  if (!FLAGS_sqlite_db.empty()) {
-    db = new SQLiteDB(FLAGS_sqlite_db);
-  } else if (!FLAGS_leveldb_db.empty()) {
-    db = new LevelDB(FLAGS_leveldb_db);
-  } else {
-    db = new FileDB(new FileStorage(FLAGS_cert_dir, FLAGS_cert_storage_depth),
-                    new FileStorage(FLAGS_tree_dir, FLAGS_tree_storage_depth),
-                    new FileStorage(FLAGS_meta_dir, 0));
-  }
+  ServerHelper::EnsureValidatorsRegistered();
+  Database* db = ServerHelper::ProvideDatabase();
+  CHECK(db != nullptr) << "No database instance created, check flag settings";
 
   shared_ptr<libevent::Base> event_base(make_shared<libevent::Base>());
   ThreadPool internal_pool(8);

--- a/cpp/server/server_helper.cc
+++ b/cpp/server/server_helper.cc
@@ -1,0 +1,87 @@
+#include "log/strict_consistent_store.h"
+#include "server/server.h"
+#include "server/server_helper.h"
+
+using cert_trans::Server;
+using google::RegisterFlagValidator;
+using std::make_shared;
+using std::shared_ptr;
+using std::string;
+
+// TODO(alcutter): Just specify a root dir with a single flag.
+DEFINE_string(cert_dir, "", "Storage directory for certificates");
+DEFINE_string(tree_dir, "", "Storage directory for trees");
+DEFINE_string(meta_dir, "", "Storage directory for meta info");
+DEFINE_string(sqlite_db, "",
+              "SQLite database for certificate and tree storage");
+DEFINE_string(leveldb_db, "",
+              "LevelDB database for certificate and tree storage");
+// TODO(ekasper): sanity-check these against the directory structure.
+DEFINE_int32(cert_storage_depth, 0,
+             "Subdirectory depth for certificates; if the directory is not "
+             "empty, must match the existing depth.");
+DEFINE_int32(tree_storage_depth, 0,
+             "Subdirectory depth for tree signatures; if the directory is not "
+             "empty, must match the existing depth");
+
+static bool ValidateWrite(const char* flagname, const string& path) {
+  if (path != "" && access(path.c_str(), W_OK) != 0) {
+    std::cout << "Cannot modify " << flagname << " at " << path << std::endl;
+    return false;
+  }
+  return true;
+}
+
+static bool ValidateIsNonNegative(const char* flagname, int value) {
+  if (value < 0) {
+    std::cout << flagname << " must not be negative" << std::endl;
+    return false;
+  }
+  return true;
+}
+
+static const bool cert_dir_dummy =
+    RegisterFlagValidator(&FLAGS_cert_dir, &ValidateWrite);
+
+static const bool tree_dir_dummy =
+    RegisterFlagValidator(&FLAGS_tree_dir, &ValidateWrite);
+
+static const bool c_st_dummy =
+    RegisterFlagValidator(&FLAGS_cert_storage_depth, &ValidateIsNonNegative);
+static const bool t_st_dummy =
+    RegisterFlagValidator(&FLAGS_tree_storage_depth, &ValidateIsNonNegative);
+
+namespace cert_trans {
+
+// static
+void ServerHelper::EnsureValidatorsRegistered() {
+  CHECK(cert_dir_dummy && tree_dir_dummy && c_st_dummy && t_st_dummy);
+}
+
+Database* ServerHelper::ProvideDatabase() {
+  if (!FLAGS_sqlite_db.empty() + !FLAGS_leveldb_db.empty() +
+          (!FLAGS_cert_dir.empty() | !FLAGS_tree_dir.empty()) !=
+      1) {
+    std::cerr << "Must only specify one database type.";
+    exit(1);
+  }
+
+  if (FLAGS_sqlite_db.empty() && FLAGS_leveldb_db.empty()) {
+    CHECK_NE(FLAGS_cert_dir, FLAGS_tree_dir)
+        << "Certificate directory and tree directory must differ";
+  }
+
+  if (!FLAGS_sqlite_db.empty()) {
+    return new SQLiteDB(FLAGS_sqlite_db);
+  } else if (!FLAGS_leveldb_db.empty()) {
+    return new LevelDB(FLAGS_leveldb_db);
+  } else {
+    return new FileDB(new FileStorage(FLAGS_cert_dir, FLAGS_cert_storage_depth),
+                      new FileStorage(FLAGS_tree_dir, FLAGS_tree_storage_depth),
+                      new FileStorage(FLAGS_meta_dir, 0));
+  }
+
+  LOG(FATAL) << "No usable database is configured by flags";
+}
+
+}  // namespace cert_trans

--- a/cpp/server/server_helper.h
+++ b/cpp/server/server_helper.h
@@ -13,54 +13,28 @@
 
 #include "base/macros.h"
 #include "log/database.h"
-#include "log/etcd_consistent_store.h"
 #include "log/file_db.h"
 #include "log/file_storage.h"
 #include "log/leveldb_db.h"
-#include "log/log_signer.h"
-#include "log/log_verifier.h"
 #include "log/sqlite_db.h"
-#include "log/strict_consistent_store.h"
-#include "log/tree_signer.h"
-#include "monitoring/gcm/exporter.h"
-#include "monitoring/latency.h"
-#include "monitoring/monitoring.h"
-#include "monitoring/registry.h"
-#include "server/metrics.h"
-#include "util/fake_etcd.h"
-#include "util/etcd.h"
-#include "util/task.h"
-#include "util/thread_pool.h"
-#include "server/server.h"
 
 namespace cert_trans {
 
-// This class includes code common to multiple CT servers. It handles parsing
+// This includes code common to multiple CT servers. It handles parsing
 // flags and creating objects that are used by multiple servers. Anything that
 // is specific one type of CT server should not be in this class.
 //
-// Do not link this class into servers that don't use it as it will confuse
+// Do not link server_helper into servers that don't use it as it will confuse
 // the user with extra flags.
 //
 // Note methods named ProvideX create a new instance of X each call.
-// This class does not own any resources.
 
-class ServerHelper {
- public:
-  // Utility class, not for instantiation
-  ServerHelper() = delete;
-  ~ServerHelper() = delete;
+// Calling this will CHECK if the flag validators failed to register
+void EnsureValidatorsRegistered();
 
-  // Calling this will CHECK if the flag validators failed to register
-  static void EnsureValidatorsRegistered();
+// Create one of the supported database types based on flags settings
+std::unique_ptr<Database> ProvideDatabase();
 
-  // Create one of the supported database types based on flags settings
-  static Database* ProvideDatabase();
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(ServerHelper)
-  ;
-};
 }  // namespace cert_trans
 
 #endif  // CERT_TRANS_SERVER_SERVER_HELPER_H_

--- a/cpp/server/server_helper.h
+++ b/cpp/server/server_helper.h
@@ -1,0 +1,66 @@
+#ifndef CERT_TRANS_SERVER_SERVER_HELPER_H_
+#define CERT_TRANS_SERVER_SERVER_HELPER_H_
+
+#include <chrono>
+#include <csignal>
+#include <cstring>
+#include <functional>
+#include <gflags/gflags.h>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <openssl/crypto.h>
+
+#include "base/macros.h"
+#include "log/database.h"
+#include "log/etcd_consistent_store.h"
+#include "log/file_db.h"
+#include "log/file_storage.h"
+#include "log/leveldb_db.h"
+#include "log/log_signer.h"
+#include "log/log_verifier.h"
+#include "log/sqlite_db.h"
+#include "log/strict_consistent_store.h"
+#include "log/tree_signer.h"
+#include "monitoring/gcm/exporter.h"
+#include "monitoring/latency.h"
+#include "monitoring/monitoring.h"
+#include "monitoring/registry.h"
+#include "server/metrics.h"
+#include "util/fake_etcd.h"
+#include "util/etcd.h"
+#include "util/task.h"
+#include "util/thread_pool.h"
+#include "server/server.h"
+
+namespace cert_trans {
+
+// This class includes code common to multiple CT servers. It handles parsing
+// flags and creating objects that are used by multiple servers. Anything that
+// is specific one type of CT server should not be in this class.
+//
+// Do not link this class into servers that don't use it as it will confuse
+// the user with extra flags.
+//
+// Note methods named ProvideX create a new instance of X each call.
+// This class does not own any resources.
+
+class ServerHelper {
+ public:
+  // Utility class, not for instantiation
+  ServerHelper() = delete;
+  ~ServerHelper() = delete;
+
+  // Calling this will CHECK if the flag validators failed to register
+  static void EnsureValidatorsRegistered();
+
+  // Create one of the supported database types based on flags settings
+  static Database* ProvideDatabase();
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(ServerHelper)
+  ;
+};
+}  // namespace cert_trans
+
+#endif  // CERT_TRANS_SERVER_SERVER_HELPER_H_

--- a/cpp/server/xjson-server.cc
+++ b/cpp/server/xjson-server.cc
@@ -14,15 +14,11 @@
 #include "log/cert_submission_handler.h"
 #include "log/cluster_state_controller.h"
 #include "log/etcd_consistent_store.h"
-#include "log/file_db.h"
-#include "log/file_storage.h"
 #include "log/frontend.h"
 #include "log/frontend_signer.h"
-#include "log/leveldb_db.h"
 #include "log/log_lookup.h"
 #include "log/log_signer.h"
 #include "log/log_verifier.h"
-#include "log/sqlite_db.h"
 #include "log/strict_consistent_store.h"
 #include "log/tree_signer.h"
 #include "merkletree/merkle_verifier.h"
@@ -90,7 +86,6 @@ using cert_trans::LoggedEntry;
 using cert_trans::ReadPrivateKey;
 using cert_trans::ScopedLatency;
 using cert_trans::Server;
-using cert_trans::ServerHelper;
 using cert_trans::SplitHosts;
 using cert_trans::ThreadPool;
 using cert_trans::TreeSigner;
@@ -297,8 +292,9 @@ int main(int argc, char* argv[]) {
   CHECK_EQ(pkey.status(), util::Status::OK);
   LogSigner log_signer(pkey.ValueOrDie());
 
-  ServerHelper::EnsureValidatorsRegistered();
-  Database* db = ServerHelper::ProvideDatabase();
+  cert_trans::EnsureValidatorsRegistered();
+  const unique_ptr<Database> db(cert_trans::ProvideDatabase());
+  CHECK(db) << "No database instance created, check flag settings";
 
   shared_ptr<libevent::Base> event_base(make_shared<libevent::Base>());
   ThreadPool internal_pool(8);
@@ -327,13 +323,13 @@ int main(int argc, char* argv[]) {
 
   ThreadPool http_pool(FLAGS_num_http_server_threads);
 
-  Server server(options, event_base, &internal_pool, &http_pool, db,
+  Server server(options, event_base, &internal_pool, &http_pool, db.get(),
                 etcd_client.get(), &url_fetcher, &log_verifier);
   server.Initialise(false /* is_mirror */);
 
   Frontend frontend(
-      new FrontendSigner(db, server.consistent_store(), &log_signer));
-  XJsonHttpHandler handler(server.log_lookup(), db,
+      new FrontendSigner(db.get(), server.consistent_store(), &log_signer));
+  XJsonHttpHandler handler(server.log_lookup(), db.get(),
                            server.cluster_state_controller(), &frontend,
                            &internal_pool, event_base.get());
 
@@ -342,7 +338,7 @@ int main(int argc, char* argv[]) {
   handler.Add(server.http_server());
 
   TreeSigner<LoggedEntry> tree_signer(
-      std::chrono::duration<double>(FLAGS_guard_window_seconds), db,
+      std::chrono::duration<double>(FLAGS_guard_window_seconds), db.get(),
       server.log_lookup()->GetCompactMerkleTree(new Sha256Hasher),
       server.consistent_store(), &log_signer);
 


### PR DESCRIPTION
I'm expecting to pull more of the flag interactions code into the helper class in future PRs. I know the name server_helper isn't great but naming things is hard!