### PR TITLE
Add a simple first cut of a SparseMerkleTree.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -87,6 +87,7 @@ TESTS = \
 	cpp/merkletree/merkle_tree_large_test \
 	cpp/merkletree/merkle_tree_test \
 	cpp/merkletree/serial_hasher_test \
+	cpp/merkletree/sparse_merkle_tree_test \
 	cpp/merkletree/tree_hasher_test \
 	cpp/monitor/database_test \
 	cpp/monitoring/counter_test \
@@ -160,6 +161,7 @@ cpp_libcore_a_SOURCES = \
 	cpp/merkletree/merkle_tree_math.cc \
 	cpp/merkletree/merkle_verifier.cc \
 	cpp/merkletree/serial_hasher.cc \
+	cpp/merkletree/sparse_merkle_tree.cc \
 	cpp/merkletree/tree_hasher.cc \
 	cpp/monitoring/gcm/exporter.cc \
 	cpp/monitoring/monitoring.cc \
@@ -754,6 +756,14 @@ cpp_merkletree_serial_hasher_test_LDADD = \
 cpp_merkletree_serial_hasher_test_SOURCES = \
 	cpp/util/util.cc \
 	cpp/merkletree/serial_hasher_test.cc
+
+cpp_merkletree_sparse_merkle_tree_test_LDADD = \
+	cpp/libcore.a \
+	cpp/libtest.a \
+	$(libevent_LIBS)
+cpp_merkletree_sparse_merkle_tree_test_SOURCES = \
+	cpp/util/util.cc \
+	cpp/merkletree/sparse_merkle_tree_test.cc
 
 cpp_merkletree_tree_hasher_test_LDADD = \
 	cpp/libcore.a \

--- a/cpp/merkletree/sparse_merkle_tree.cc
+++ b/cpp/merkletree/sparse_merkle_tree.cc
@@ -1,0 +1,217 @@
+#include "cpp/merkletree/sparse_merkle_tree.h"
+
+#include <stddef.h>
+#include <algorithm>
+#include <vector>
+
+#include "merkletree/merkle_tree_math.h"
+#include "util/util.h"
+
+using std::make_pair;
+using std::ostream;
+using std::ostringstream;
+using std::reverse;
+using std::string;
+using std::unique_ptr;
+using std::unordered_map;
+using std::vector;
+
+
+const vector<string>* GetNullHashes(const TreeHasher& hasher) {
+  static unique_ptr<const vector<string>> null_hashes;
+  if (!null_hashes) {
+    vector<string> r{hasher.HashLeaf("")};
+    for (int i(1); i < hasher.DigestSize() * 8; ++i) {
+      r.emplace_back(hasher.HashChildren(r.back(), r.back()));
+    }
+    reverse(r.begin(), r.end());
+    null_hashes.reset(new vector<string>(std::move(r)));
+  }
+  return null_hashes.get();
+}
+
+
+SparseMerkleTree::SparseMerkleTree(SerialHasher* hasher)
+    : serial_hasher_(CHECK_NOTNULL(hasher)->Create()),
+      treehasher_(hasher),
+      null_hashes_(GetNullHashes(treehasher_)) {
+}
+
+
+void SparseMerkleTree::EnsureHaveLevel(size_t level) {
+  if (tree_.size() < (level + 1)) {
+    tree_.resize(level + 1);
+  }
+}
+
+
+void SparseMerkleTree::SetLeafByHash(const string& key, const string& data) {
+  serial_hasher_->Reset();
+  serial_hasher_->Update(key);
+  return SetLeaf(PathFromBytes(serial_hasher_->Final()), data);
+}
+
+
+void SparseMerkleTree::SetLeaf(const Path& path, const string& data) {
+  CHECK_EQ(treehasher_.DigestSize(), path.size());
+  // Mark the tree dirty:
+  root_hash_.clear();
+
+  IndexType node_index(0);
+  for (int depth(0); depth <= kDigestSizeBits; ++depth) {
+    node_index += PathBit(path, depth);
+    EnsureHaveLevel(depth);
+    auto it(tree_[depth].find(node_index));
+    if (it == tree_[depth].end()) {
+      CHECK(tree_[depth]
+                .emplace(make_pair(node_index, TreeNode(path, data)))
+                .second);
+      return;
+    } else if (it->second.type_ == TreeNode::INTERNAL) {
+      // Mark the internal node hash dirty
+      it->second.hash_.reset();
+    } else if (it->second.leaf_->path_ == path) {
+      // replacement
+      CHECK_EQ(TreeNode::LEAF, it->second.type_);
+      it->second.leaf_->value_ = data;
+      return;
+    } else {
+      // restructure: push the existing node down a level and replace this one
+      // with an INTERNAL node
+      CHECK_LT(depth, kDigestSizeBits);
+      EnsureHaveLevel(depth + 1);
+      IndexType child_index((node_index << 1) +
+                            PathBit(it->second.leaf_->path_, depth + 1));
+      CHECK(tree_[depth + 1]
+                .emplace(make_pair(child_index, std::move(it->second)))
+                .second);
+      it->second.type_ = TreeNode::INTERNAL;
+      it->second.leaf_.reset();
+    }
+    node_index <<= 1;
+  }
+  LOG(FATAL) << "Failed to set " << path << " to " << data;
+}
+
+
+void SparseMerkleTree::DumpTree(ostream* os, size_t depth,
+                                IndexType index) const {
+  if (tree_.size() <= depth) {
+    return;
+  }
+  const string indent((depth + 1) * 2, '-');
+  for (int side(0); side < 2; ++side) {
+    auto child(tree_[depth].find(index + side));
+    if (child != tree_[depth].end()) {
+      *os << indent << side << ": " << child->second.DebugString() << "\n";
+      DumpTree(os, depth + 1, (index + side) << 1);
+    }
+  }
+}
+
+
+string SparseMerkleTree::Dump() const {
+  ostringstream ret;
+  ret << "\nTree [Root: " << util::ToBase64(root_hash_) << "]:\n";
+  if (!tree_.empty()) {
+    DumpTree(&ret, 0, 0);
+  }
+  return ret.str();
+}
+
+
+string SparseMerkleTree::CalculateSubtreeHash(size_t depth, IndexType index) {
+  if (tree_.size() <= depth) {
+    return null_hashes_->at(depth);
+  }
+
+  auto it(tree_[depth].find(index));
+  if (it != tree_[depth].end()) {
+    switch (it->second.type_) {
+      case TreeNode::INTERNAL: {
+        if (it->second.hash_) {
+          return *(it->second.hash_);
+        }
+        IndexType left_child_index(index << 1);
+        const string left(CalculateSubtreeHash(depth + 1, left_child_index));
+        const string right(
+            CalculateSubtreeHash(depth + 1, left_child_index + 1));
+        it->second.hash_.reset(
+            new string(treehasher_.HashChildren(left, right)));
+        return *(it->second.hash_);
+      }
+
+      case TreeNode::LEAF: {
+        string ret(treehasher_.HashLeaf(it->second.leaf_->value_));
+        for (int i(kDigestSizeBits - 1); i > depth; --i) {
+          if (PathBit(it->second.leaf_->path_, i) == 0) {
+            ret = treehasher_.HashChildren(ret, null_hashes_->at(i));
+          } else {
+            ret = treehasher_.HashChildren(null_hashes_->at(i), ret);
+          }
+        }
+        // TODO(alcutter): maybe cache this?
+        return ret;
+      }
+    }
+    LOG(FATAL) << "Unknown node type " << it->second.type_ << " !";
+  }
+
+  return null_hashes_->at(depth);
+}
+
+
+string SparseMerkleTree::CurrentRoot() {
+  if (root_hash_.empty()) {
+    root_hash_ = treehasher_.HashChildren(CalculateSubtreeHash(0, 0),
+                                          CalculateSubtreeHash(0, 1));
+  }
+  return root_hash_;
+}
+
+
+std::vector<string> SparseMerkleTree::InclusionProof(const Path& path) {
+  // TODO(alcutter): implement
+  LOG(FATAL) << "Not implemented.";
+}
+
+
+string SparseMerkleTree::TreeNode::DebugString() const {
+  ostringstream os;
+  os << "[TreeNode ";
+  switch (type_) {
+    case INTERNAL:
+      os << "INTL hash: ";
+      if (hash_) {
+        os << util::ToBase64(*hash_);
+      } else {
+        os << "(unset)";
+      }
+      break;
+    case LEAF:
+      os << "LEAF leaf: ";
+      os << leaf_->DebugString();
+      break;
+  }
+  os << "]";
+  return os.str();
+}
+
+
+string SparseMerkleTree::Leaf::DebugString() const {
+  ostringstream os;
+  os << "[Leaf path: " << path_ << " value: " << value_ << "]";
+  return os.str();
+}
+
+
+ostream& operator<<(ostream& out, const SparseMerkleTree::Path& path) {
+  for (size_t i(0); i < path.size(); ++i) {
+    uint8_t t(path[i]);
+    for (size_t b(8); b > 0; --b) {
+      out << (t & 0x80 ? '1' : '0');
+      t <<= 1;
+    }
+  }
+  return out;
+}

--- a/cpp/merkletree/sparse_merkle_tree.h
+++ b/cpp/merkletree/sparse_merkle_tree.h
@@ -1,0 +1,263 @@
+#ifndef CERT_TRANS_MERKLETREE_SPARSE_MERKLE_TREE_H
+#define CERT_TRANS_MERKLETREE_SPARSE_MERKLE_TREE_H
+
+#include <glog/logging.h>
+#include <stddef.h>
+#include <array>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "merkletree/merkle_tree_interface.h"
+#include "merkletree/tree_hasher.h"
+
+class SerialHasher;
+
+
+// Calculates the set of "null" hashes:
+// ...H(H(H("")||H(""))||H("")||(H(""))||...)...
+//
+// Visible out here because it's useful for testing too.
+const std::vector<std::string>* GetNullHashes(const TreeHasher& hasher);
+
+// Implementation of a Sparse Merkle Tree.
+//
+// The design is inspired by the tree described in
+// http://www.links.org/files/RevocationTransparency.pdf), but with some
+// tweaks, most notably:
+//   1) Leaf values are hashed before being incorporated into the tree.
+//   2) Similar to the way it works in the CT MerkleTree, hashes are domain
+//      separated by prefixing the preimage with \x00 for leaves, and \x01 for
+//      internal nodes.
+//
+//
+// These mean that level 2 nodes are of the form:
+//      H(\x01||H(\0x00||valueL)||H(\0x00||valueR))
+// and so on.
+//
+// Nodes are addressed by a Path, which is a bit-string of the same length as
+// the output of the hashing fuction used.  This string describes a path down
+// from the root to a leaf, with the 0-bits indicating the path takes the
+// left-hand child branch, and 1-bits the right. e.g:
+//        Root
+//        /  \
+//      0/    \1
+//      /      \
+//     i0      i3
+//   0/ \1   0/  \1
+//   /   \   /    \
+//  l0  l1  l2    l3
+//
+//  The paths to the 4 leaves would then be:
+//  l0: "00"
+//  l1: "01"
+//  l2: "10"
+//  l3: "11"
+//
+// To help with memory consumption, leaves inserted into the tree are stored
+// at the first unused node along their path.  An example is given below:
+//
+// * Empty tree:
+//      Root
+//
+// * Add "10" = "hi":
+// Since the tree is empty, the first bit of the added path is sufficient to
+// identify a unique prefix, so the leaf is stored as the "1" entry
+// immediately below the root.
+//              Root
+//                |
+//                |_______1
+//                       p:"10"
+//                       v:"hi"
+//
+// * Add "11" = "to":
+// The first bit of the added path is not enough to provide a unique
+// prefix so the leaf node currently occupying the "1" node immediately below
+// the root must be pushed down a level, resulting in:
+//              Root
+//                |
+//                |_______1
+//                        |
+//                        |
+//                  0_____|_____1
+//                  |           |
+//                p:"10"      p:"11"
+//                v:"hi"      v:"to"
+//
+// (In the case where paths are longer and multiple bits of the prefix collide,
+// the existing node is repeated pushed down a level until a unique prefix is
+// found.)
+//
+// * Add "00" = "aa":
+// The first bit of the added path is unique, and so the resulting tree is:
+//              Root
+//                |
+//        0_______|_______1
+//        |               |
+//      p:"00"            |
+//      v:"aa"      0_____|_____1
+//                  |           |
+//                p:"10"      p:"11"
+//                v:"hi"      v:"to"
+//
+// * Calculating the root hash
+// Calculating the root of the tree is similar to a regular MerkleTree, but is
+// optimised by cribbing the value of "missing" nodes from a simple cache. This
+// removes the need to calculate the vast majority of nodes from scratch.
+//
+// TODO(alcutter): LOTS!
+//
+// This class is thread-compatible, but not thread-safe.
+class SparseMerkleTree {
+ public:
+  static const int kDigestSizeBits = 256;
+
+  // Represents a path into the SparseMerkleTree.
+  // The MSB of the 0th entry in the path specifies the path from the root node
+  // of the tree, and so on until the LSB in the final byte specifies the leaf
+  // itself.
+  //
+  // i.e:
+  //   0th        1st     ...
+  // [76543210|76543210|76...|...|...0]
+  //  ||                             |_____LSB of path, identifies leaf at
+  //  lowest level in the tree
+  //  ||___________________________________Identifies 2nd level child node
+  //  |____________________________________Identifies 1st level child node
+  //
+  //  The reasoning behind this convention is that looked as a single
+  //  kDigestSizeBits sized word, the value of the path is then the same as
+  //  the index of the leaf node it identifies, this also has the advantage
+  //  that the paths are lexographically sortable.
+  typedef std::array<uint8_t, kDigestSizeBits / 8> Path;
+
+  // The constructor takes a pointer to some concrete hash function
+  // instantiation of the SerialHasher abstract class.
+  // Takes ownership of the hasher.
+  explicit SparseMerkleTree(SerialHasher* hasher);
+
+  // Length of a node (i.e., a hash), in bytes.
+  virtual size_t NodeSize() const {
+    return treehasher_.DigestSize();
+  };
+
+  // Return the leaf hash, but do not append the data to the tree.
+  virtual std::string LeafHash(const std::string& data) const {
+    return treehasher_.HashLeaf(data);
+  }
+
+  // Add a new leaf to the hash tree. Stores the hash of the leaf data in the
+  // tree structure at path |Hash(key)|, does not store the data itself.
+  //
+  // @param data Binary input blob
+  // @param path Binary path of node to set.
+  virtual void SetLeafByHash(const std::string& key, const std::string& data);
+
+  // Add a new leaf to the hash tree. Stores the hash of the leaf data in the
+  // tree structure, does not store the data itself.
+  //
+  // @param data Binary input blob
+  // @param path Binary path of node to set.
+  virtual void SetLeaf(const Path& path, const std::string& data);
+
+  // Get the current root of the tree.
+  // Update the root to reflect the current shape of the tree,
+  // and return the tree digest.
+  //
+  // Returns the hash of an empty string if the tree has no leaves
+  // (and hence, no root).
+  virtual std::string CurrentRoot();
+
+  // Get the Merkle path from the leaf at |path| to the current root.
+  //
+  // Returns a vector of node hashes, ordered by levels from leaf to root.
+  // The first element is the sibling of the leaf hash, and the last element
+  // is one below the root.
+  // Returns an empty vector if the tree is not large enough
+  // or the leaf index is 0.
+  //
+  // @param path the path of the leaf whose inclusion proof to return.
+  std::vector<std::string> InclusionProof(const Path& path);
+
+  std::string Dump() const;
+
+ private:
+  // WARNING WARNING WARNING
+  // 64 < 256 !
+  // WARNING WARNING WARNING
+  // TODO(alcutter): BIGNUM probably.
+  typedef uint64_t IndexType;
+
+  struct Leaf {
+    Leaf(const Path& path, const std::string& value)
+        : path_(path), value_(value) {
+    }
+
+    std::string DebugString() const;
+
+    const Path path_;
+    std::string value_;
+  };
+
+  struct TreeNode {
+    TreeNode() : type_(INTERNAL), hash_(nullptr) {
+    }
+    TreeNode(const std::string& hash)
+        : type_(INTERNAL), hash_(new std::string(hash)) {
+    }
+
+    TreeNode(const Path& path, const std::string& leaf_value)
+        : type_(LEAF), leaf_(new Leaf(path, leaf_value)) {
+    }
+
+    std::string DebugString() const;
+
+    enum { INTERNAL, LEAF } type_;
+    // TODO(alcutter): sort this out
+    std::unique_ptr<std::string> hash_;
+    std::unique_ptr<Leaf> leaf_;
+  };
+
+  std::string CalculateSubtreeHash(size_t depth, IndexType index);
+
+  void DumpTree(std::ostream* os, size_t depth, IndexType index) const;
+
+  // Get the |index|-th node at level |level|. Indexing starts at 0;
+  // caller is responsible for ensuring tree is sufficiently up to date.
+  std::string Node(size_t level, size_t index) const;
+
+  // Maybe add a new tree level.
+  void EnsureHaveLevel(size_t n);
+
+  std::unique_ptr<SerialHasher> serial_hasher_;
+  TreeHasher treehasher_;
+  const std::vector<std::string>* const null_hashes_;
+  // TODO(alcutter): investigate other structures
+  std::vector<std::unordered_map<IndexType, TreeNode>> tree_;
+  std::string root_hash_;
+};
+
+
+// Pretty print a Path
+std::ostream& operator<<(std::ostream& out,
+                         const SparseMerkleTree::Path& path);
+
+
+// Creates a Path from the bits passed in.
+inline SparseMerkleTree::Path PathFromBytes(const std::string& bytes) {
+  SparseMerkleTree::Path path;
+  // Path size must be a multiple of 8 for now.
+  CHECK_EQ(bytes.size(), path.size());
+
+  std::copy(bytes.begin(), bytes.end(), path.begin());
+  return path;
+}
+
+
+// Extracts the |n|th most significant bit from |path|
+inline int PathBit(const SparseMerkleTree::Path& path, size_t bit) {
+  CHECK_LT(bit, path.size() * 8);
+  return (path[bit / 8] & (1 << (7 - bit % 8))) == 0 ? 0 : 1;
+}
+
+#endif  // CERT_TRANS_MERKLETREE_SPARSE_MERKLE_TREE_H

--- a/cpp/merkletree/sparse_merkle_tree_test.cc
+++ b/cpp/merkletree/sparse_merkle_tree_test.cc
@@ -1,0 +1,344 @@
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <openssl/bn.h>
+#include <sys/resource.h>
+#include <algorithm>
+#include <map>
+#include <random>
+#include <string>
+
+#include "merkletree/sparse_merkle_tree.h"
+#include "util/openssl_scoped_types.h"
+#include "util/testing.h"
+#include "util/util.h"
+
+namespace {
+
+using std::lower_bound;
+using std::map;
+using std::mt19937;
+using std::ostringstream;
+using std::pair;
+using std::random_device;
+using std::reverse;
+using std::string;
+using std::to_string;
+using std::unique_ptr;
+using std::vector;
+using util::ToBase64;
+
+
+const char kEmptyRootHashB64[] =
+    "xmifEIEqCYCXbZUz2Dh1KCFmFZVn7DUVVxbBQTr1PWo=";
+
+
+struct KeyComp {
+  const BIGNUM* AsBN(const ScopedBIGNUM& a) const {
+    return a.get();
+  }
+
+  const BIGNUM* AsBN(const BIGNUM* a) const {
+    return a;
+  }
+
+  const BIGNUM* AsBN(const pair<ScopedBIGNUM, string>& a) const {
+    return a.first.get();
+  }
+};
+
+
+struct KeyEq : public KeyComp {
+  template <class A, class B>
+  bool operator()(const A& a, const B& b) const {
+    return BN_cmp(AsBN(a), AsBN(b)) == 0;
+  }
+};
+
+
+struct KeyLess : public KeyComp {
+  template <class A, class B>
+  bool operator()(const A& a, const B& b) const {
+    return BN_cmp(AsBN(a), AsBN(b)) < 0;
+  }
+};
+
+
+typedef vector<pair<ScopedBIGNUM, string>> ValueList;
+
+pair<ScopedBIGNUM, string> Value(uint64_t n, const string& v) {
+  pair<ScopedBIGNUM, string> ret;
+  ret.second = v;
+  ret.first.reset(BN_new());
+  BN_set_word(ret.first.get(), n);
+  return ret;
+}
+
+// Implements (more-or-less) the reference python code given in the
+// revocation transparency paper for calculating the root-hash of a sparse
+// tree with a given set of leaf nodes.
+class Reference {
+ public:
+  Reference(SerialHasher* hasher)
+      : tree_hasher_(CHECK_NOTNULL(hasher)),
+        hStarEmptyCache_{tree_hasher_.HashLeaf("")} {
+  }
+
+  // Calculates the root hash of a sparse merkle tree of depth |n|, containing
+  // the leaf values in |values|.
+  string HStar2(size_t n, ValueList* values) {
+    // values should be sorted
+    std::sort(values->begin(), values->end(), KeyLess());
+    // and without dupes
+    values->erase(std::unique(values->begin(), values->end(), KeyEq()),
+                  values->end());
+    // Sounds a lot like a map to me, but I've left it as a list because:
+    // a) it's just reference code, and
+    // b) I want it to be as similar as possible to the code in the paper.
+
+    ScopedBIGNUM offset(BN_new());
+    CHECK_EQ(1, BN_zero(offset.get()));
+    const string ret(
+        HStar2b(n, *values, values->begin(), values->end(), offset.get()));
+    return ret;
+  }
+
+
+ private:
+  // Calculates & caches the 'null' node at depth |n|
+  string HStarEmpty(size_t n) {
+    if (hStarEmptyCache_.size() <= n) {
+      const string t(
+          tree_hasher_.HashChildren(HStarEmpty(n - 1), HStarEmpty(n - 1)));
+      CHECK_EQ(n, hStarEmptyCache_.size());
+      hStarEmptyCache_.push_back(t);
+    }
+    CHECK_LT(n, hStarEmptyCache_.size());
+    return hStarEmptyCache_[n];
+  }
+
+  // Calculates an internal subtree.
+  string HStar2b(size_t n, const ValueList& values,
+                 ValueList::const_iterator lo, ValueList::const_iterator hi,
+                 BIGNUM* offset) {
+    if (n == 0) {
+      if (lo == hi) {
+        // DIFF: return the null leaf hash, rather than "0" as in the paper.
+        return hStarEmptyCache_[0];
+      }
+      CHECK_EQ(1, hi - lo);
+      // DIFF: return H(\x00||value) rather than "1" as in the paper.
+      return tree_hasher_.HashLeaf(lo->second);
+    }
+    if (lo == hi) {
+      return HStarEmpty(n);
+    }
+
+    // DIFF: use BIGNUM, 'cos we'll get to values of O(1 << 256) here (!)
+    ScopedBIGNUM split(BN_new());
+    CHECK_EQ(1, BN_set_word(split.get(), 1));
+    CHECK_EQ(1, BN_lshift(split.get(), split.get(), n - 1));
+    CHECK_EQ(1, BN_add(split.get(), split.get(), offset));
+
+    auto i(lower_bound(lo, hi, split, KeyLess()));
+    const string ret(
+        tree_hasher_.HashChildren(HStar2b(n - 1, values, lo, i, offset),
+                                  HStar2b(n - 1, values, i, hi, split.get())));
+    return ret;
+  }
+
+  TreeHasher tree_hasher_;
+  vector<string> hStarEmptyCache_;
+};
+
+
+class SparseMerkleTreeTest : public testing::Test {
+ public:
+  SparseMerkleTreeTest()
+      : tree_hasher_(new Sha256Hasher),
+        tree_(new Sha256Hasher()),
+        rand_({1234}) {
+  }
+
+ protected:
+  // Returns a Path with the high 64 bits set to |high|
+  SparseMerkleTree::Path PathHigh(uint64_t high) {
+    SparseMerkleTree::Path ret;
+    ret.fill(0);
+    for (size_t i(0); i < 8; ++i) {
+      ret[7 - i] = high & 0xff;
+      high >>= 8;
+    }
+    return ret;
+  }
+
+  // Returns a Path with the low 64 bits set to |high|
+  SparseMerkleTree::Path PathLow(uint64_t low) {
+    SparseMerkleTree::Path ret;
+    ret.fill(0);
+    for (size_t i(0); i < 8; ++i) {
+      ret[ret.size() - 1 - i] = low & 0xff;
+      low >>= 8;
+    }
+    return ret;
+  }
+
+  // Returns a random Path.
+  SparseMerkleTree::Path RandomPath() {
+    SparseMerkleTree::Path ret;
+    for (int i(0); i < ret.size(); ++i) {
+      ret[i] = rand_() & 0xff;
+    }
+    return ret;
+  }
+
+  TreeHasher tree_hasher_;
+  SparseMerkleTree tree_;
+  mt19937 rand_;
+};
+
+
+TEST_F(SparseMerkleTreeTest, PathBitAndPathStreamOperatorAgree) {
+  ostringstream os;
+  const SparseMerkleTree::Path p(RandomPath());
+  os << p;
+  string b;
+  for (size_t i(0); i < SparseMerkleTree::kDigestSizeBits; ++i) {
+    b += PathBit(p, i) == 0 ? '0' : '1';
+  }
+  EXPECT_EQ(os.str(), b);
+}
+
+
+TEST_F(SparseMerkleTreeTest, ReferenceEmptyTreeRootKAT) {
+  Reference ref(new Sha256Hasher);
+  ValueList empty_values;
+  EXPECT_EQ(kEmptyRootHashB64, ToBase64(ref.HStar2(256, &empty_values)));
+}
+
+
+TEST_F(SparseMerkleTreeTest, EmptyTreeRootKAT) {
+  tree_.CurrentRoot();
+  EXPECT_EQ(kEmptyRootHashB64, ToBase64(tree_.CurrentRoot()));
+}
+
+
+TEST_F(SparseMerkleTreeTest, SimpleTest) {
+  Reference ref(new Sha256Hasher);
+  ValueList values;
+  for (auto r : vector<uint64_t>{1, 5, 10}) {
+    const string value(to_string(r));
+    values.emplace_back(std::move(Value(r, value)));
+    SparseMerkleTree::Path p(PathLow(r));
+    tree_.SetLeaf(p, value);
+  }
+  const string ref_root(
+      ref.HStar2(SparseMerkleTree::kDigestSizeBits, &values));
+  const string smt_root(tree_.CurrentRoot());
+  EXPECT_EQ(ToBase64(ref_root), ToBase64(smt_root));
+}
+
+
+TEST_F(SparseMerkleTreeTest, RandomReferenceTest) {
+  Reference ref(new Sha256Hasher);
+  ValueList values;
+  LOG(INFO) << "Setup";
+  for (int i(0); i < 10000; ++i) {
+    uint64_t r(rand_() + i);
+    const string value(to_string(r));
+    values.emplace_back(std::move(Value(r, value)));
+    const SparseMerkleTree::Path p(PathLow(r));
+    tree_.SetLeaf(p, value);
+  }
+  LOG(INFO) << "Calculating SMT Root";
+  const string smt_root(tree_.CurrentRoot());
+  LOG(INFO) << "Calculating Reference Root";
+  const string ref_root(ref.HStar2(256, &values));
+  LOG(INFO) << "Comparing";
+  EXPECT_EQ(ToBase64(ref_root), ToBase64(smt_root));
+}
+
+
+TEST_F(SparseMerkleTreeTest, DISABLED_RefMemTest) {
+  Reference ref(new Sha256Hasher);
+  ValueList values;
+
+  struct rusage ru;
+  getrusage(RUSAGE_SELF, &ru);
+  long max_rss_before = ru.ru_maxrss;
+  uint64_t time_before = util::TimeInMilliseconds();
+  LOG(INFO) << "Setup";
+
+  for (int i(0); i < 10000000; ++i) {
+    uint64_t r(rand_() + i);
+    const string value(to_string(r));
+    values.emplace_back(std::move(Value(r, value)));
+  }
+  LOG(INFO) << "Calculating Root";
+  const string ref_root(ref.HStar2(256, &values));
+  LOG(INFO) << "Done";
+
+  uint64_t time_after = util::TimeInMilliseconds();
+  getrusage(RUSAGE_SELF, &ru);
+  LOG(INFO) << "Peak RSS delta (as reported by getrusage()) was "
+            << ru.ru_maxrss - max_rss_before << " kB";
+  LOG(INFO) << "Elapsed time: " << time_after - time_before << " ms";
+}
+
+
+TEST_F(SparseMerkleTreeTest, DISABLED_SMTMemTest) {
+  struct rusage ru;
+  getrusage(RUSAGE_SELF, &ru);
+  long max_rss_before = ru.ru_maxrss;
+  uint64_t time_before = util::TimeInMilliseconds();
+  LOG(INFO) << "Setup";
+
+  for (int i(0); i < 10000000; ++i) {
+    uint64_t r(rand_() + i);
+    const string value(to_string(r));
+    const SparseMerkleTree::Path p(PathLow(r));
+    tree_.SetLeaf(p, value);
+  }
+  LOG(INFO) << "Calculating Root";
+  const string smt_root(tree_.CurrentRoot());
+  LOG(INFO) << "Done";
+
+  uint64_t time_after = util::TimeInMilliseconds();
+  getrusage(RUSAGE_SELF, &ru);
+  LOG(INFO) << "Peak RSS delta (as reported by getrusage()) was "
+            << ru.ru_maxrss - max_rss_before << " kB";
+  LOG(INFO) << "Elapsed time: " << time_after - time_before << " ms";
+}
+
+
+TEST_F(SparseMerkleTreeTest, TestSetLeafByHash) {
+  tree_.CurrentRoot();
+  LOG(INFO) << "Tree@0:";
+  LOG(INFO) << tree_.Dump();
+
+  tree_.SetLeafByHash("one", "one");
+  tree_.CurrentRoot();
+  LOG(INFO) << "Tree@1:";
+  LOG(INFO) << tree_.Dump();
+
+  tree_.SetLeafByHash("two", "two");
+  tree_.CurrentRoot();
+  LOG(INFO) << "Tree@2:";
+  LOG(INFO) << tree_.Dump();
+
+  tree_.SetLeafByHash("three", "three");
+  tree_.CurrentRoot();
+  LOG(INFO) << "Tree@3:";
+  LOG(INFO) << tree_.Dump();
+}
+
+
+// TODO(alcutter): Lots and lots more tests.
+
+
+}  // namespace
+
+
+int main(int argc, char** argv) {
+  cert_trans::test::InitTesting(argv[0], &argc, &argv, true);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Very early first cut of a C++ sparse merkle tree / map implementation.
Inspired by the [revocation transparency](http://www.links.org/files/RevocationTransparency.pdf) paper, but with some differences (as noted in the header) for security and to be useful as a general purpose verifiable map.

Lots left to do, just trying to break it up into digestible chunks.