### PR TITLE
Remove unused flag for stats collection

### DIFF
--- a/cpp/server/ct-mirror.cc
+++ b/cpp/server/ct-mirror.cc
@@ -52,11 +52,6 @@
 
 DEFINE_string(server, "localhost", "Server host");
 DEFINE_int32(port, 9999, "Server port");
-DEFINE_int32(log_stats_frequency_seconds, 3600,
-             "Interval for logging summary statistics. Approximate: the "
-             "server will log statistics if in the beginning of its select "
-             "loop, at least this period has elapsed since the last log time. "
-             "Must be greater than 0.");
 DEFINE_int32(target_poll_frequency_seconds, 10,
              "How often should the target log be polled for updates.");
 DEFINE_string(etcd_servers, "",
@@ -174,10 +169,6 @@ static bool ValidateIsPositive(const char* flagname, int value) {
   }
   return true;
 }
-
-static const bool stats_dummy =
-    RegisterFlagValidator(&FLAGS_log_stats_frequency_seconds,
-                          &ValidateIsPositive);
 
 static const bool follow_dummy =
     RegisterFlagValidator(&FLAGS_target_poll_frequency_seconds,

--- a/cpp/server/ct-server.cc
+++ b/cpp/server/ct-server.cc
@@ -43,11 +43,6 @@ DEFINE_int32(port, 9999, "Server port");
 DEFINE_string(key, "", "PEM-encoded server private key file");
 DEFINE_string(trusted_cert_file, "",
               "File for trusted CA certificates, in concatenated PEM format");
-DEFINE_int32(log_stats_frequency_seconds, 3600,
-             "Interval for logging summary statistics. Approximate: the "
-             "server will log statistics if in the beginning of its select "
-             "loop, at least this period has elapsed since the last log time. "
-             "Must be greater than 0.");
 DEFINE_int32(sequencing_frequency_seconds, 10,
              "How often should new entries be sequenced. The sequencing runs "
              "in parallel with the tree signing and cleanup.");
@@ -170,10 +165,6 @@ static bool ValidateIsPositive(const char* flagname, int value) {
   }
   return true;
 }
-
-static const bool stats_dummy =
-    RegisterFlagValidator(&FLAGS_log_stats_frequency_seconds,
-                          &ValidateIsPositive);
 
 static const bool sign_dummy =
     RegisterFlagValidator(&FLAGS_tree_signing_frequency_seconds,

--- a/cpp/server/xjson-server.cc
+++ b/cpp/server/xjson-server.cc
@@ -41,11 +41,6 @@
 DEFINE_string(server, "localhost", "Server host");
 DEFINE_int32(port, 9999, "Server port");
 DEFINE_string(key, "", "PEM-encoded server private key file");
-DEFINE_int32(log_stats_frequency_seconds, 3600,
-             "Interval for logging summary statistics. Approximate: the "
-             "server will log statistics if in the beginning of its select "
-             "loop, at least this period has elapsed since the last log time. "
-             "Must be greater than 0.");
 DEFINE_int32(sequencing_frequency_seconds, 10,
              "How often should new entries be sequenced. The sequencing runs "
              "in parallel with the tree signing and cleanup.");
@@ -161,10 +156,6 @@ static bool ValidateIsPositive(const char* flagname, int value) {
   }
   return true;
 }
-
-static const bool stats_dummy =
-    RegisterFlagValidator(&FLAGS_log_stats_frequency_seconds,
-                          &ValidateIsPositive);
 
 static const bool sign_dummy =
     RegisterFlagValidator(&FLAGS_tree_signing_frequency_seconds,


### PR DESCRIPTION
The log_stats_frequency_seconds flag was defined in all 3 servers and I can't see any references to it elsewhere.