### PR TITLE
Pull in objecthash for XJSON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,16 +96,18 @@ install:
  - export PYTHONPATH=$(python -m site --user-site)
  - pip install --user --upgrade -r python/requirements.txt
 # Sigh, go get -t will fetch part of this package, but doesn't catch the transitive deps so grab it manually:
+ - pushd go
  - go get github.com/stretchr/testify
  - go get -v -d -t ./...
+ - popd
 
 script:
  - getconf _NPROCESSORS_ONLN
- - ${MAKE} -j$(getconf _NPROCESSORS_ONLN) check VERBOSE=1
+ - ${MAKE} -j$(getconf _NPROCESSORS_ONLN) check VERBOSE=1 V=${ENV_VERBOSE}
  - ant build test
  - ${MAKE} -C python test
  - |
    pushd ${GOPATH}
-   CGO_CPPFLAGS="-I${INSTALL_DIR}/include" CGO_LDFLAGS="-L${INSTALL_DIR}/lib" go test -v ./src/github.com/google/certificate-transparency/...
+   CGO_CPPFLAGS="-I${INSTALL_DIR}/include" CGO_LDFLAGS="-L${INSTALL_DIR}/lib" go test -v ./src/github.com/google/certificate-transparency/go/...
    popd
 

--- a/DEPS
+++ b/DEPS
@@ -3,11 +3,14 @@ deps = {
      "glog":             "https://github.com/benlaurie/glog.git@0.3.4-fix",
      "googlemock": 			 "https://github.com/google/googlemock.git@release-1.7.0",
      "googlemock/gtest": "https://github.com/google/googletest.git@release-1.7.0",
+     "icu4c":            "https://github.com/icu-project/icu4c.git@bbd17a792336de5873550794f8304a4b548b0663",
      "json-c": 					 "https://github.com/AlCutter/json-c.git@json-c-0.12-20140410-fix",
      "ldns":             "https://github.com/benlaurie/ldns.git@1.6.17-fix",
      "leveldb": 				 "https://github.com/google/leveldb.git@v1.18",
      "libevent": 				 "https://github.com/libevent/libevent.git@release-2.0.22-stable",
-     "libevhtp": 				 "https://github.com/ellzey/libevhtp.git@ba4c44eed1fb7a5cf8e4deb236af4f7675cc72d5",
+     "libevhtp": 				 "https://github.com/ellzey/libevhtp.git@a89d9b3f9fdf2ebef41893b3d5e4466f4b0ecfda",
+     "certificate-transparency/third_party/objecthash":
+                         "https://github.com/benlaurie/objecthash.git@798f66bd8c5313da226aa7a60c114147910a7407",
      "openssl": 				 "https://github.com/openssl/openssl.git@OpenSSL_1_0_2d",
      "protobuf":         "https://github.com/google/protobuf.git@v2.6.1",
      "protobuf/gtest":   "https://github.com/google/googletest.git@release-1.7.0",
@@ -124,6 +127,16 @@ hooks = [
         "name": "json-c",
         "pattern": "^json-c/",
         "action": [ make, "-f", os.path.join(here, "certificate-transparency/build.gclient"), "_json-c" ],
+    },
+    {
+        "name": "icu4c",
+        "pattern": "^icu4c/",
+        "action": [ make, "-f", os.path.join(here, "certificate-transparency/build.gclient"), "_icu4c" ],
+    },
+    {
+        "name": "objecthash",
+        "pattern": "^certificate-transparency/third_party/objecthash/",
+        "action": [ make, "-f", os.path.join(here, "certificate-transparency/build.gclient"), "_objecthash" ],
     },
     # Do this last
     {

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,9 @@ ACLOCAL_AMFLAGS = -Im4
 AM_CPPFLAGS = \
 	-I$(GMOCK_DIR)/include \
 	-I$(GTEST_DIR)/include \
+	-Ithird_party/objecthash \
 	$(evhtp_CFLAGS) \
+	$(icu_CFLAGS) \
 	$(json_c_CFLAGS)
 
 AM_CXXFLAGS = \
@@ -282,6 +284,7 @@ cpp_server_ct_server_v2_SOURCES = \
 cpp_server_xjson_server_LDADD = \
 	cpp/libcore.a \
 	$(evhtp_LIBS) \
+	$(icu_LIBS) \
 	$(json_c_LIBS) \
 	$(libevent_LIBS) \
 	$(leveldb_LIBS) \
@@ -294,7 +297,8 @@ cpp_server_xjson_server_SOURCES = \
 	cpp/server/server_helper.cc \
 	cpp/server/xjson-server.cc \
 	cpp/server/x_json_handler.cc \
-	cpp/util/json_wrapper.cc
+	cpp/util/json_wrapper.cc \
+	third_party/objecthash/objecthash.cc
 
 cpp_tools_ct_clustertool_LDADD = \
 	cpp/libcore.a \
@@ -352,8 +356,8 @@ cpp_client_ct_SOURCES = \
 	cpp/version.cc
 
 cpp_server_ct_dns_server_LDADD = \
-	$(evhtp_LIBS) \
 	cpp/libcore.a \
+	$(evhtp_LIBS) \
 	${libevent_LIBS} \
 	-lprotobuf -lldns -lsqlite3
 cpp_server_ct_dns_server_SOURCES = \

--- a/build.gclient
+++ b/build.gclient
@@ -2,8 +2,10 @@
 
 INSTALL_DIR?=$(shell pwd)/install
 export INSTALL_DIR
+PKG_CONFIG_PATH=$(shell pwd)/install/lib/pkgconfig
+export PKG_CONFIG_PATH
 
-PHONY: libunwind tcmalloc openssl protobuf libevent libevhtp gflags glog ldns sqlite3 leveldb json-c configure-ct
+PHONY: libunwind tcmalloc objecthash openssl protobuf libevent libevhtp gflags glog ldns sqlite3 leveldb json-c configure-ct
 
 all: configure-ct
 
@@ -16,6 +18,12 @@ _libunwind:
 _tcmalloc:
 	$(MAKE) -C tcmalloc -f ../certificate-transparency/build/Makefile.tcmalloc
 	cd tcmalloc && git checkout --
+
+_icu4c:
+	$(MAKE) -C icu4c/source -f `pwd`/certificate-transparency/build/Makefile.icu4c
+
+_objecthash:
+	$(MAKE) -C certificate-transparency/third_party/objecthash -f `pwd`/certificate-transparency/build/Makefile.objecthash
 
 _openssl:
 	$(MAKE) -C openssl -f `pwd`/certificate-transparency/build/Makefile.openssl

--- a/build/Makefile.icu4c
+++ b/build/Makefile.icu4c
@@ -1,0 +1,9 @@
+all: Makefile
+	$(MAKE) install
+
+Makefile: configure
+	EXTRA_LDFLAGS="-ldl"
+	./configure --prefix=$(INSTALL_DIR) --disable-shared --enable-static CPPFLAGS="-I${INSTALL_DIR}/include" LDFLAGS="-L${INSTALL_DIR}/lib ${EXTRA_LDFLAGS}" CXXFLAGS="$(WARN_OVERRIDES) -fPIC" CFLAGS="$(WARN_OVERRIDES) -fPIC"
+
+configure: configure.ac
+	autoreconf -vi

--- a/build/Makefile.objecthash
+++ b/build/Makefile.objecthash
@@ -1,0 +1,5 @@
+all: test
+
+test:
+	# TODO(alcutter): Doesn't work because pkg-config in the objecthash doesn't know we need -ldl too.
+	# PKG_CONFIG_PATH="$(INSTALL_DIR)/lib/pkgconfig" $(MAKE) c CPPFLAGS="-I $(INSTALL_DIR)/include" LDFLAGS="-L $(INSTALL_DIR)/lib"

--- a/build/configure-ct
+++ b/build/configure-ct
@@ -39,5 +39,7 @@ then
       ;;
   esac
 
-  ./configure GMOCK_DIR=${GMOCK} ${CONFIGURE_FLAGS} PROTOC=${INSTALL_DIR}/bin/protoc PKG_CONFIG_PATH="${INSTALL_DIR}/lib/pkgconfig" CPPFLAGS="-I${INSTALL_DIR}/include" CXXFLAGS="${CXXFLAGS} ${EXTRA_CXXFLAGS}" LDFLAGS="-L${INSTALL_DIR}/lib $EXTRA_LDFLAGS" LIBS="${EXTRA_LIBS}" evhtp_CFLAGS="-I${INSTALL_DIR}/include" evhtp_LIBS="-levhtp" INSTALL_DIR=${INSTALL_DIR} || tail -1000 config.log
+  ./configure GMOCK_DIR=${GMOCK} ${CONFIGURE_FLAGS} PROTOC=${INSTALL_DIR}/bin/protoc PKG_CONFIG_PATH="${INSTALL_DIR}/lib/pkgconfig" CPPFLAGS="-I${INSTALL_DIR}/include" CXXFLAGS="${CXXFLAGS} ${EXTRA_CXXFLAGS}" LDFLAGS="-L${INSTALL_DIR}/lib $EXTRA_LDFLAGS" LIBS="${EXTRA_LIBS}" INSTALL_DIR=${INSTALL_DIR} || tail -1000 config.log
+
+  ./config.status --config
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,7 @@ AC_CHECK_PROGS([ANT], [ant])
 
 PKG_CHECK_MODULES([json_c], [json-c])
 PKG_CHECK_MODULES([evhtp], [evhtp])
+PKG_CHECK_MODULES([icu], [icu-uc])
 
 if test "x${enable_hardening}" != "xno"; then
   common_harden_copts="-fstack-protector-all -fPIC -Wa,--noexecstack -Wformat -Wformat-security"

--- a/cpp/proto/xjson_serializer.cc
+++ b/cpp/proto/xjson_serializer.cc
@@ -3,6 +3,7 @@
 
 #include <glog/logging.h>
 #include <math.h>
+#include <objecthash.h>
 #include <string>
 
 #include "proto/ct.pb.h"


### PR DESCRIPTION
Doesn't really do anything with it currently.

Unfortunately it's resulted in a spray of `-lcrypto -ljson-c` in the Makefile, but that's an artifact of the single `serializer.{cc,h}` module which needs breaking out into domain specific modules so that servers will only include the type(s) of serialization that they actually need.
