### PR TITLE
gclient fixes: Build and use lzma

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
       - python-dev
       - libstdc++-4.9-dev
       - tcl8.5
+      - autopoint
 
 matrix:
   include:

--- a/DEPS
+++ b/DEPS
@@ -18,7 +18,8 @@ deps = {
      # Randomly chosen github mirror
      "sqlite3-export": 	 "http://repo.or.cz/sqlite-export.git",
      "sqlite3": 				 "http://repo.or.cz/sqlite.git@version-3.8.10.1",
-		 "tcmalloc":				 "https://github.com/gperftools/gperftools.git@gperftools-2.4"
+		 "tcmalloc":				 "https://github.com/gperftools/gperftools.git@gperftools-2.4",
+     "xz-utils":             "http://git.tukaani.org/xz.git@9815cdf6987ef91a85493bfcfd1ce2aaf3b47a0a"
 }
 
 # Can't use deps_os for this because it doesn't know about freebsd :/
@@ -63,6 +64,11 @@ print("Using make %s with %d jobs" % (make, num_cores))
 here = os.getcwd()
 
 hooks = [
+    {
+        "name": "xz-utils",
+        "pattern": "^xz-utils/",
+        "action": [ make, "-f", os.path.join(here, "certificate-transparency/build.gclient"), "_lzma" ],
+    },
     {
         "name": "libunwind",
         "pattern": "^libunwind/",

--- a/build.gclient
+++ b/build.gclient
@@ -15,6 +15,12 @@ _libunwind:
 		(cd libunwind && git checkout --); \
 	fi
 
+_lzma:
+	if [ -d xz-utils ]; then \
+		$(MAKE) -C xz-utils -f ../certificate-transparency/build/Makefile.xz-utils ; \
+		(cd xz-utils && git checkout --); \
+	fi
+
 _tcmalloc:
 	$(MAKE) -C tcmalloc -f ../certificate-transparency/build/Makefile.tcmalloc
 	cd tcmalloc && git checkout --

--- a/build/Makefile.tcmalloc
+++ b/build/Makefile.tcmalloc
@@ -11,7 +11,7 @@ all: Makefile
 
 Makefile: configure
 	WARN_OVERRIDES="-Wno-unused-function"
-	./configure --prefix=$(INSTALL_DIR) --disable-shared --enable-static CXXFLAGS="$(WARN_OVERRIDES) -fPIC" CFLAGS="$(WARN_OVERRIDES) -fPIC" CPPFLAGS="-I$(INSTALL_DIR)/include" LDFLAGS="-L$(INSTALL_DIR)/lib $(EXTRA_LDFLAGS)" || tail -1000 config.log
+	./configure --prefix=$(INSTALL_DIR) --disable-shared --enable-static CXXFLAGS="$(WARN_OVERRIDES) -fPIC" CFLAGS="$(WARN_OVERRIDES) -fPIC" CPPFLAGS="-I$(INSTALL_DIR)/include" LDFLAGS="-L$(INSTALL_DIR)/lib -lunwind $(EXTRA_LDFLAGS)" || tail -1000 config.log
 
 configure: configure.ac
 	autoreconf -vi

--- a/build/Makefile.unwind
+++ b/build/Makefile.unwind
@@ -2,7 +2,7 @@ all: Makefile
 	$(MAKE) install
 
 Makefile: configure
-	./configure --prefix=$(INSTALL_DIR) --disable-shared --enable-static CXXFLAGS="-fPIC" CFLAGS="-fPIC"
+	./configure --prefix=$(INSTALL_DIR) --disable-shared --enable-static CXXFLAGS="-fPIC" CFLAGS="-fPIC" LDFLAGS="-L$(INSTALL_DIR)/lib"
 	# Don't really want to install latex:
 	sed -e 's/latex2man/echo/' -e 's/pdflatex/echo/' -ibak doc/Makefile
 

--- a/build/Makefile.xz-utils
+++ b/build/Makefile.xz-utils
@@ -1,0 +1,8 @@
+all: Makefile
+	$(MAKE) install
+
+Makefile: configure
+	./configure --prefix=$(INSTALL_DIR) --disable-shared --enable-static CXXFLAGS="-fPIC" CFLAGS="-fPIC"
+
+configure: configure.ac
+	autoreconf -vi

--- a/build/configure-ct
+++ b/build/configure-ct
@@ -35,7 +35,7 @@ then
       ;;
     Linux)
       EXTRA_LDFLAGS="${EXTRA_LDFLAGS} -Wl,-rpath=${INSTALL_DIR}/lib"
-      EXTRA_LIBS="-lunwind"
+      EXTRA_LIBS="-lunwind -llzma"
       ;;
   esac
 


### PR DESCRIPTION
lzma is needed by libunwind, which would fail the ct configure script
if not present.
Also, explicitly depend on libunwind for tcmalloc.