### PR TITLE
parse of asn1 utc time which don't ends with "Z" in cert

### DIFF
--- a/python/ct/config/logs.config
+++ b/python/ct/config/logs.config
@@ -1,13 +1,13 @@
-ctlog:{
-  log_server:'https://ct.googleapis.com/pilot'
-  log_id:'pLkJkLQYWBSHuxOizGdwCjw1mAT5G9+443fNDsgN3BA='
-  public_key_info:{
-    type:ECDSA
-        pem_key:'-----BEGIN ECDSA PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0D'
-	'AQcDQgAEfahLEimAoz2t01p3uMziiLOl/fHTDM0YDOhBRuiBARsV4UvxG2LdNgoIGLrtCz'
-	'WE0J5APC2em4JlvR8EEEFMoA==\n-----END ECDSA PUBLIC KEY-----'
-  }
-}
+#ctlog:{
+#  log_server:'https://ct.googleapis.com/pilot'
+#  log_id:'pLkJkLQYWBSHuxOizGdwCjw1mAT5G9+443fNDsgN3BA='
+#  public_key_info:{
+#    type:ECDSA
+#        pem_key:'-----BEGIN ECDSA PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0D'
+#	'AQcDQgAEfahLEimAoz2t01p3uMziiLOl/fHTDM0YDOhBRuiBARsV4UvxG2LdNgoIGLrtCz'
+#	'WE0J5APC2em4JlvR8EEEFMoA==\n-----END ECDSA PUBLIC KEY-----'
+#  }
+#}
 
 # Add more logs here
 
@@ -19,3 +19,15 @@ ctlog:{
 #     pem_key:'pem_key_with_headers'
 #   }
 # }
+
+ctlog:{
+  log_server:'https://ct.wosign.com'
+  log_id:'nk\/3PcPOIgtpIXyJnkaAdqv414Y21cz8haMadWKLqIs='
+  public_key_info:{
+    type:ECDSA
+        pem_key:'-----BEGIN ECDSA PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1+wvK3VPN7yjQ7qLZWY8fWrlDCqm\n'
+        'wuUm/gx9TnzwOrzi0yLcAdAfbkOcXG6DrZwV9sSNYLUdu6NiaX7rp6oBmw==\n-----END ECDSA PUBLIC KEY-----'
+  }
+}
+
+

--- a/python/ct/crypto/asn1/x509_time.py
+++ b/python/ct/crypto/asn1/x509_time.py
@@ -103,6 +103,9 @@ class UTCTime(BaseTime):
             #
             format = "%Y%m%d%H%M%S%Z"
             string_time = string_time[0:self._ASN1_LENGTH]
+        elif (len(string_time) == self._UTC_NO_Z_LENGTH):
+            string_time += "Z"
+            format = "%Y%m%d%H%M%S%Z"
         else:
             return None
 

--- a/python/ct/crypto/asn1/x509_time_test.py
+++ b/python/ct/crypto/asn1/x509_time_test.py
@@ -19,6 +19,9 @@ class TimeTest(unittest.TestCase):
         t = x509_time.UTCTime(value="130822153902Z").gmtime()
         self.verify_time(t, 2013, 8, 22, 15, 39, 2)
 
+        t = x509_time.UTCTime(value="130822153902").gmtime()
+        self.verify_time(t, 2013, 8, 22, 15, 39, 2)
+
         t = x509_time.GeneralizedTime(value="20130822153902Z").gmtime()
         self.verify_time(t, 2013, 8, 22, 15, 39, 2)
 


### PR DESCRIPTION
according to https://github.com/google/certificate-transparency/issues/1078, there are some certficates will cause exception raise in python code, this kind of certifcates "nobefore" and "noafter" part don't ends with "Z", so add some code to parse utc time which don't ends with "Z" in cert