### PR TITLE
Rename LogVerifier::VerifyResult to LogVerifyResult.

### DIFF
--- a/cpp/client/ct.cc
+++ b/cpp/client/ct.cc
@@ -259,7 +259,7 @@ static bool VerifySCTAndPopulateSSLClientCTData(
   sct_info->mutable_sct()->CopyFrom(sct);
   const unique_ptr<LogVerifier> verifier(GetLogVerifierFromFlags());
   string merkle_leaf;
-  LogVerifier::VerifyResult result =
+  LogVerifier::LogVerifyResult result =
       verifier->VerifySignedCertificateTimestamp(
           ct_data->reconstructed_entry(), sct, &merkle_leaf);
   if (result != LogVerifier::VERIFY_OK) {
@@ -653,7 +653,7 @@ static AuditResult Audit() {
     }
 
     LOG(INFO) << "Received proof:\n" << proof.DebugString();
-    LogVerifier::VerifyResult res =
+    LogVerifier::LogVerifyResult res =
         verifier->VerifyMerkleAuditProof(ct_data.reconstructed_entry(),
                                          ct_data.attached_sct_info(i).sct(),
                                          proof);
@@ -764,7 +764,7 @@ static void DiagnoseCertChain() {
         LOG(WARNING) << "SCT key ID does not match verifier's ID, skipping";
         continue;
       } else {
-        LogVerifier::VerifyResult res =
+        LogVerifier::LogVerifyResult res =
             verifier->VerifySignedCertificateTimestamp(entry, sct);
         if (res == LogVerifier::VERIFY_OK)
           LOG(INFO) << "SCT verified";
@@ -918,7 +918,7 @@ int GetSTH() {
 
   // Allow for 10 seconds of clock skew
   uint64_t latest = ((uint64_t)time(NULL) + 10) * 1000;
-  const LogVerifier::VerifyResult result =
+  const LogVerifier::LogVerifyResult result =
       verifier->VerifySignedTreeHead(sth, 0, latest);
 
   LOG(INFO) << "STH is " << sth.DebugString();

--- a/cpp/client/ssl_client.cc
+++ b/cpp/client/ssl_client.cc
@@ -128,9 +128,9 @@ void SSLClient::GetSSLClientCTData(SSLClientCTData* data) const {
 // proof is re-submitted (or submitted to another log) and the server attaches
 // that proof too, but let's not complicate things for now.
 // static
-LogVerifier::VerifyResult SSLClient::VerifySCT(const string& token,
-                                               LogVerifier* verifier,
-                                               SSLClientCTData* data) {
+LogVerifier::LogVerifyResult SSLClient::VerifySCT(const string& token,
+                                                  LogVerifier* verifier,
+                                                  SSLClientCTData* data) {
   CHECK(data->has_reconstructed_entry());
   SignedCertificateTimestamp local_sct;
   // Skip over bad SCTs. These could be either badly encoded ones, or
@@ -139,7 +139,7 @@ LogVerifier::VerifyResult SSLClient::VerifySCT(const string& token,
     return LogVerifier::INVALID_FORMAT;
 
   string merkle_leaf;
-  LogVerifier::VerifyResult result =
+  LogVerifier::LogVerifyResult result =
       verifier->VerifySignedCertificateTimestamp(data->reconstructed_entry(),
                                                  local_sct, &merkle_leaf);
   if (result != LogVerifier::VERIFY_OK)
@@ -245,7 +245,7 @@ int SSLClient::VerifyCallback(X509_STORE_CTX* ctx, void* arg) {
       } else {
         LOG(INFO) << "Received " << sct_list.sct_list_size() << " SCTs";
         for (int i = 0; i < sct_list.sct_list_size(); ++i) {
-          LogVerifier::VerifyResult result =
+          LogVerifier::LogVerifyResult result =
               VerifySCT(sct_list.sct_list(i), verifier, &args->ct_data);
 
           if (result == LogVerifier::VERIFY_OK) {

--- a/cpp/client/ssl_client.h
+++ b/cpp/client/ssl_client.h
@@ -45,9 +45,9 @@ class SSLClient {
   void GetSSLClientCTData(ct::SSLClientCTData* data) const;
 
   // Need a static wrapper for the callback.
-  static LogVerifier::VerifyResult VerifySCT(const std::string& token,
-                                             LogVerifier* verifier,
-                                             ct::SSLClientCTData* data);
+  static LogVerifier::LogVerifyResult VerifySCT(const std::string& token,
+                                                LogVerifier* verifier,
+                                                ct::SSLClientCTData* data);
 
   // Custom verification callback for verifying the SCT token
   // in a superfluous certificate. Return values:

--- a/cpp/fetcher/fetcher.cc
+++ b/cpp/fetcher/fetcher.cc
@@ -248,8 +248,7 @@ void FetchState::WriteToDatabase(int64_t index, Range* range,
       // If we have the full SCT (because this LogEntry came from another
       // internal node which supports our private "give me the SCT too"
       // option), then verify that the signature is good.
-      // TODO(pphaneuf): Note to self: util::Status this!
-      const LogVerifier::VerifyResult verify_result(
+      const LogVerifier::LogVerifyResult verify_result(
           log_verifier_->VerifySignedCertificateTimestamp(
               cert.contents().entry(), cert.sct()));
       VLOG(1) << "SCT verify entry #" << index << ": "

--- a/cpp/fetcher/remote_peer.cc
+++ b/cpp/fetcher/remote_peer.cc
@@ -80,7 +80,7 @@ void RemotePeer::Impl::DoneGetSTH(
   if (status == AsyncLogClient::OK) {
     bool sth_provisionally_valid(false);
 
-    const LogVerifier::VerifyResult result(verifier_->VerifySignedTreeHead(
+    const LogVerifier::LogVerifyResult result(verifier_->VerifySignedTreeHead(
         *new_sth, 0, (time(NULL) + 10) * kNumMillisPerSecond));
 
     // TODO(alcutter): We should probably log these invalid STHs somewhere a bit

--- a/cpp/log/log_verifier.cc
+++ b/cpp/log/log_verifier.cc
@@ -26,7 +26,7 @@ LogVerifier::~LogVerifier() {
   delete merkle_verifier_;
 }
 
-LogVerifier::VerifyResult LogVerifier::VerifySignedCertificateTimestamp(
+LogVerifier::LogVerifyResult LogVerifier::VerifySignedCertificateTimestamp(
     const LogEntry& entry, const SignedCertificateTimestamp& sct,
     uint64_t begin_range, uint64_t end_range, string* merkle_leaf_hash) const {
   if (!IsBetween(sct.timestamp(), begin_range, end_range))
@@ -46,7 +46,7 @@ LogVerifier::VerifyResult LogVerifier::VerifySignedCertificateTimestamp(
   return VERIFY_OK;
 }
 
-LogVerifier::VerifyResult LogVerifier::VerifySignedCertificateTimestamp(
+LogVerifier::LogVerifyResult LogVerifier::VerifySignedCertificateTimestamp(
     const LogEntry& entry, const SignedCertificateTimestamp& sct,
     string* merkle_leaf_hash) const {
   // Allow a bit of slack, say 1 second into the future.
@@ -55,7 +55,7 @@ LogVerifier::VerifyResult LogVerifier::VerifySignedCertificateTimestamp(
                                           merkle_leaf_hash);
 }
 
-LogVerifier::VerifyResult LogVerifier::VerifySignedTreeHead(
+LogVerifier::LogVerifyResult LogVerifier::VerifySignedTreeHead(
     const SignedTreeHead& sth, uint64_t begin_range,
     uint64_t end_range) const {
   if (!IsBetween(sth.timestamp(), begin_range, end_range))
@@ -66,13 +66,13 @@ LogVerifier::VerifyResult LogVerifier::VerifySignedTreeHead(
   return VERIFY_OK;
 }
 
-LogVerifier::VerifyResult LogVerifier::VerifySignedTreeHead(
+LogVerifier::LogVerifyResult LogVerifier::VerifySignedTreeHead(
     const SignedTreeHead& sth) const {
   // Allow a bit of slack, say 1 second into the future.
   return VerifySignedTreeHead(sth, 0, util::TimeInMilliseconds() + 1000);
 }
 
-LogVerifier::VerifyResult LogVerifier::VerifyMerkleAuditProof(
+LogVerifier::LogVerifyResult LogVerifier::VerifyMerkleAuditProof(
     const LogEntry& entry, const SignedCertificateTimestamp& sct,
     const MerkleAuditProof& merkle_proof) const {
   if (!IsBetween(merkle_proof.timestamp(), sct.timestamp(),

--- a/cpp/log/log_verifier.h
+++ b/cpp/log/log_verifier.h
@@ -18,7 +18,7 @@ class LogVerifier {
   LogVerifier(LogSigVerifier* sig_verifier, MerkleVerifier* tree_verifier);
   ~LogVerifier();
 
-  enum VerifyResult {
+  enum LogVerifyResult {
     VERIFY_OK,
     // Invalid format
     INVALID_FORMAT,
@@ -33,7 +33,7 @@ class LogVerifier {
     INVALID_MERKLE_PATH,
   };
 
-  static std::string VerifyResultString(VerifyResult result) {
+  static std::string VerifyResultString(LogVerifyResult result) {
     switch (result) {
       case VERIFY_OK:
         return "Verify OK.";
@@ -49,7 +49,7 @@ class LogVerifier {
         return "Invalid Merkle path.";
     }
 
-    LOG(FATAL) << "unknown value for VerifyResult enum: " << result;
+    LOG(FATAL) << "unknown value for LogVerifyResult enum: " << result;
     // It should not be possible for control to reach this point but this
     // avoids a compilation warning on some platforms.
     abort();
@@ -63,18 +63,18 @@ class LogVerifier {
   // and the signature is valid.
   // Timestamps are given in milliseconds, since January 1, 1970,
   // 00:00 UTC time.
-  VerifyResult VerifySignedCertificateTimestamp(
+  LogVerifyResult VerifySignedCertificateTimestamp(
       const ct::LogEntry& entry, const ct::SignedCertificateTimestamp& sct,
       uint64_t begin_range, uint64_t end_range,
       std::string* merkle_leaf_hash) const;
 
   // Verify that the timestamp is not in the future, and the signature is
   // valid.
-  VerifyResult VerifySignedCertificateTimestamp(
+  LogVerifyResult VerifySignedCertificateTimestamp(
       const ct::LogEntry& entry, const ct::SignedCertificateTimestamp& sct,
       std::string* merkle_leaf_hash) const;
 
-  VerifyResult VerifySignedCertificateTimestamp(
+  LogVerifyResult VerifySignedCertificateTimestamp(
       const ct::LogEntry& entry, const ct::SignedCertificateTimestamp& sct,
       uint64_t begin_range, uint64_t end_range) const {
     return VerifySignedCertificateTimestamp(entry, sct, begin_range, end_range,
@@ -82,7 +82,7 @@ class LogVerifier {
   }
   // Verify that the timestamp is not in the future, and the signature is
   // valid.
-  VerifyResult VerifySignedCertificateTimestamp(
+  LogVerifyResult VerifySignedCertificateTimestamp(
       const ct::LogEntry& entry,
       const ct::SignedCertificateTimestamp& sct) const {
     return VerifySignedCertificateTimestamp(entry, sct, NULL);
@@ -92,19 +92,19 @@ class LogVerifier {
   // and the signature is valid.
   // Timestamps are given in milliseconds, since January 1, 1970,
   // 00:00 UTC time.
-  VerifyResult VerifySignedTreeHead(const ct::SignedTreeHead& sth,
-                                    uint64_t begin_range,
-                                    uint64_t end_range) const;
+  LogVerifyResult VerifySignedTreeHead(const ct::SignedTreeHead& sth,
+                                       uint64_t begin_range,
+                                       uint64_t end_range) const;
 
   // Verify that the timestamp is not in the future, and the signature is
   // valid.
-  VerifyResult VerifySignedTreeHead(const ct::SignedTreeHead& sth) const;
+  LogVerifyResult VerifySignedTreeHead(const ct::SignedTreeHead& sth) const;
 
   // Verify that
   // (1) The audit proof signature is valid
   // (2) sct timestamp <= audit proof timestamp <= now
   // Does not verify the SCT signature (or even require one).
-  VerifyResult VerifyMerkleAuditProof(
+  LogVerifyResult VerifyMerkleAuditProof(
       const ct::LogEntry& entry, const ct::SignedCertificateTimestamp& sct,
       const ct::MerkleAuditProof& merkle_proof) const;
 

--- a/cpp/monitor/monitor.cc
+++ b/cpp/monitor/monitor.cc
@@ -84,7 +84,7 @@ Monitor::VerifyResult Monitor::VerifySTHInternal() {
 
 Monitor::VerifyResult Monitor::VerifySTHWithInvalidTimestamp(
     const ct::SignedTreeHead& sth) {
-  LogVerifier::VerifyResult v_result =
+  LogVerifier::LogVerifyResult v_result =
       verifier_->VerifySignedTreeHead(sth, sth.timestamp(), sth.timestamp());
 
   if (v_result == LogVerifier::VERIFY_OK) {
@@ -101,7 +101,7 @@ Monitor::VerifyResult Monitor::VerifySTHWithInvalidTimestamp(
 
 Monitor::VerifyResult Monitor::VerifySTHInternal(
     const ct::SignedTreeHead& sth) {
-  LogVerifier::VerifyResult v_result = verifier_->VerifySignedTreeHead(sth);
+  LogVerifier::LogVerifyResult v_result = verifier_->VerifySignedTreeHead(sth);
   std::string v_result_string = LogVerifier::VerifyResultString(v_result);
 
   VerifyResult result = SIGNATURE_INVALID;

--- a/cpp/server/server.cc
+++ b/cpp/server/server.cc
@@ -226,7 +226,7 @@ void Server::Initialise(bool is_mirror) {
   {
     ct::SignedTreeHead db_sth;
     if (db_->LatestTreeHead(&db_sth) == Database::LOOKUP_OK) {
-      const LogVerifier::VerifyResult sth_verify_result(
+      const LogVerifier::LogVerifyResult sth_verify_result(
           log_verifier_->VerifySignedTreeHead(db_sth));
       if (sth_verify_result != LogVerifier::VERIFY_OK) {
         LOG(FATAL) << "STH retrieved from DB did not verify: "


### PR DESCRIPTION
There was no less than *three* things VerifyResult, one less is progress!