### PR TITLE
Pull Server::Options and EtcdClient init into server_helper

### DIFF
--- a/cpp/server/server.h
+++ b/cpp/server/server.h
@@ -40,23 +40,10 @@ Gauge<>* latest_local_tree_size_gauge();
 
 class Server {
  public:
-  struct Options {
-    Options() : port(0), num_http_server_threads(16) {
-    }
-
-    std::string server;
-    uint16_t port;
-
-    std::string etcd_root;
-
-    int num_http_server_threads;
-  };
-
   static void StaticInit();
 
   // Doesn't take ownership of anything.
-  Server(const Options& opts,
-         const std::shared_ptr<libevent::Base>& event_base,
+  Server(const std::shared_ptr<libevent::Base>& event_base,
          ThreadPool* internal_pool, ThreadPool* http_pool, Database* db,
          EtcdClient* etcd_client, UrlFetcher* url_fetcher,
          const LogVerifier* log_verifier);
@@ -76,7 +63,6 @@ class Server {
   void Run();
 
  private:
-  const Options options_;
   const std::shared_ptr<libevent::Base> event_base_;
   std::unique_ptr<libevent::EventPumpThread> event_pump_;
   libevent::HttpServer http_server_;

--- a/cpp/server/server_helper.cc
+++ b/cpp/server/server_helper.cc
@@ -1,12 +1,24 @@
 #include "log/strict_consistent_store.h"
 #include "server/server.h"
 #include "server/server_helper.h"
+#include "util/fake_etcd.h"
 
 using cert_trans::Server;
 using google::RegisterFlagValidator;
 using std::string;
 using std::unique_ptr;
 
+// Main server configuration flags
+DEFINE_string(server, "localhost", "Server host");
+DEFINE_int32(port, 9999, "Server port");
+DEFINE_string(etcd_root, "/root", "Root of cluster entries in etcd.");
+DEFINE_string(etcd_servers, "",
+              "Comma separated list of 'hostname:port' of the etcd server(s)");
+DEFINE_bool(i_know_stand_alone_mode_can_lose_data, false,
+            "Set this to allow stand-alone mode, even though it will lose "
+            "submissions in the case of a crash.");
+
+// Storage related flags
 // TODO(alcutter): Just specify a root dir with a single flag.
 DEFINE_string(cert_dir, "", "Storage directory for certificates");
 DEFINE_string(tree_dir, "", "Storage directory for trees");
@@ -23,6 +35,7 @@ DEFINE_int32(tree_storage_depth, 0,
              "Subdirectory depth for tree signatures; if the directory is not "
              "empty, must match the existing depth");
 
+// Basic sanity checks on flag values.
 static bool ValidateWrite(const char* flagname, const string& path) {
   if (path != "" && access(path.c_str(), W_OK) != 0) {
     std::cout << "Cannot modify " << flagname << " at " << path << std::endl;
@@ -39,6 +52,17 @@ static bool ValidateIsNonNegative(const char* flagname, int value) {
   return true;
 }
 
+static bool ValidatePort(const char*, int port) {
+  if (port <= 0 || port > 65535) {
+    std::cout << "Port value " << port << " is invalid. " << std::endl;
+    return false;
+  }
+  return true;
+}
+
+static const bool port_dummy =
+    RegisterFlagValidator(&FLAGS_port, &ValidatePort);
+
 static const bool cert_dir_dummy =
     RegisterFlagValidator(&FLAGS_cert_dir, &ValidateWrite);
 
@@ -54,7 +78,25 @@ static const bool t_st_dummy =
 namespace cert_trans {
 
 void EnsureValidatorsRegistered() {
-  CHECK(cert_dir_dummy && tree_dir_dummy && c_st_dummy && t_st_dummy);
+  CHECK(cert_dir_dummy && tree_dir_dummy && c_st_dummy && t_st_dummy &&
+        port_dummy);
+}
+
+
+bool IsStandalone(bool warn_data_loss) {
+  const bool stand_alone_mode(FLAGS_etcd_servers.empty());
+  if (stand_alone_mode && warn_data_loss &&
+      !FLAGS_i_know_stand_alone_mode_can_lose_data) {
+    LOG(FATAL) << "attempted to run in stand-alone mode without the "
+                  "--i_know_stand_alone_mode_can_lose_data flag";
+  }
+
+  if (!stand_alone_mode && FLAGS_server.empty()) {
+    // Part of a cluster so server must be set
+    LOG(FATAL) << "not in stand-alone mode but --server is empty";
+  }
+
+  return stand_alone_mode;
 }
 
 
@@ -84,4 +126,15 @@ unique_ptr<Database> ProvideDatabase() {
   LOG(FATAL) << "No usable database is configured by flags";
 }
 
+
+unique_ptr<EtcdClient> ProvideEtcdClient(libevent::Base* event_base,
+                                         ThreadPool* pool,
+                                         UrlFetcher* fetcher) {
+  // No need to enforce --warn-data-loss here as it will already have been
+  // done if required
+  return unique_ptr<EtcdClient>(
+      IsStandalone(false)
+          ? new FakeEtcdClient(event_base)
+          : new EtcdClient(pool, fetcher, SplitHosts(FLAGS_etcd_servers)));
+}
 }  // namespace cert_trans

--- a/cpp/server/xjson-server.cc
+++ b/cpp/server/xjson-server.cc
@@ -39,8 +39,6 @@
 #include "util/thread_pool.h"
 #include "util/uuid.h"
 
-DEFINE_string(server, "localhost", "Server host");
-DEFINE_int32(port, 9999, "Server port");
 DEFINE_string(key, "", "PEM-encoded server private key file");
 DEFINE_int32(cleanup_frequency_seconds, 10,
              "How often should new entries be cleanedup. The cleanup runs in "
@@ -54,14 +52,8 @@ DEFINE_int32(tree_signing_frequency_seconds, 600,
 DEFINE_double(guard_window_seconds, 60,
               "Unsequenced entries newer than this "
               "number of seconds will not be sequenced.");
-DEFINE_string(etcd_servers, "",
-              "Comma separated list of 'hostname:port' of the etcd server(s)");
-DEFINE_string(etcd_root, "/root", "Root of cluster entries in etcd.");
 DEFINE_int32(num_http_server_threads, 16,
              "Number of threads for servicing the incoming HTTP requests.");
-DEFINE_bool(i_know_stand_alone_mode_can_lose_data, false,
-            "Set this to allow stand-alone mode, even though it will lost "
-            "submissions in the case of a crash.");
 
 namespace libevent = cert_trans::libevent;
 
@@ -120,17 +112,6 @@ Latency<milliseconds> signer_run_latency_ms("signer_run_latency_ms",
 
 
 // Basic sanity checks on flag values.
-static bool ValidatePort(const char*, int port) {
-  if (port <= 0 || port > 65535) {
-    std::cout << "Port value " << port << " is invalid. " << std::endl;
-    return false;
-  }
-  return true;
-}
-
-static const bool port_dummy =
-    RegisterFlagValidator(&FLAGS_port, &ValidatePort);
-
 static bool ValidateRead(const char* flagname, const string& path) {
   if (access(path.c_str(), R_OK) != 0) {
     std::cout << "Cannot access " << flagname << " at " << path << std::endl;
@@ -256,31 +237,21 @@ int main(int argc, char* argv[]) {
   ThreadPool internal_pool(8);
   UrlFetcher url_fetcher(event_base.get(), &internal_pool);
 
-  const bool stand_alone_mode(FLAGS_etcd_servers.empty());
-  if (stand_alone_mode && !FLAGS_i_know_stand_alone_mode_can_lose_data) {
-    LOG(FATAL) << "attempted to run in stand-alone mode without the "
-                  "--i_know_stand_alone_mode_can_lose_data flag";
-  }
+  const bool stand_alone_mode(cert_trans::IsStandalone(true));
   LOG(INFO) << "Running in "
             << (stand_alone_mode ? "STAND-ALONE" : "CLUSTERED") << " mode.";
 
-  std::unique_ptr<EtcdClient> etcd_client(
-      stand_alone_mode ? new FakeEtcdClient(event_base.get())
-                       : new EtcdClient(&internal_pool, &url_fetcher,
-                                        SplitHosts(FLAGS_etcd_servers)));
+  unique_ptr<EtcdClient> etcd_client(
+      cert_trans::ProvideEtcdClient(event_base.get(), &internal_pool,
+                                    &url_fetcher));
 
   const LogVerifier log_verifier(new LogSigVerifier(pkey.ValueOrDie()),
                                  new MerkleVerifier(new Sha256Hasher));
 
-  Server::Options options;
-  options.server = FLAGS_server;
-  options.port = FLAGS_port;
-  options.etcd_root = FLAGS_etcd_root;
-
   ThreadPool http_pool(FLAGS_num_http_server_threads);
 
-  Server server(options, event_base, &internal_pool, &http_pool, db.get(),
-                etcd_client.get(), &url_fetcher, &log_verifier);
+  Server server(event_base, &internal_pool, &http_pool,
+                db.get(), etcd_client.get(), &url_fetcher, &log_verifier);
   server.Initialise(false /* is_mirror */);
 
   Frontend frontend(
@@ -338,8 +309,6 @@ int main(int argc, char* argv[]) {
     // if it's not set, which in turn causes us to not attempt to become
     // master:
     server.consistent_store()->SetServingSTH(tree_signer.LatestSTH());
-  } else {
-    CHECK(!FLAGS_server.empty());
   }
 
   server.WaitForReplication();


### PR DESCRIPTION
Bring the code and flags for initializing options and etcd into the
server helper, reducing code dup again. Remove the corresponding code
from all 3 servers.