### PR TITLE
Fix libevent build.

### DIFF
--- a/build/Makefile.libevent
+++ b/build/Makefile.libevent
@@ -12,7 +12,7 @@ all: Makefile
 	$(MAKE) install
 
 Makefile: configure
-	./configure --prefix=$(INSTALL_DIR) --disable-shared --enable-static --enable-openssl CPPFLAGS="-I$(INSTALL_DIR)/include" CFLAGS="-fPIC" LDFLAGS="-fPIC -L$(INSTALL_DIR)/lib $(EXTRA_LDFLAGS)" || tail -1000 config.out
+	./configure --prefix=$(INSTALL_DIR) --disable-shared --enable-static --enable-openssl CPPFLAGS="-I$(INSTALL_DIR)/include" CFLAGS="-fPIC" LDFLAGS="-fPIC -L$(INSTALL_DIR)/lib" OPENSSL_LIBADD="$(EXTRA_LDFLAGS)" || tail -1000 config.out
 	$(MAKE) clean
 
 configure: configure.ac


### PR DESCRIPTION
A clean gclient sync was failing locally during a clean build because `libevent` wasn't building `libevent_openssl.a`.  This was due to it missing a bunch of `libdl` symbols (presumably for engine support?)

Anyway, either Travis wasn't affected by this for some reason, or we didn't notice because of the caching. 