### PR TITLE
Golang: added Ticker interface to Scanner

### DIFF
--- a/go/scanner/main/scanner.go
+++ b/go/scanner/main/scanner.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"math/big"
 	"regexp"
+	"time"
 
 	"github.com/google/certificate-transparency/go"
 	"github.com/google/certificate-transparency/go/client"
@@ -25,6 +26,7 @@ var batchSize = flag.Int("batch_size", 1000, "Max number of entries to request a
 var numWorkers = flag.Int("num_workers", 2, "Number of concurrent matchers")
 var parallelFetch = flag.Int("parallel_fetch", 2, "Number of concurrent GetEntries fetches")
 var startIndex = flag.Int64("start_index", 0, "Log index to start scanning at")
+var tickTime = flag.Int("tick_time", 1, "Number of seconds to wait between logging operations")
 var quiet = flag.Bool("quiet", false, "Don't print out extra logging messages, only matches.")
 
 // Prints out a short bit of info about |cert|, found at |index| in the
@@ -80,6 +82,8 @@ func main() {
 		ParallelFetch: *parallelFetch,
 		StartIndex:    *startIndex,
 		Quiet:         *quiet,
+		TickTime:      time.Duration(*tickTime) * time.Second,
+		Tickers:       []scanner.Ticker{scanner.LogTicker{}},
 	}
 	scanner := scanner.NewScanner(logClient, opts)
 	scanner.Scan(logCertInfo, logPrecertInfo)

--- a/go/scanner/scanner.go
+++ b/go/scanner/scanner.go
@@ -104,12 +104,12 @@ type Ticker interface {
 type LogTicker struct{}
 
 func (t LogTicker) HandleTick(s *Scanner, startTime time.Time, sth *ct.SignedTreeHead) {
-	throughput := float64(s.certsProcessed) / time.Since(startTime).Seconds()
-	remainingCerts := int64(sth.TreeSize) - int64(s.opts.StartIndex) - s.certsProcessed
+	throughput := float64(s.CertsProcessed) / time.Since(startTime).Seconds()
+	remainingCerts := int64(sth.TreeSize) - int64(s.opts.StartIndex) - s.CertsProcessed
 	remainingSeconds := int(float64(remainingCerts) / throughput)
 	remainingString := humanTime(remainingSeconds)
-	s.Log(fmt.Sprintf("Processed: %d certs (to index %d). Throughput: %3.2f ETA: %s\n", s.certsProcessed,
-		s.opts.StartIndex+int64(s.certsProcessed), throughput, remainingString))
+	s.Log(fmt.Sprintf("Processed: %d certs (to index %d). Throughput: %3.2f ETA: %s\n", s.CertsProcessed,
+		s.opts.StartIndex+int64(s.CertsProcessed), throughput, remainingString))
 }
 
 // ScannerOptions holds configuration options for the Scanner
@@ -167,7 +167,7 @@ type Scanner struct {
 	opts ScannerOptions
 
 	// Counter of the number of certificates scanned
-	certsProcessed int64
+	CertsProcessed int64
 
 	// Counter of the number of precertificates encountered during the scan.
 	precertsSeen int64
@@ -218,7 +218,7 @@ func (s *Scanner) handleParseEntryError(err error, entryType ct.LogEntryType, in
 
 // Processes the given |entry| in the specified log.
 func (s *Scanner) processEntry(entry ct.LogEntry, foundCert func(*ct.LogEntry), foundPrecert func(*ct.LogEntry)) {
-	atomic.AddInt64(&s.certsProcessed, 1)
+	atomic.AddInt64(&s.CertsProcessed, 1)
 	switch entry.Leaf.TimestampedEntry.EntryType {
 	case ct.X509LogEntryType:
 		if s.opts.PrecertOnly {
@@ -352,7 +352,7 @@ func (s Scanner) Log(msg string) {
 func (s *Scanner) Scan(foundCert func(*ct.LogEntry),
 	foundPrecert func(*ct.LogEntry)) error {
 	s.Log("Starting up...\n")
-	s.certsProcessed = 0
+	s.CertsProcessed = 0
 	s.precertsSeen = 0
 	s.unparsableEntries = 0
 	s.entriesWithNonFatalErrors = 0
@@ -401,7 +401,7 @@ func (s *Scanner) Scan(foundCert func(*ct.LogEntry),
 	close(jobs)
 	matcherWG.Wait()
 
-	s.Log(fmt.Sprintf("Completed %d certs in %s", s.certsProcessed, humanTime(int(time.Since(startTime).Seconds()))))
+	s.Log(fmt.Sprintf("Completed %d certs in %s", s.CertsProcessed, humanTime(int(time.Since(startTime).Seconds()))))
 	s.Log(fmt.Sprintf("Saw %d precerts", s.precertsSeen))
 	s.Log(fmt.Sprintf("%d unparsable entries, %d non-fatal errors", s.unparsableEntries, s.entriesWithNonFatalErrors))
 	return nil

--- a/go/scanner/scanner.go
+++ b/go/scanner/scanner.go
@@ -153,6 +153,7 @@ func DefaultScannerOptions() *ScannerOptions {
 		ParallelFetch: 1,
 		StartIndex:    0,
 		Quiet:         false,
+		TickTime:      time.Second,
 		Tickers:       []Ticker{LogTicker{}},
 	}
 }
@@ -362,7 +363,7 @@ func (s *Scanner) Scan(foundCert func(*ct.LogEntry),
 	}
 	s.Log(fmt.Sprintf("Got STH with %d certs", latestSth.TreeSize))
 
-	ticker := time.NewTicker(time.Second)
+	ticker := time.NewTicker(s.opts.TickTime)
 	startTime := time.Now()
 	fetches := make(chan fetchRange, 1000)
 	jobs := make(chan matcherJob, 100000)


### PR DESCRIPTION
If we need to store the latest STH we fetched and then restore fetching process later it'll be a big problem in current Scanner implementation. Introducing Tickers we can handle it via interfaces (example of logging included).
