### PR TITLE
Don't force callers of util::InitCT() to be CT V1.

### DIFF
--- a/cpp/tools/clustertool_main.cc
+++ b/cpp/tools/clustertool_main.cc
@@ -13,6 +13,7 @@
 #include "log/sqlite_db.h"
 #include "log/strict_consistent_store.h"
 #include "log/tree_signer.h"
+#include "proto/cert_serializer.h"
 #include "proto/ct.pb.h"
 #include "tools/clustertool-inl.h"
 #include "util/etcd.h"
@@ -132,8 +133,10 @@ ClusterConfig LoadConfig() {
 
 
 int main(int argc, char* argv[]) {
-  util::InitCT(&argc, &argv);
   FLAGS_logtostderr = true;
+
+  ConfigureSerializerForV1CT();
+  util::InitCT(&argc, &argv);
 
   if (argc == 1) {
     Usage();

--- a/cpp/util/init.cc
+++ b/cpp/util/init.cc
@@ -54,8 +54,6 @@ void InitCT(int* argc, char** argv[]) {
   google::InitGoogleLogging(*argv[0]);
   google::InstallFailureSignalHandler();
 
-  ConfigureSerializerForV1CT();
-
   event_set_log_callback(&LibEventLog);
 
   evthread_use_pthreads();


### PR DESCRIPTION
They should be able to decide for themselves (and in fact, already do causing this to explode.)