### PR TITLE
Dedup server sequencing logic

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -231,6 +231,7 @@ cpp_server_ct_server_SOURCES = \
 	cpp/server/certificate_handler.cc \
 	cpp/server/handler.cc \
 	cpp/server/json_output.cc \
+        cpp/server/log_processes.cc \
 	cpp/server/server_helper.cc
 
 cpp_server_xjson_server_LDADD = \
@@ -243,6 +244,7 @@ cpp_server_xjson_server_SOURCES = \
   cpp/client/async_log_client.cc \
 	cpp/server/handler.cc \
 	cpp/server/json_output.cc \
+        cpp/server/log_processes.cc \
 	cpp/server/server_helper.cc \
 	cpp/server/xjson-server.cc \
 	cpp/server/x_json_handler.cc \

--- a/cpp/server/log_processes.cc
+++ b/cpp/server/log_processes.cc
@@ -1,0 +1,61 @@
+#include "server/log_processes.h"
+
+#include <chrono>
+#include <functional>
+#include <gflags/gflags.h>
+
+#include "monitoring/latency.h"
+#include "monitoring/monitoring.h"
+#include "server/metrics.h"
+
+DEFINE_int32(sequencing_frequency_seconds, 10,
+             "How often should new entries be sequenced. The sequencing runs "
+             "in parallel with the tree signing and cleanup.");
+
+using cert_trans::Counter;
+using cert_trans::Latency;
+using std::function;
+using std::chrono::milliseconds;
+using std::chrono::seconds;
+using std::chrono::steady_clock;
+
+namespace {
+
+Counter<bool>* sequencer_total_runs = Counter<bool>::New(
+    "sequencer_total_runs", "successful",
+    "Total number of sequencer runs broken out by success.");
+Latency<milliseconds> sequencer_sequence_latency_ms(
+    "sequencer_sequence_latency_ms",
+    "Total time spent sequencing entries by sequencer");
+}
+
+namespace cert_trans {
+void SequenceEntries(TreeSigner<LoggedEntry>* tree_signer,
+                     const function<bool()>& is_master) {
+  CHECK_NOTNULL(tree_signer);
+  CHECK(is_master);
+  const steady_clock::duration period(
+      (seconds(FLAGS_sequencing_frequency_seconds)));
+  steady_clock::time_point target_run_time(steady_clock::now());
+
+  while (true) {
+    if (is_master()) {
+      const ScopedLatency sequencer_sequence_latency(
+          sequencer_sequence_latency_ms.GetScopedLatency());
+      util::Status status(tree_signer->SequenceNewEntries());
+      if (!status.ok()) {
+        LOG(WARNING) << "Problem sequencing new entries: " << status;
+      }
+      sequencer_total_runs->Increment(status.ok());
+    }
+
+    const steady_clock::time_point now(steady_clock::now());
+    while (target_run_time <= now) {
+      target_run_time += period;
+    }
+
+    std::this_thread::sleep_for(target_run_time - now);
+  }
+}
+
+}  // namespace cert_trans

--- a/cpp/server/log_processes.h
+++ b/cpp/server/log_processes.h
@@ -1,0 +1,20 @@
+#ifndef CERT_TRANS_SERVER_LOG_PROCESSES_H_
+#define CERT_TRANS_SERVER_LOG_PROCESSES_H_
+
+#include <functional>
+
+#include "log/logged_entry.h"
+#include "log/tree_signer.h"
+
+namespace cert_trans {
+
+// Common processes that are called by server threads at intervals. This
+// code is shared by binaries that write to logs, currently ct-server
+// (all versions) and xjson-server.
+
+void SequenceEntries(TreeSigner<LoggedEntry>* tree_signer,
+                     const std::function<bool()>& is_master);
+
+}
+
+#endif  // CERT_TRANS_SERVER_LOG_PROCESSES_H_

--- a/cpp/server/xjson-server.cc
+++ b/cpp/server/xjson-server.cc
@@ -25,6 +25,7 @@
 #include "monitoring/latency.h"
 #include "monitoring/monitoring.h"
 #include "monitoring/registry.h"
+#include "server/log_processes.h"
 #include "server/metrics.h"
 #include "server/server.h"
 #include "server/server_helper.h"
@@ -41,9 +42,6 @@
 DEFINE_string(server, "localhost", "Server host");
 DEFINE_int32(port, 9999, "Server port");
 DEFINE_string(key, "", "PEM-encoded server private key file");
-DEFINE_int32(sequencing_frequency_seconds, 10,
-             "How often should new entries be sequenced. The sequencing runs "
-             "in parallel with the tree signing and cleanup.");
 DEFINE_int32(cleanup_frequency_seconds, 10,
              "How often should new entries be cleanedup. The cleanup runs in "
              "in parallel with the tree signing and sequencing.");
@@ -80,6 +78,7 @@ using cert_trans::LevelDB;
 using cert_trans::LoggedEntry;
 using cert_trans::ReadPrivateKey;
 using cert_trans::ScopedLatency;
+using cert_trans::SequenceEntries;
 using cert_trans::Server;
 using cert_trans::SplitHosts;
 using cert_trans::ThreadPool;
@@ -112,13 +111,6 @@ namespace {
 Gauge<>* latest_local_tree_size_gauge =
     Gauge<>::New("latest_local_tree_size",
                  "Size of latest locally generated STH.");
-
-Counter<bool>* sequencer_total_runs = Counter<bool>::New(
-    "sequencer_total_runs", "successful",
-    "Total number of sequencer runs broken out by success.");
-Latency<milliseconds> sequencer_sequence_latency_ms(
-    "sequencer_sequence_latency_ms",
-    "Total time spent sequencing entries by sequencer");
 
 Counter<bool>* signer_total_runs =
     Counter<bool>::New("signer_total_runs", "successful",
@@ -196,33 +188,6 @@ void CleanUpEntries(ConsistentStore<LoggedEntry>* store,
   }
 }
 
-void SequenceEntries(TreeSigner<LoggedEntry>* tree_signer,
-                     const function<bool()>& is_master) {
-  CHECK_NOTNULL(tree_signer);
-  CHECK(is_master);
-  const steady_clock::duration period(
-      (seconds(FLAGS_sequencing_frequency_seconds)));
-  steady_clock::time_point target_run_time(steady_clock::now());
-
-  while (true) {
-    if (is_master()) {
-      const ScopedLatency sequencer_sequence_latency(
-          sequencer_sequence_latency_ms.GetScopedLatency());
-      util::Status status(tree_signer->SequenceNewEntries());
-      if (!status.ok()) {
-        LOG(WARNING) << "Problem sequencing new entries: " << status;
-      }
-      sequencer_total_runs->Increment(status.ok());
-    }
-
-    const steady_clock::time_point now(steady_clock::now());
-    while (target_run_time <= now) {
-      target_run_time += period;
-    }
-
-    std::this_thread::sleep_for(target_run_time - now);
-  }
-}
 
 void SignMerkleTree(TreeSigner<LoggedEntry>* tree_signer,
                     ConsistentStore<LoggedEntry>* store,


### PR DESCRIPTION
Move SequenceEntries out of ct-server so it can be shared by xjson and ct v2. Going to move signing and cleanup in same way but doing it in stages.