### PR TITLE
Additional validation on etcd_servers flag.

### DIFF
--- a/cpp/net/url.cc
+++ b/cpp/net/url.cc
@@ -28,6 +28,10 @@ URL::URL(const string& url) {
   unique_ptr<evhttp_uri, void (*)(evhttp_uri*)> uri(
       evhttp_uri_parse(url.c_str()), &evhttp_uri_free);
 
+  if (!uri) {
+    LOG(FATAL) << "URL invalid: " << url;
+  }
+
   const int port(evhttp_uri_get_port(uri.get()));
   port_ = port > 0 && port <= UINT16_MAX ? port : 0;
 

--- a/cpp/util/etcd_test.cc
+++ b/cpp/util/etcd_test.cc
@@ -1105,6 +1105,22 @@ TEST_F(EtcdDeathTest, SplitHostsWithOutOfRangePort) {
   EXPECT_DEATH(SplitHosts("host:65536"), "Port is > 65535");
 }
 
+TEST_F(EtcdDeathTest, SplitHostsWithQuotedUrlInList) {
+  EXPECT_DEATH(SplitHosts("host:123,\"host:4002\", host:456"),
+               "Invalid etcd_server url specified: \\\"host:4002\\\"");
+}
+
+TEST_F(EtcdDeathTest, SplitHostsWithQuotedUrl) {
+  EXPECT_DEATH(SplitHosts("\"host:4001\""),
+               "Invalid etcd_server url specified: \\\"host:4001\\\"");
+}
+
+
+// Test that if the SplitHosts validation failed the bad URL would still
+// be caught
+TEST_F(EtcdDeathTest, UrlRejectsQuotedValue) {
+  EXPECT_DEATH(URL("\"host:4001\""), "URL invalid: \"host:4001\"");
+}
 
 TEST_F(EtcdTest, LogsVersion) {
   EXPECT_CALL(url_fetcher_,


### PR DESCRIPTION
Ensure each element can be parsed as a URL when it is split up from the flag value. Add tests. Addresses #1053.