### PR TITLE
Proposal to split the node staleness logic out of HttpHandler

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -171,6 +171,7 @@ cpp_libcore_a_SOURCES = \
 	cpp/server/metrics.cc \
 	cpp/server/proxy.cc \
 	cpp/server/server.cc \
+	cpp/server/staleness_tracker.cc \
 	cpp/third_party/curl/hostcheck.c \
 	cpp/third_party/isec_partners/openssl_hostname_validation.c \
 	cpp/util/etcd.cc \

--- a/cpp/server/certificate_handler.cc
+++ b/cpp/server/certificate_handler.cc
@@ -79,8 +79,10 @@ CertificateHttpHandler::CertificateHttpHandler(
     LogLookup* log_lookup, const ReadOnlyDatabase* db,
     const ClusterStateController<LoggedEntry>* controller,
     const CertChecker* cert_checker, Frontend* frontend, ThreadPool* pool,
-    libevent::Base* event_base)
-    : HttpHandler(log_lookup, db, controller, pool, event_base),
+    libevent::Base* event_base,
+    StalenessTracker* staleness_tracker)
+    : HttpHandler(log_lookup, db, controller, pool, event_base,
+                  staleness_tracker),
       cert_checker_(CHECK_NOTNULL(cert_checker)),
       submission_handler_(cert_checker_),
       frontend_(frontend) {

--- a/cpp/server/certificate_handler.h
+++ b/cpp/server/certificate_handler.h
@@ -5,6 +5,7 @@
 #include "log/database.h"
 #include "log/logged_entry.h"
 #include "server/handler.h"
+#include "server/staleness_tracker.h"
 
 namespace cert_trans {
 
@@ -18,7 +19,8 @@ class CertificateHttpHandler : public HttpHandler {
   CertificateHttpHandler(LogLookup* log_lookup, const ReadOnlyDatabase* db,
                          const ClusterStateController<LoggedEntry>* controller,
                          const CertChecker* cert_checker, Frontend* frontend,
-                         ThreadPool* pool, libevent::Base* event_base);
+                         ThreadPool* pool, libevent::Base* event_base,
+                         StalenessTracker* staleness_tracker);
 
   ~CertificateHttpHandler() = default;
 

--- a/cpp/server/handler.h
+++ b/cpp/server/handler.h
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "proto/ct.pb.h"
+#include "server/staleness_tracker.h"
 #include "util/libevent_wrapper.h"
 #include "util/sync_task.h"
 #include "util/task.h"
@@ -33,7 +34,8 @@ class HttpHandler {
   // this instance.
   HttpHandler(LogLookup* log_lookup, const ReadOnlyDatabase* db,
               const ClusterStateController<LoggedEntry>* controller,
-              ThreadPool* pool, libevent::Base* event_base);
+              ThreadPool* pool, libevent::Base* event_base,
+              StalenessTracker* staleness_tracker);
   virtual ~HttpHandler();
 
   void Add(libevent::HttpServer* server);
@@ -72,10 +74,7 @@ class HttpHandler {
   Proxy* proxy_;
   ThreadPool* const pool_;
   libevent::Base* const event_base_;
-
-  util::SyncTask task_;
-  mutable std::mutex mutex_;
-  bool node_is_stale_;
+  StalenessTracker* staleness_tracker_;
 
   DISALLOW_COPY_AND_ASSIGN(HttpHandler);
 };

--- a/cpp/server/staleness_tracker.cc
+++ b/cpp/server/staleness_tracker.cc
@@ -1,0 +1,66 @@
+#include <algorithm>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <string>
+#include <vector>
+
+#include "log/cluster_state_controller.h"
+#include "log/logged_entry.h"
+#include "server/staleness_tracker.h"
+#include "util/thread_pool.h"
+
+namespace libevent = cert_trans::libevent;
+
+using cert_trans::StalenessTracker;
+using cert_trans::LoggedEntry;
+using std::bind;
+using std::chrono::seconds;
+using std::lock_guard;
+using std::mutex;
+
+DEFINE_int32(staleness_check_delay_secs, 5,
+             "number of seconds between node staleness checks");
+
+
+StalenessTracker::StalenessTracker(
+    const ClusterStateController<LoggedEntry>* controller, ThreadPool* pool,
+    libevent::Base* event_base)
+    : controller_(CHECK_NOTNULL(controller)),
+      pool_(CHECK_NOTNULL(pool)),
+      event_base_(CHECK_NOTNULL(event_base)),
+      task_(pool_),
+      node_is_stale_(controller_->NodeIsStale()) {
+  event_base_->Delay(seconds(FLAGS_staleness_check_delay_secs),
+                     task_.task()->AddChild(
+                         bind(&StalenessTracker::UpdateNodeStaleness, this)));
+}
+
+
+StalenessTracker::~StalenessTracker() {
+  task_.task()->Return();
+  task_.Wait();
+}
+
+
+bool StalenessTracker::IsNodeStale() const {
+  lock_guard<mutex> lock(mutex_);
+  return node_is_stale_;
+}
+
+
+void StalenessTracker::UpdateNodeStaleness() {
+  if (!task_.task()->IsActive()) {
+    // We're shutting down, just return.
+    return;
+  }
+
+  const bool node_is_stale(controller_->NodeIsStale());
+  {
+    lock_guard<mutex> lock(mutex_);
+    node_is_stale_ = node_is_stale;
+  }
+
+  event_base_->Delay(seconds(FLAGS_staleness_check_delay_secs),
+                     task_.task()->AddChild(
+                         bind(&StalenessTracker::UpdateNodeStaleness, this)));
+}

--- a/cpp/server/staleness_tracker.h
+++ b/cpp/server/staleness_tracker.h
@@ -1,0 +1,49 @@
+#ifndef CERT_TRANS_SERVER_STALENESS_TRACKER_H_
+#define CERT_TRANS_SERVER_STALENESS_TRACKER_H_
+
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include "log/logged_entry.h"
+#include "util/libevent_wrapper.h"
+#include "util/sync_task.h"
+#include "util/task.h"
+
+namespace cert_trans {
+
+template <class T>
+class ClusterStateController;
+class ThreadPool;
+
+
+class StalenessTracker {
+ public:
+  // Does not take ownership of its parameters, which must outlive
+  // this instance.
+  StalenessTracker(const ClusterStateController<LoggedEntry>* controller,
+                   ThreadPool* pool, libevent::Base* event_base);
+  virtual ~StalenessTracker();
+
+  // Check if we consider our node to be stale
+  bool IsNodeStale() const;
+  // Update our view of node staleness from the controller. This causes
+  // periodic updates to be scheduled
+  void UpdateNodeStaleness();
+
+ private:
+  const ClusterStateController<LoggedEntry>* const controller_;
+  ThreadPool* const pool_;
+  libevent::Base* const event_base_;
+
+  util::SyncTask task_;
+  mutable std::mutex mutex_;
+  bool node_is_stale_;
+
+  DISALLOW_COPY_AND_ASSIGN(StalenessTracker);
+};
+
+
+}  // namespace cert_trans
+
+#endif  // CERT_TRANS_SERVER_STALENESS_TRACKER_H_

--- a/cpp/server/x_json_handler.cc
+++ b/cpp/server/x_json_handler.cc
@@ -54,8 +54,10 @@ shared_ptr<JsonObject> ExtractJson(libevent::Base* base, evhttp_request* req) {
 XJsonHttpHandler::XJsonHttpHandler(
     LogLookup* log_lookup, const ReadOnlyDatabase* db,
     const ClusterStateController<LoggedEntry>* controller, Frontend* frontend,
-    ThreadPool* pool, libevent::Base* event_base)
-    : HttpHandler(log_lookup, db, controller, pool, event_base),
+    ThreadPool* pool, libevent::Base* event_base,
+    StalenessTracker* staleness_tracker)
+    : HttpHandler(log_lookup, db, controller, pool, event_base,
+                  staleness_tracker),
       frontend_(frontend) {
 }
 

--- a/cpp/server/x_json_handler.h
+++ b/cpp/server/x_json_handler.h
@@ -5,6 +5,7 @@
 
 #include "log/logged_entry.h"
 #include "server/handler.h"
+#include "server/staleness_tracker.h"
 #include "util/json_wrapper.h"
 
 namespace cert_trans {
@@ -18,7 +19,7 @@ class XJsonHttpHandler : public HttpHandler {
   XJsonHttpHandler(LogLookup* log_lookup, const ReadOnlyDatabase* db,
                    const ClusterStateController<LoggedEntry>* controller,
                    Frontend* frontend, ThreadPool* pool,
-                   libevent::Base* event_base);
+                   libevent::Base* event_base, StalenessTracker*);
 
   ~XJsonHttpHandler() = default;
 


### PR DESCRIPTION
This is because HttpHandler is V1 specific and we'd otherwise be duplicating this code.