### PR TITLE
Add the infrastructure for v2 versions of ct-server and ct-mirror 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,9 @@
 /cpp/server/blob-server
 /cpp/server/ct-dns-server
 /cpp/server/ct-mirror
+/cpp/server/ct-mirror-v2
 /cpp/server/ct-server
+/cpp/server/ct-server-v2
 /cpp/server/proxy_test
 /cpp/server/xjson-server
 /cpp/stamp-h1

--- a/Makefile.am
+++ b/Makefile.am
@@ -32,7 +32,9 @@ cpp/version.o: \
 bin_PROGRAMS = \
 	cpp/client/ct \
 	cpp/server/ct-mirror \
+	cpp/server/ct-mirror-v2 \
 	cpp/server/ct-server \
+	cpp/server/ct-server-v2 \
 	cpp/server/xjson-server \
 	cpp/tools/ct-clustertool
 
@@ -213,10 +215,24 @@ cpp_server_ct_mirror_LDADD = \
 	$(leveldb_LIBS) \
 	-lprotobuf -lsqlite3
 cpp_server_ct_mirror_SOURCES = \
-  cpp/client/async_log_client.cc \
+	cpp/client/async_log_client.cc \
 	cpp/server/ct-mirror.cc \
 	cpp/server/certificate_handler.cc \
 	cpp/server/handler.cc \
+	cpp/server/json_output.cc \
+	cpp/server/server_helper.cc
+
+cpp_server_ct_mirror_v2_LDADD = \
+	cpp/libcore.a \
+	$(json_c_LIBS) \
+	$(libevent_LIBS) \
+	$(leveldb_LIBS) \
+	-lprotobuf -lsqlite3
+cpp_server_ct_mirror_v2_SOURCES = \
+	cpp/client/async_log_client.cc \
+	cpp/server/ct-mirror_v2.cc \
+	cpp/server/certificate_handler_v2.cc \
+	cpp/server/handler_v2.cc \
 	cpp/server/json_output.cc \
 	cpp/server/server_helper.cc
 
@@ -227,12 +243,27 @@ cpp_server_ct_server_LDADD = \
 	$(leveldb_LIBS) \
 	-lprotobuf -lsqlite3
 cpp_server_ct_server_SOURCES = \
-  cpp/client/async_log_client.cc \
+	cpp/client/async_log_client.cc \
 	cpp/server/ct-server.cc \
 	cpp/server/certificate_handler.cc \
 	cpp/server/handler.cc \
 	cpp/server/json_output.cc \
-        cpp/server/log_processes.cc \
+	cpp/server/log_processes.cc \
+	cpp/server/server_helper.cc
+
+cpp_server_ct_server_v2_LDADD = \
+	cpp/libcore.a \
+	$(json_c_LIBS) \
+	$(libevent_LIBS) \
+	$(leveldb_LIBS) \
+	-lprotobuf -lsqlite3
+cpp_server_ct_server_v2_SOURCES = \
+	cpp/client/async_log_client.cc \
+	cpp/server/ct-server_v2.cc \
+	cpp/server/certificate_handler_v2.cc \
+	cpp/server/handler_v2.cc \
+	cpp/server/json_output.cc \
+	cpp/server/log_processes.cc \
 	cpp/server/server_helper.cc
 
 cpp_server_xjson_server_LDADD = \
@@ -242,10 +273,10 @@ cpp_server_xjson_server_LDADD = \
 	$(leveldb_LIBS) \
 	-lprotobuf -lsqlite3
 cpp_server_xjson_server_SOURCES = \
-  cpp/client/async_log_client.cc \
+	cpp/client/async_log_client.cc \
 	cpp/server/handler.cc \
 	cpp/server/json_output.cc \
-        cpp/server/log_processes.cc \
+	cpp/server/log_processes.cc \
 	cpp/server/server_helper.cc \
 	cpp/server/xjson-server.cc \
 	cpp/server/x_json_handler.cc \

--- a/cpp/server/certificate_handler.h
+++ b/cpp/server/certificate_handler.h
@@ -32,7 +32,6 @@ class CertificateHttpHandler : public HttpHandler {
   const CertSubmissionHandler submission_handler_;
   Frontend* const frontend_;
 
-  void GetEntries(evhttp_request* req) const;
   void GetRoots(evhttp_request* req) const;
   void AddChain(evhttp_request* req);
   void AddPreChain(evhttp_request* req);

--- a/cpp/server/certificate_handler_v2.cc
+++ b/cpp/server/certificate_handler_v2.cc
@@ -1,0 +1,103 @@
+#include <functional>
+
+#include "log/frontend.h"
+#include "server/certificate_handler_v2.h"
+#include "server/json_output.h"
+#include "util/json_wrapper.h"
+#include "util/status.h"
+#include "util/thread_pool.h"
+
+namespace cert_trans {
+
+using ct::LogEntry;
+using ct::SignedCertificateTimestamp;
+using std::bind;
+using std::make_shared;
+using std::multimap;
+using std::placeholders::_1;
+using std::shared_ptr;
+using std::string;
+using std::unique_ptr;
+using util::Status;
+
+
+namespace {
+
+
+bool ExtractChain(libevent::Base* base, evhttp_request* req,
+                  CertChain* chain) {
+  SendJsonError(base, req, HTTP_NOTIMPLEMENTED, "Not yet implemented.");
+  return false;
+}
+
+
+}  // namespace
+
+
+CertificateHttpHandlerV2::CertificateHttpHandlerV2(
+    LogLookup* log_lookup, const ReadOnlyDatabase* db,
+    const ClusterStateController<LoggedEntry>* controller,
+    const CertChecker* cert_checker, Frontend* frontend, ThreadPool* pool,
+    libevent::Base* event_base, StalenessTracker* staleness_tracker)
+    : HttpHandlerV2(log_lookup, db, controller, pool, event_base,
+                    staleness_tracker),
+      cert_checker_(CHECK_NOTNULL(cert_checker)),
+      submission_handler_(cert_checker_),
+      frontend_(frontend) {
+}
+
+
+void CertificateHttpHandlerV2::AddHandlers(libevent::HttpServer* server) {
+  // TODO(alcutter): Support this for mirrors too
+  if (cert_checker_) {
+    // Don't really need to proxy this one, but may as well just to keep
+    // everything tidy:
+    AddProxyWrappedHandler(server, "/ct/v2/get-roots",
+                           bind(&CertificateHttpHandlerV2::GetRoots, this, _1));
+  }
+  if (frontend_) {
+    // Proxy the add-* calls too, technically we could serve them, but a
+    // more up-to-date node will have a better chance of handling dupes
+    // correctly, rather than bloating the tree.
+    AddProxyWrappedHandler(server, "/ct/v2/add-chain",
+                           bind(&CertificateHttpHandlerV2::AddChain, this, _1));
+    AddProxyWrappedHandler(server, "/ct/v2/add-pre-chain",
+                           bind(&CertificateHttpHandlerV2::AddPreChain, this,
+                                _1));
+  }
+}
+
+
+void CertificateHttpHandlerV2::GetRoots(evhttp_request* req) const {
+  return SendJsonError(event_base_, req, HTTP_NOTIMPLEMENTED,
+                       "Not yet implemented.");
+}
+
+
+void CertificateHttpHandlerV2::AddChain(evhttp_request* req) {
+  return SendJsonError(event_base_, req, HTTP_NOTIMPLEMENTED,
+                       "Not yet implemented.");
+}
+
+
+void CertificateHttpHandlerV2::AddPreChain(evhttp_request* req) {
+  return SendJsonError(event_base_, req, HTTP_NOTIMPLEMENTED,
+                       "Not yet implemented.");
+}
+
+
+void CertificateHttpHandlerV2::BlockingAddChain(
+    evhttp_request* req, const shared_ptr<CertChain>& chain) const {
+  return SendJsonError(event_base_, req, HTTP_NOTIMPLEMENTED,
+                       "Not yet implemented.");
+}
+
+
+void CertificateHttpHandlerV2::BlockingAddPreChain(
+    evhttp_request* req, const shared_ptr<PreCertChain>& chain) const {
+  return SendJsonError(event_base_, req, HTTP_NOTIMPLEMENTED,
+                       "Not yet implemented.");
+}
+
+
+}  // namespace cert_trans

--- a/cpp/server/certificate_handler_v2.cc
+++ b/cpp/server/certificate_handler_v2.cc
@@ -21,19 +21,6 @@ using std::unique_ptr;
 using util::Status;
 
 
-namespace {
-
-
-bool ExtractChain(libevent::Base* base, evhttp_request* req,
-                  CertChain* chain) {
-  SendJsonError(base, req, HTTP_NOTIMPLEMENTED, "Not yet implemented.");
-  return false;
-}
-
-
-}  // namespace
-
-
 CertificateHttpHandlerV2::CertificateHttpHandlerV2(
     LogLookup* log_lookup, const ReadOnlyDatabase* db,
     const ClusterStateController<LoggedEntry>* controller,

--- a/cpp/server/certificate_handler_v2.h
+++ b/cpp/server/certificate_handler_v2.h
@@ -32,7 +32,6 @@ class CertificateHttpHandlerV2 : public HttpHandlerV2 {
   const CertSubmissionHandler submission_handler_;
   Frontend* const frontend_;
 
-  void GetEntries(evhttp_request* req) const;
   void GetRoots(evhttp_request* req) const;
   void AddChain(evhttp_request* req);
   void AddPreChain(evhttp_request* req);

--- a/cpp/server/certificate_handler_v2.h
+++ b/cpp/server/certificate_handler_v2.h
@@ -1,0 +1,52 @@
+#ifndef CERT_TRANS_SERVER_CERTIFICATE_HANDLER_V2_H_
+#define CERT_TRANS_SERVER_CERTIFICATE_HANDLER_V2_H_
+
+#include "log/cert_submission_handler.h"
+#include "log/database.h"
+#include "log/logged_entry.h"
+#include "server/handler_v2.h"
+#include "server/staleness_tracker.h"
+
+namespace cert_trans {
+
+
+class CertificateHttpHandlerV2 : public HttpHandlerV2 {
+ public:
+  // Does not take ownership of its parameters, which must outlive
+  // this instance. The |frontend| and |cert_checker| parameters can be NULL,
+  // in which case this server will not accept "add-chain" and "add-pre-chain"
+  // requests.
+  CertificateHttpHandlerV2(LogLookup* log_lookup, const ReadOnlyDatabase* db,
+                         const ClusterStateController<LoggedEntry>* controller,
+                         const CertChecker* cert_checker, Frontend* frontend,
+                         ThreadPool* pool, libevent::Base* event_base,
+                         StalenessTracker* staleness_tracker);
+
+  ~CertificateHttpHandlerV2() = default;
+
+ protected:
+  void AddHandlers(libevent::HttpServer* server) override;
+
+ private:
+  const CertChecker* const cert_checker_;
+  const CertSubmissionHandler submission_handler_;
+  Frontend* const frontend_;
+
+  void GetEntries(evhttp_request* req) const;
+  void GetRoots(evhttp_request* req) const;
+  void AddChain(evhttp_request* req);
+  void AddPreChain(evhttp_request* req);
+
+  void BlockingAddChain(evhttp_request* req,
+                        const std::shared_ptr<CertChain>& chain) const;
+  void BlockingAddPreChain(evhttp_request* req,
+                           const std::shared_ptr<PreCertChain>& chain) const;
+
+  DISALLOW_COPY_AND_ASSIGN(CertificateHttpHandlerV2);
+};
+
+
+}  // namespace cert_trans
+
+
+#endif  // CERT_TRANS_SERVER_CERTIFICATE_HANDLER_V2_H_

--- a/cpp/server/ct-mirror_v2.cc
+++ b/cpp/server/ct-mirror_v2.cc
@@ -1,0 +1,365 @@
+/* -*- indent-tabs-mode: nil -*- */
+
+#include <gflags/gflags.h>
+#include <iostream>
+#include <signal.h>
+#include <string>
+#include <unistd.h>
+#include <utility>
+
+#include "client/async_log_client.h"
+#include "config.h"
+#include "fetcher/continuous_fetcher.h"
+#include "fetcher/peer_group.h"
+#include "fetcher/remote_peer.h"
+#include "log/cluster_state_controller.h"
+#include "log/ct_extensions.h"
+#include "log/database.h"
+#include "log/etcd_consistent_store.h"
+#include "log/log_lookup.h"
+#include "log/strict_consistent_store.h"
+#include "merkletree/compact_merkle_tree.h"
+#include "merkletree/merkle_verifier.h"
+#include "monitoring/latency.h"
+#include "monitoring/monitoring.h"
+#include "monitoring/registry.h"
+#include "server/certificate_handler_v2.h"
+#include "server/json_output.h"
+#include "server/metrics.h"
+#include "server/proxy.h"
+#include "server/server.h"
+#include "server/server_helper.h"
+#include "util/etcd.h"
+#include "util/init.h"
+#include "util/libevent_wrapper.h"
+#include "util/masterelection.h"
+#include "util/periodic_closure.h"
+#include "util/read_key.h"
+#include "util/status.h"
+#include "util/thread_pool.h"
+#include "util/util.h"
+#include "util/uuid.h"
+
+DEFINE_int32(log_stats_frequency_seconds, 3600,
+             "Interval for logging summary statistics. Approximate: the "
+             "server will log statistics if in the beginning of its select "
+             "loop, at least this period has elapsed since the last log time. "
+             "Must be greater than 0.");
+DEFINE_int32(target_poll_frequency_seconds, 10,
+             "How often should the target log be polled for updates.");
+DEFINE_int32(num_http_server_threads, 16,
+             "Number of threads for servicing the incoming HTTP requests.");
+DEFINE_string(target_log_uri, "http://ct.googleapis.com/pilot",
+              "URI of the log to mirror.");
+DEFINE_string(
+    target_public_key, "",
+    "PEM-encoded server public key file of the log we're mirroring.");
+DEFINE_int32(local_sth_update_frequency_seconds, 30,
+             "Number of seconds between local checks for updated tree data.");
+
+namespace libevent = cert_trans::libevent;
+
+using cert_trans::AsyncLogClient;
+using cert_trans::CertificateHttpHandlerV2;
+using cert_trans::ClusterStateController;
+using cert_trans::ConsistentStore;
+using cert_trans::ContinuousFetcher;
+using cert_trans::Counter;
+using cert_trans::Database;
+using cert_trans::EtcdClient;
+using cert_trans::EtcdConsistentStore;
+using cert_trans::Gauge;
+using cert_trans::Latency;
+using cert_trans::LogLookup;
+using cert_trans::LoggedEntry;
+using cert_trans::MasterElection;
+using cert_trans::PeriodicClosure;
+using cert_trans::Proxy;
+using cert_trans::ReadPublicKey;
+using cert_trans::RemotePeer;
+using cert_trans::ScopedLatency;
+using cert_trans::Server;
+using cert_trans::StalenessTracker;
+using cert_trans::StrictConsistentStore;
+using cert_trans::ThreadPool;
+using cert_trans::Update;
+using cert_trans::UrlFetcher;
+using ct::ClusterNodeState;
+using ct::SignedTreeHead;
+using google::RegisterFlagValidator;
+using std::bind;
+using std::chrono::duration;
+using std::chrono::duration_cast;
+using std::chrono::milliseconds;
+using std::chrono::seconds;
+using std::chrono::steady_clock;
+using std::function;
+using std::lock_guard;
+using std::make_pair;
+using std::make_shared;
+using std::map;
+using std::mutex;
+using std::placeholders::_1;
+using std::shared_ptr;
+using std::string;
+using std::thread;
+using std::unique_ptr;
+using util::HexString;
+using util::StatusOr;
+using util::SyncTask;
+using util::Task;
+
+
+namespace {
+
+
+Gauge<>* latest_local_tree_size_gauge =
+    Gauge<>::New("latest_local_tree_size",
+                 "Size of latest locally available STH.");
+
+Counter<>* inconsistent_sths_received =
+    Counter<>::New("inconsistent_sths_received",
+                   "Number of STHs received from the mirror target whose root "
+                   "hash does not match the locally built tree.");
+
+
+// Basic sanity checks on flag values.
+static bool ValidateRead(const char* flagname, const string& path) {
+  if (access(path.c_str(), R_OK) != 0) {
+    std::cout << "Cannot access " << flagname << " at " << path << std::endl;
+    return false;
+  }
+  return true;
+}
+
+static const bool pubkey_dummy =
+    RegisterFlagValidator(&FLAGS_target_public_key, &ValidateRead);
+
+static bool ValidateIsPositive(const char* flagname, int value) {
+  if (value <= 0) {
+    std::cout << flagname << " must be greater than 0" << std::endl;
+    return false;
+  }
+  return true;
+}
+
+static const bool follow_dummy =
+    RegisterFlagValidator(&FLAGS_target_poll_frequency_seconds,
+                          &ValidateIsPositive);
+}  // namespace
+
+
+void STHUpdater(Database* db,
+                ClusterStateController<LoggedEntry>* cluster_state_controller,
+                mutex* queue_mutex, map<int64_t, ct::SignedTreeHead>* queue,
+                LogLookup* log_lookup, Task* task) {
+  CHECK_NOTNULL(db);
+  CHECK_NOTNULL(cluster_state_controller);
+  CHECK_NOTNULL(queue_mutex);
+  CHECK_NOTNULL(queue);
+  CHECK_NOTNULL(task);
+  CHECK_NOTNULL(log_lookup);
+
+  while (true) {
+    if (task->CancelRequested()) {
+      task->Return(util::Status::CANCELLED);
+    }
+
+    const int64_t local_size(db->TreeSize());
+    latest_local_tree_size_gauge->Set(local_size);
+
+    // log_lookup doesn't yet have the data for the new STHs integrated (that
+    // happens via a callback when the WriteTreeHead() method is called on the
+    // DB), so we'll used a compact tree to pre-validate the STH roots.
+    //
+    // We'll start with one based on the current state of our serving tree and
+    // update it to the STH sizes we're checking.
+    unique_ptr<CompactMerkleTree> new_tree(
+        log_lookup->GetCompactMerkleTree(new Sha256Hasher));
+
+    {
+      lock_guard<mutex> lock(*queue_mutex);
+      unique_ptr<Database::Iterator> entries(
+          db->ScanEntries(new_tree->LeafCount()));
+      while (!queue->empty() &&
+             queue->begin()->second.tree_size() <= local_size) {
+        const SignedTreeHead next_sth(queue->begin()->second);
+        queue->erase(queue->begin());
+
+        // First, if necessary, catch our local compact tree up to the
+        // candidate STH size:
+        {
+          LoggedEntry entry;
+          CHECK_LE(next_sth.tree_size(), local_size);
+          CHECK_GE(next_sth.tree_size(), 0);
+          const uint64_t next_sth_tree_size(
+              static_cast<uint64_t>(next_sth.tree_size()));
+          while (new_tree->LeafCount() < next_sth_tree_size) {
+            CHECK(entries->GetNextEntry(&entry));
+            CHECK(entry.has_sequence_number());
+            CHECK_GE(entry.sequence_number(), 0);
+            const uint64_t entry_sequence_number(
+                static_cast<uint64_t>(entry.sequence_number()));
+            CHECK_EQ(new_tree->LeafCount(), entry_sequence_number);
+            string serialized_leaf;
+            CHECK(entry.SerializeForLeaf(&serialized_leaf));
+            CHECK_EQ(entry_sequence_number + 1,
+                     new_tree->AddLeaf(serialized_leaf));
+          }
+        }
+
+        // If the candidate STH is historical, use the RootAtSnapshot() from
+        // our serving tree, otherwise use the root we just calculated with our
+        // compact tree.
+        const string local_root_at_snapshot(
+            next_sth.tree_size() > log_lookup->GetSTH().tree_size()
+                ? new_tree->CurrentRoot()
+                : log_lookup->RootAtSnapshot(next_sth.tree_size()));
+
+        if (next_sth.sha256_root_hash() != local_root_at_snapshot) {
+          LOG(WARNING) << "Received STH:\n" << next_sth.DebugString()
+                       << " whose root:\n"
+                       << HexString(next_sth.sha256_root_hash())
+                       << "\ndoes not match that of local tree at "
+                       << "corresponding snapshot:\n"
+                       << HexString(local_root_at_snapshot);
+          inconsistent_sths_received->Increment();
+          // TODO(alcutter): We should probably write these bad STHs out to a
+          // separate DB table for later analysis.
+          continue;
+        }
+        LOG(INFO) << "Can serve new STH of size " << next_sth.tree_size()
+                  << " locally";
+        cluster_state_controller->NewTreeHead(next_sth);
+      }
+    }
+
+    std::this_thread::sleep_for(
+        seconds(FLAGS_local_sth_update_frequency_seconds));
+  }
+}
+
+
+int main(int argc, char* argv[]) {
+  // Ignore various signals whilst we start up.
+  signal(SIGHUP, SIG_IGN);
+  signal(SIGINT, SIG_IGN);
+  signal(SIGTERM, SIG_IGN);
+
+  util::InitCT(&argc, &argv);
+
+  Server::StaticInit();
+
+  cert_trans::EnsureValidatorsRegistered();
+  const unique_ptr<Database> db(cert_trans::ProvideDatabase());
+  CHECK(db) << "No database instance created, check flag settings";
+
+  const bool stand_alone_mode(cert_trans::IsStandalone(false));
+  const shared_ptr<libevent::Base> event_base(make_shared<libevent::Base>());
+  ThreadPool internal_pool(8);
+  UrlFetcher url_fetcher(event_base.get(), &internal_pool);
+
+  const unique_ptr<EtcdClient> etcd_client(
+      cert_trans::ProvideEtcdClient(event_base.get(), &internal_pool,
+                                    &url_fetcher));
+
+  CHECK(!FLAGS_target_public_key.empty());
+  const StatusOr<EVP_PKEY*> pubkey(ReadPublicKey(FLAGS_target_public_key));
+  CHECK(pubkey.ok()) << "Failed to read target log's public key file: "
+                     << pubkey.status();
+
+  const LogVerifier log_verifier(new LogSigVerifier(pubkey.ValueOrDie()),
+                                 new MerkleVerifier(new Sha256Hasher));
+
+  ThreadPool http_pool(FLAGS_num_http_server_threads);
+
+  Server server(event_base, &internal_pool, &http_pool, db.get(),
+                etcd_client.get(), &url_fetcher, &log_verifier);
+  server.Initialise(true /* is_mirror */);
+
+  unique_ptr<StalenessTracker> staleness_tracker(
+      new StalenessTracker(server.cluster_state_controller(), &internal_pool,
+                           event_base.get()));
+
+  CertificateHttpHandlerV2 handler(server.log_lookup(), db.get(),
+                                 server.cluster_state_controller(),
+                                 nullptr /* checker */, nullptr /* Frontend */,
+                                 &internal_pool, event_base.get(),
+                                 staleness_tracker.get());
+
+  // Connect the handler, proxy and server together
+  handler.SetProxy(server.proxy());
+  handler.Add(server.http_server());
+
+  if (stand_alone_mode) {
+    // Set up a simple single-node mirror environment for testing.
+    //
+    // Put a sensible single-node config into FakeEtcd. For a real clustered
+    // log
+    // we'd expect a ClusterConfig already to be present within etcd as part of
+    // the provisioning of the log.
+    //
+    // TODO(alcutter): Note that we're currently broken wrt to restarting the
+    // log server when there's data in the log.  It's a temporary thing though,
+    // so fear ye not.
+    ct::ClusterConfig config;
+    config.set_minimum_serving_nodes(1);
+    config.set_minimum_serving_fraction(1);
+    LOG(INFO) << "Setting default single-node ClusterConfig:\n"
+              << config.DebugString();
+    server.consistent_store()->SetClusterConfig(config);
+
+    // Since we're a single node cluster, we'll settle that we're the
+    // master here, so that we can populate the initial STH
+    // (StrictConsistentStore won't allow us to do so unless we're master.)
+    server.election()->StartElection();
+    server.election()->WaitToBecomeMaster();
+  }
+
+  CHECK(!FLAGS_target_log_uri.empty());
+
+  ThreadPool pool(16);
+  SyncTask fetcher_task(&pool);
+
+  mutex queue_mutex;
+  map<int64_t, ct::SignedTreeHead> queue;
+
+  const function<void(const ct::SignedTreeHead&)> new_sth(
+      [&queue_mutex, &queue](const ct::SignedTreeHead& sth) {
+        lock_guard<mutex> lock(queue_mutex);
+        const auto it(queue.find(sth.tree_size()));
+        if (it != queue.end() && sth.timestamp() < it->second.timestamp()) {
+          LOG(WARNING) << "Received older STH:\nHad:\n"
+                       << it->second.DebugString() << "\nGot:\n"
+                       << sth.DebugString();
+          return;
+        }
+        queue.insert(make_pair(sth.tree_size(), sth));
+      });
+
+  const shared_ptr<RemotePeer> peer(make_shared<RemotePeer>(
+      unique_ptr<AsyncLogClient>(
+          new AsyncLogClient(&pool, &url_fetcher, FLAGS_target_log_uri)),
+      unique_ptr<LogVerifier>(
+          new LogVerifier(new LogSigVerifier(pubkey.ValueOrDie()),
+                          new MerkleVerifier(new Sha256Hasher))),
+      new_sth, fetcher_task.task()->AddChild(
+                   [](Task*) { LOG(INFO) << "RemotePeer exited."; })));
+
+  server.continuous_fetcher()->AddPeer("target", peer);
+
+  server.WaitForReplication();
+
+  thread sth_updater(&STHUpdater, db.get(), server.cluster_state_controller(),
+                     &queue_mutex, &queue, server.log_lookup(),
+                     fetcher_task.task()->AddChild(
+                         [](Task*) { LOG(INFO) << "STHUpdater exited."; }));
+
+  server.Run();
+
+  fetcher_task.task()->Return();
+  fetcher_task.Wait();
+  sth_updater.join();
+
+  return 0;
+}

--- a/cpp/server/ct-server_v2.cc
+++ b/cpp/server/ct-server_v2.cc
@@ -1,0 +1,211 @@
+/* -*- indent-tabs-mode: nil -*- */
+
+#include <gflags/gflags.h>
+#include <iostream>
+#include <signal.h>
+#include <string>
+#include <unistd.h>
+
+#include "config.h"
+#include "log/cert_checker.h"
+#include "log/cert_submission_handler.h"
+#include "log/cluster_state_controller.h"
+#include "log/etcd_consistent_store.h"
+#include "log/frontend_signer.h"
+#include "log/frontend.h"
+#include "log/log_lookup.h"
+#include "log/log_signer.h"
+#include "log/log_verifier.h"
+#include "log/strict_consistent_store.h"
+#include "log/tree_signer.h"
+#include "merkletree/merkle_verifier.h"
+#include "server/certificate_handler_v2.h"
+#include "server/log_processes.h"
+#include "server/server.h"
+#include "server/server_helper.h"
+#include "server/staleness_tracker.h"
+#include "util/etcd.h"
+#include "util/init.h"
+#include "util/libevent_wrapper.h"
+#include "util/read_key.h"
+#include "util/status.h"
+#include "util/uuid.h"
+
+DEFINE_string(key, "", "PEM-encoded server private key file");
+DEFINE_string(trusted_cert_file, "",
+              "File for trusted CA certificates, in concatenated PEM format");
+DEFINE_double(guard_window_seconds, 60,
+              "Unsequenced entries newer than this "
+              "number of seconds will not be sequenced.");
+DEFINE_int32(num_http_server_threads, 16,
+             "Number of threads for servicing the incoming HTTP requests.");
+
+namespace libevent = cert_trans::libevent;
+
+using cert_trans::CertChecker;
+using cert_trans::CertificateHttpHandlerV2;
+using cert_trans::CleanUpEntries;
+using cert_trans::ClusterStateController;
+using cert_trans::ConsistentStore;
+using cert_trans::Database;
+using cert_trans::EtcdClient;
+using cert_trans::EtcdConsistentStore;
+using cert_trans::LoggedEntry;
+using cert_trans::ReadPrivateKey;
+using cert_trans::SequenceEntries;
+using cert_trans::Server;
+using cert_trans::SignMerkleTree;
+using cert_trans::StalenessTracker;
+using cert_trans::ThreadPool;
+using cert_trans::TreeSigner;
+using cert_trans::UrlFetcher;
+using ct::ClusterNodeState;
+using ct::SignedTreeHead;
+using google::RegisterFlagValidator;
+using std::bind;
+using std::function;
+using std::make_shared;
+using std::shared_ptr;
+using std::string;
+using std::thread;
+using std::unique_ptr;
+
+
+namespace {
+
+// Basic sanity checks on flag values.
+static bool ValidateRead(const char* flagname, const string& path) {
+  if (access(path.c_str(), R_OK) != 0) {
+    std::cout << "Cannot access " << flagname << " at " << path << std::endl;
+    return false;
+  }
+  return true;
+}
+
+static const bool key_dummy = RegisterFlagValidator(&FLAGS_key, &ValidateRead);
+
+static const bool cert_dummy =
+    RegisterFlagValidator(&FLAGS_trusted_cert_file, &ValidateRead);
+
+}  // namespace
+
+
+int main(int argc, char* argv[]) {
+  // Ignore various signals whilst we start up.
+  signal(SIGHUP, SIG_IGN);
+  signal(SIGINT, SIG_IGN);
+  signal(SIGTERM, SIG_IGN);
+
+  util::InitCT(&argc, &argv);
+
+  Server::StaticInit();
+
+  util::StatusOr<EVP_PKEY*> pkey(ReadPrivateKey(FLAGS_key));
+  CHECK_EQ(pkey.status(), util::Status::OK);
+  LogSigner log_signer(pkey.ValueOrDie());
+
+  CertChecker checker;
+  CHECK(checker.LoadTrustedCertificates(FLAGS_trusted_cert_file))
+      << "Could not load CA certs from " << FLAGS_trusted_cert_file;
+
+  cert_trans::EnsureValidatorsRegistered();
+  const unique_ptr<Database> db(cert_trans::ProvideDatabase());
+  CHECK(db) << "No database instance created, check flag settings";
+
+  shared_ptr<libevent::Base> event_base(make_shared<libevent::Base>());
+  ThreadPool internal_pool(8);
+  UrlFetcher url_fetcher(event_base.get(), &internal_pool);
+
+  const bool stand_alone_mode(cert_trans::IsStandalone(true));
+  LOG(INFO) << "Running in "
+            << (stand_alone_mode ? "STAND-ALONE" : "CLUSTERED") << " mode.";
+
+  unique_ptr<EtcdClient> etcd_client(
+      cert_trans::ProvideEtcdClient(event_base.get(), &internal_pool,
+                                    &url_fetcher));
+
+  const LogVerifier log_verifier(new LogSigVerifier(pkey.ValueOrDie()),
+                                 new MerkleVerifier(new Sha256Hasher));
+
+  ThreadPool http_pool(FLAGS_num_http_server_threads);
+
+  Server server(event_base, &internal_pool, &http_pool,
+                db.get(), etcd_client.get(), &url_fetcher, &log_verifier);
+  server.Initialise(false /* is_mirror */);
+
+  Frontend frontend(
+      new FrontendSigner(db.get(), server.consistent_store(), &log_signer));
+  unique_ptr<StalenessTracker> staleness_tracker(
+      new StalenessTracker(server.cluster_state_controller(), &internal_pool,
+                           event_base.get()));
+  CertificateHttpHandlerV2 handler(server.log_lookup(), db.get(),
+                                 server.cluster_state_controller(), &checker,
+                                 &frontend, &internal_pool, event_base.get(),
+                                 staleness_tracker.get());
+
+  // Connect the handler, proxy and server together
+  handler.SetProxy(server.proxy());
+  handler.Add(server.http_server());
+
+  TreeSigner<LoggedEntry> tree_signer(
+      std::chrono::duration<double>(FLAGS_guard_window_seconds), db.get(),
+      server.log_lookup()->GetCompactMerkleTree(new Sha256Hasher),
+      server.consistent_store(), &log_signer);
+
+  if (stand_alone_mode) {
+    // Set up a simple single-node environment.
+    //
+    // Put a sensible single-node config into FakeEtcd. For a real clustered
+    // log
+    // we'd expect a ClusterConfig already to be present within etcd as part of
+    // the provisioning of the log.
+    //
+    // TODO(alcutter): Note that we're currently broken wrt to restarting the
+    // log server when there's data in the log.  It's a temporary thing though,
+    // so fear ye not.
+    ct::ClusterConfig config;
+    config.set_minimum_serving_nodes(1);
+    config.set_minimum_serving_fraction(1);
+    LOG(INFO) << "Setting default single-node ClusterConfig:\n"
+              << config.DebugString();
+    server.consistent_store()->SetClusterConfig(config);
+
+    // Since we're a single node cluster, we'll settle that we're the
+    // master here, so that we can populate the initial STH
+    // (StrictConsistentStore won't allow us to do so unless we're master.)
+    server.election()->StartElection();
+    server.election()->WaitToBecomeMaster();
+
+    {
+      EtcdClient::Response resp;
+      util::SyncTask task(event_base.get());
+      etcd_client->Create("/root/sequence_mapping", "", &resp, task.task());
+      task.Wait();
+      CHECK_EQ(util::Status::OK, task.status());
+    }
+
+    // Do an initial signing run to get the initial STH, again this is
+    // temporary until we re-populate FakeEtcd from the DB.
+    CHECK_EQ(tree_signer.UpdateTree(), TreeSigner<LoggedEntry>::OK);
+
+    // Need to boot-strap the Serving STH too because we consider it an error
+    // if it's not set, which in turn causes us to not attempt to become
+    // master:
+    server.consistent_store()->SetServingSTH(tree_signer.LatestSTH());
+  }
+
+  server.WaitForReplication();
+
+  // TODO(pphaneuf): We should be remaining in an "unhealthy state"
+  // (either not accepting any requests, or returning some internal
+  // server error) until we have an STH to serve.
+  const function<bool()> is_master(bind(&Server::IsMaster, &server));
+  thread sequencer(&SequenceEntries, &tree_signer, is_master);
+  thread cleanup(&CleanUpEntries, server.consistent_store(), is_master);
+  thread signer(&SignMerkleTree, &tree_signer, server.consistent_store(),
+                server.cluster_state_controller());
+
+  server.Run();
+
+  return 0;
+}

--- a/cpp/server/handler.cc
+++ b/cpp/server/handler.cc
@@ -116,7 +116,7 @@ void HttpHandler::ProxyInterceptor(
   // TODO(alcutter): We can be a bit smarter about when to proxy off
   // the request - being stale wrt to the current serving STH doesn't
   // automatically mean we're unable to answer this request.
-  if (IsNodeStale()) {
+  if (staleness_tracker_->IsNodeStale()) {
     // Can't do this on the libevent thread since it can block on the lock in
     // ClusterStatusController::GetFreshNodes().
     pool_->Add(bind(&Proxy::ProxyRequest, proxy_, request));
@@ -156,7 +156,7 @@ void HttpHandler::Add(libevent::HttpServer* server) {
 
 
 void HttpHandler::SetProxy(Proxy* proxy) {
-  LOG_IF(FATAL, proxy_) << "Attempting to re-add a HttpHandler.";
+  LOG_IF(FATAL, proxy_) << "Attempting to re-add a Proxy.";
   proxy_ = CHECK_NOTNULL(proxy);
 }
 
@@ -342,14 +342,4 @@ void HttpHandler::BlockingGetEntries(evhttp_request* req, int64_t start,
   json_reply.Add("entries", json_entries);
 
   SendJsonReply(event_base_, req, HTTP_OK, json_reply);
-}
-
-
-bool HttpHandler::IsNodeStale() const {
-  return staleness_tracker_->IsNodeStale();
-}
-
-
-void HttpHandler::UpdateNodeStaleness() {
-  staleness_tracker_->UpdateNodeStaleness();
 }

--- a/cpp/server/handler.h
+++ b/cpp/server/handler.h
@@ -65,16 +65,13 @@ class HttpHandler {
   void BlockingGetEntries(evhttp_request* req, int64_t start, int64_t end,
                           bool include_scts) const;
 
-  bool IsNodeStale() const;
-  void UpdateNodeStaleness();
-
   LogLookup* const log_lookup_;
   const ReadOnlyDatabase* const db_;
   const ClusterStateController<LoggedEntry>* const controller_;
   Proxy* proxy_;
   ThreadPool* const pool_;
   libevent::Base* const event_base_;
-  StalenessTracker* staleness_tracker_;
+  StalenessTracker* const staleness_tracker_;
 
   DISALLOW_COPY_AND_ASSIGN(HttpHandler);
 };

--- a/cpp/server/handler_v2.cc
+++ b/cpp/server/handler_v2.cc
@@ -1,0 +1,185 @@
+#include "server/handler_v2.h"
+
+#include <algorithm>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <string>
+#include <vector>
+
+#include "log/cert.h"
+#include "log/cert_checker.h"
+#include "log/cluster_state_controller.h"
+#include "log/log_lookup.h"
+#include "log/logged_entry.h"
+#include "monitoring/latency.h"
+#include "monitoring/monitoring.h"
+#include "server/json_output.h"
+#include "server/proxy.h"
+#include "util/json_wrapper.h"
+#include "util/thread_pool.h"
+
+namespace libevent = cert_trans::libevent;
+
+using cert_trans::Counter;
+using cert_trans::HttpHandlerV2;
+using cert_trans::Latency;
+using cert_trans::LoggedEntry;
+using cert_trans::Proxy;
+using cert_trans::ScopedLatency;
+using ct::ShortMerkleAuditProof;
+using ct::SignedCertificateTimestamp;
+using ct::SignedTreeHead;
+using std::bind;
+using std::chrono::milliseconds;
+using std::chrono::seconds;
+using std::lock_guard;
+using std::make_shared;
+using std::multimap;
+using std::min;
+using std::mutex;
+using std::placeholders::_1;
+using std::string;
+using std::unique_ptr;
+using std::vector;
+
+DEFINE_int32(max_leaf_entries_per_response, 1000,
+             "maximum number of entries to put in the response of a "
+             "get-entries request");
+
+namespace {
+
+
+static Latency<milliseconds, string> http_server_request_latency_ms(
+    "total_http_server_request_latency_ms", "path",
+    "Total request latency in ms broken down by path");
+
+
+}  // namespace
+
+
+HttpHandlerV2::HttpHandlerV2(LogLookup* log_lookup, const ReadOnlyDatabase* db,
+                         const ClusterStateController<LoggedEntry>* controller,
+                         ThreadPool* pool, libevent::Base* event_base,
+                         StalenessTracker* staleness_tracker)
+    : log_lookup_(CHECK_NOTNULL(log_lookup)),
+      db_(CHECK_NOTNULL(db)),
+      controller_(CHECK_NOTNULL(controller)),
+      proxy_(nullptr),
+      pool_(CHECK_NOTNULL(pool)),
+      event_base_(CHECK_NOTNULL(event_base)),
+      staleness_tracker_(CHECK_NOTNULL(staleness_tracker)) {
+}
+
+
+HttpHandlerV2::~HttpHandlerV2() {
+}
+
+
+void StatsHandlerInterceptor(const string& path,
+                             const libevent::HttpServer::HandlerCallback& cb,
+                             evhttp_request* req) {
+  ScopedLatency total_http_server_request_latency(
+      http_server_request_latency_ms.GetScopedLatency(path));
+
+  cb(req);
+}
+
+
+void HttpHandlerV2::AddEntryReply(evhttp_request* req,
+                                const util::Status& add_status,
+                                const SignedCertificateTimestamp& sct) const {
+  return SendJsonError(event_base_, req, HTTP_NOTIMPLEMENTED,
+                       "Not yet implemented.");
+}
+
+void HttpHandlerV2::ProxyInterceptor(
+    const libevent::HttpServer::HandlerCallback& local_handler,
+    evhttp_request* request) {
+  VLOG(2) << "Running proxy interceptor...";
+  // TODO(alcutter): We can be a bit smarter about when to proxy off
+  // the request - being stale wrt to the current serving STH doesn't
+  // automatically mean we're unable to answer this request.
+  if (IsNodeStale()) {
+    // Can't do this on the libevent thread since it can block on the lock in
+    // ClusterStatusController::GetFreshNodes().
+    pool_->Add(bind(&Proxy::ProxyRequest, proxy_, request));
+  } else {
+    local_handler(request);
+  }
+}
+
+
+void HttpHandlerV2::AddProxyWrappedHandler(
+    libevent::HttpServer* server, const string& path,
+    const libevent::HttpServer::HandlerCallback& local_handler) {
+  const libevent::HttpServer::HandlerCallback stats_handler(
+      bind(&StatsHandlerInterceptor, path, local_handler, _1));
+  CHECK(server->AddHandler(path, bind(&HttpHandlerV2::ProxyInterceptor, this,
+                                      stats_handler, _1)));
+}
+
+
+void HttpHandlerV2::Add(libevent::HttpServer* server) {
+  CHECK_NOTNULL(server);
+  // TODO(pphaneuf): An optional prefix might be nice?
+  // TODO(pphaneuf): Find out which methods are CPU intensive enough
+  // that they should be spun off to the thread pool.
+  AddProxyWrappedHandler(server, "/ct/v2/get-entries",
+                         bind(&HttpHandlerV2::GetEntries, this, _1));
+  AddProxyWrappedHandler(server, "/ct/v2/get-proof-by-hash",
+                         bind(&HttpHandlerV2::GetProof, this, _1));
+  AddProxyWrappedHandler(server, "/ct/v2/get-sth",
+                         bind(&HttpHandlerV2::GetSTH, this, _1));
+  AddProxyWrappedHandler(server, "/ct/v2/get-sth-consistency",
+                         bind(&HttpHandlerV2::GetConsistency, this, _1));
+
+  // Now add any sub-class handlers.
+  AddHandlers(server);
+}
+
+
+void HttpHandlerV2::SetProxy(Proxy* proxy) {
+  LOG_IF(FATAL, proxy_) << "Attempting to re-add a HttpHandlerV2.";
+  proxy_ = CHECK_NOTNULL(proxy);
+}
+
+
+void HttpHandlerV2::GetEntries(evhttp_request* req) const {
+  return SendJsonError(event_base_, req, HTTP_NOTIMPLEMENTED,
+                       "Not yet implemented.");
+}
+
+
+void HttpHandlerV2::GetProof(evhttp_request* req) const {
+  return SendJsonError(event_base_, req, HTTP_NOTIMPLEMENTED,
+                       "Not yet implemented.");
+}
+
+
+void HttpHandlerV2::GetSTH(evhttp_request* req) const {
+  return SendJsonError(event_base_, req, HTTP_NOTIMPLEMENTED,
+                       "Not yet implemented.");
+}
+
+
+void HttpHandlerV2::GetConsistency(evhttp_request* req) const {
+  return SendJsonError(event_base_, req, HTTP_NOTIMPLEMENTED,
+                       "Not yet implemented.");
+}
+
+
+void HttpHandlerV2::BlockingGetEntries(evhttp_request* req, int64_t start,
+                                     int64_t end, bool include_scts) const {
+  return SendJsonError(event_base_, req, HTTP_NOTIMPLEMENTED,
+                       "Not yet implemented.");
+}
+
+
+bool HttpHandlerV2::IsNodeStale() const {
+  return staleness_tracker_->IsNodeStale();
+}
+
+
+void HttpHandlerV2::UpdateNodeStaleness() {
+  staleness_tracker_->UpdateNodeStaleness();
+}

--- a/cpp/server/handler_v2.cc
+++ b/cpp/server/handler_v2.cc
@@ -99,7 +99,7 @@ void HttpHandlerV2::ProxyInterceptor(
   // TODO(alcutter): We can be a bit smarter about when to proxy off
   // the request - being stale wrt to the current serving STH doesn't
   // automatically mean we're unable to answer this request.
-  if (IsNodeStale()) {
+  if (staleness_tracker_->IsNodeStale()) {
     // Can't do this on the libevent thread since it can block on the lock in
     // ClusterStatusController::GetFreshNodes().
     pool_->Add(bind(&Proxy::ProxyRequest, proxy_, request));
@@ -139,7 +139,7 @@ void HttpHandlerV2::Add(libevent::HttpServer* server) {
 
 
 void HttpHandlerV2::SetProxy(Proxy* proxy) {
-  LOG_IF(FATAL, proxy_) << "Attempting to re-add a HttpHandlerV2.";
+  LOG_IF(FATAL, proxy_) << "Attempting to re-add a Proxy.";
   proxy_ = CHECK_NOTNULL(proxy);
 }
 
@@ -172,14 +172,4 @@ void HttpHandlerV2::BlockingGetEntries(evhttp_request* req, int64_t start,
                                      int64_t end, bool include_scts) const {
   return SendJsonError(event_base_, req, HTTP_NOTIMPLEMENTED,
                        "Not yet implemented.");
-}
-
-
-bool HttpHandlerV2::IsNodeStale() const {
-  return staleness_tracker_->IsNodeStale();
-}
-
-
-void HttpHandlerV2::UpdateNodeStaleness() {
-  staleness_tracker_->UpdateNodeStaleness();
 }

--- a/cpp/server/handler_v2.h
+++ b/cpp/server/handler_v2.h
@@ -65,16 +65,13 @@ class HttpHandlerV2 {
   void BlockingGetEntries(evhttp_request* req, int64_t start, int64_t end,
                           bool include_scts) const;
 
-  bool IsNodeStale() const;
-  void UpdateNodeStaleness();
-
   LogLookup* const log_lookup_;
   const ReadOnlyDatabase* const db_;
   const ClusterStateController<LoggedEntry>* const controller_;
   Proxy* proxy_;
   ThreadPool* const pool_;
   libevent::Base* const event_base_;
-  StalenessTracker* staleness_tracker_;
+  StalenessTracker* const staleness_tracker_;
 
   DISALLOW_COPY_AND_ASSIGN(HttpHandlerV2);
 };

--- a/cpp/server/handler_v2.h
+++ b/cpp/server/handler_v2.h
@@ -1,0 +1,85 @@
+#ifndef CERT_TRANS_SERVER_HANDLER_V2_H_
+#define CERT_TRANS_SERVER_HANDLER_V2_H_
+
+#include <memory>
+#include <mutex>
+#include <stdint.h>
+#include <string>
+
+#include "proto/ct.pb.h"
+#include "server/staleness_tracker.h"
+#include "util/libevent_wrapper.h"
+#include "util/sync_task.h"
+#include "util/task.h"
+
+class Frontend;
+
+namespace cert_trans {
+
+class CertChain;
+class CertChecker;
+template <class T>
+class ClusterStateController;
+class LogLookup;
+class LoggedEntry;
+class PreCertChain;
+class Proxy;
+class ReadOnlyDatabase;
+class ThreadPool;
+
+
+class HttpHandlerV2 {
+ public:
+  // Does not take ownership of its parameters, which must outlive
+  // this instance.
+  HttpHandlerV2(LogLookup* log_lookup, const ReadOnlyDatabase* db,
+              const ClusterStateController<LoggedEntry>* controller,
+              ThreadPool* pool, libevent::Base* event_base,
+              StalenessTracker* staleness_tracker);
+  virtual ~HttpHandlerV2();
+
+  void Add(libevent::HttpServer* server);
+
+  void SetProxy(Proxy* proxy);
+
+ protected:
+  // Implemented by subclasses which want to add their own extra http handlers.
+  virtual void AddHandlers(libevent::HttpServer* server) = 0;
+
+  void AddEntryReply(evhttp_request* req, const util::Status& add_status,
+                     const ct::SignedCertificateTimestamp& sct) const;
+
+  void ProxyInterceptor(
+      const libevent::HttpServer::HandlerCallback& local_handler,
+      evhttp_request* request);
+
+  void AddProxyWrappedHandler(
+      libevent::HttpServer* server, const std::string& path,
+      const libevent::HttpServer::HandlerCallback& local_handler);
+
+  void GetEntries(evhttp_request* req) const;
+  void GetProof(evhttp_request* req) const;
+  void GetSTH(evhttp_request* req) const;
+  void GetConsistency(evhttp_request* req) const;
+
+  void BlockingGetEntries(evhttp_request* req, int64_t start, int64_t end,
+                          bool include_scts) const;
+
+  bool IsNodeStale() const;
+  void UpdateNodeStaleness();
+
+  LogLookup* const log_lookup_;
+  const ReadOnlyDatabase* const db_;
+  const ClusterStateController<LoggedEntry>* const controller_;
+  Proxy* proxy_;
+  ThreadPool* const pool_;
+  libevent::Base* const event_base_;
+  StalenessTracker* staleness_tracker_;
+
+  DISALLOW_COPY_AND_ASSIGN(HttpHandlerV2);
+};
+
+
+}  // namespace cert_trans
+
+#endif  // CERT_TRANS_SERVER_HANDLER_V2_H_


### PR DESCRIPTION
This registers v2 request handlers but they reject all requests with HTTP_NOTIMPLEMENTED.

At the moment there seems to be no good alternative than duplicating the handlers as it's not yet clear how much of the code will remain in common with v1. Hopefully, there will be some common code that can be refactored out.