### PR TITLE
Add a .clang-format file.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+BasedOnStyle: Google
+MaxEmptyLinesToKeep: 2
+ColumnLimit: 79
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+PenaltyBreakBeforeFirstCallParameter: 80


### PR DESCRIPTION
It'd be easiest to have this file here, so that people can just use `--style=file`. Any discussions of what would be the "best formatting" can be done as PRs on that file. :stuck_out_tongue: 