### PR TITLE
correct GetEntries slice size

### DIFF
--- a/go/client/logclient.go
+++ b/go/client/logclient.go
@@ -299,7 +299,7 @@ func (c *LogClient) GetEntries(start, end int64) ([]ct.LogEntry, error) {
 	if err != nil {
 		return nil, err
 	}
-	entries := make([]ct.LogEntry, end-start+1, end-start+1)
+	entries := make([]ct.LogEntry, len(resp.Entries))
 	for index, entry := range resp.Entries {
 		leafBytes, err := base64.StdEncoding.DecodeString(entry.LeafInput)
 		leaf, err := ct.ReadMerkleTreeLeaf(bytes.NewBuffer(leafBytes))


### PR DESCRIPTION
Fixes #1100, and probably a few other problems folks were having.

Before this was corrected, we saw many "sequence truncated" from the asn1 library when running large GetEntries on the certly CT log.