### PR TITLE
Making unittest the first import in tests.

### DIFF
--- a/python/ct/cert_analysis/algorithm_test.py
+++ b/python/ct/cert_analysis/algorithm_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import unittest
+
 import mock
 import time
 from ct.cert_analysis import algorithm

--- a/python/ct/cert_analysis/ca_field_test.py
+++ b/python/ct/cert_analysis/ca_field_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import unittest
+
 import mock
 from ct.cert_analysis import base_check_test
 from ct.cert_analysis import ca_field

--- a/python/ct/cert_analysis/common_name_test.py
+++ b/python/ct/cert_analysis/common_name_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # coding=utf-8
 import unittest
+
 import mock
 from ct.cert_analysis import base_check_test
 from ct.cert_analysis import common_name

--- a/python/ct/cert_analysis/crl_pointers_test.py
+++ b/python/ct/cert_analysis/crl_pointers_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
-import mock
 import unittest
+
+import mock
 from ct.cert_analysis import base_check_test
 from ct.cert_analysis import crl_pointers
 from ct.crypto import cert

--- a/python/ct/cert_analysis/dnsnames_test.py
+++ b/python/ct/cert_analysis/dnsnames_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # coding=utf-8
 import unittest
+
 import mock
 from ct.cert_analysis import base_check_test
 from ct.cert_analysis import dnsnames

--- a/python/ct/cert_analysis/extensions_test.py
+++ b/python/ct/cert_analysis/extensions_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
-import copy
 import unittest
+
+import copy
 from ct.cert_analysis import base_check_test
 from ct.cert_analysis import extensions
 from ct.crypto.asn1 import oid

--- a/python/ct/cert_analysis/ip_addresses_test.py
+++ b/python/ct/cert_analysis/ip_addresses_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import unittest
+
 import mock
 
 from ct.cert_analysis import base_check_test

--- a/python/ct/cert_analysis/ocsp_pointers_test.py
+++ b/python/ct/cert_analysis/ocsp_pointers_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
-import mock
 import unittest
+
+import mock
 from ct.cert_analysis import base_check_test
 from ct.cert_analysis import ocsp_pointers
 from ct.crypto import cert

--- a/python/ct/cert_analysis/serial_number_test.py
+++ b/python/ct/cert_analysis/serial_number_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import unittest
+
 import mock
 from ct.cert_analysis import base_check_test
 from ct.cert_analysis import serial_number

--- a/python/ct/cert_analysis/tld_check_test.py
+++ b/python/ct/cert_analysis/tld_check_test.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # coding=utf-8
-import mock
 import unittest
+
+import mock
 from ct.cert_analysis import tld_check
 
 def gen_dns_name(name):

--- a/python/ct/cert_analysis/tld_list_test.py
+++ b/python/ct/cert_analysis/tld_list_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # coding=utf-8
 import unittest
+
 from ct.cert_analysis import tld_list
 
 TLD_DIR = "ct/cert_analysis/test_data/"

--- a/python/ct/cert_analysis/validity_test.py
+++ b/python/ct/cert_analysis/validity_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import unittest
+
 import mock
 import time
 from ct.cert_analysis import base_check_test

--- a/python/ct/client/db/cert_desc_test.py
+++ b/python/ct/client/db/cert_desc_test.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # coding=utf-8
-import time
 import unittest
+
+import time
 from ct.client.db import cert_desc
 from ct.crypto import cert
 from ct.cert_analysis import all_checks

--- a/python/ct/client/db/sqlite_connection_test.py
+++ b/python/ct/client/db/sqlite_connection_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-import sqlite3
 import unittest
+import sqlite3
 
 from ct.client.db import sqlite_connection as sqlitecon
 

--- a/python/ct/client/db/sqlite_temp_db_test.py
+++ b/python/ct/client/db/sqlite_temp_db_test.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
+import unittest
+
 import os
 import tempfile
-import unittest
 
 from ct.client.db import sqlite_connection as sqlitecon
 from ct.client.db import sqlite_temp_db

--- a/python/ct/client/log_client_test.py
+++ b/python/ct/client/log_client_test.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python
 
+import unittest
+
 import base64
 import json
+import mock
 import requests
 import sys
-import unittest
 
 from ct.client import log_client
 from ct.client import log_client_test_util as test_util
 from ct.crypto import merkle
 from ct.proto import client_pb2
 import gflags
-import mock
 
 FLAGS = gflags.FLAGS
 

--- a/python/ct/client/state_test.py
+++ b/python/ct/client/state_test.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
+import unittest
+
 import os
 import tempfile
-import unittest
 
 from ct.client import state
 from ct.proto import client_pb2

--- a/python/ct/crypto/cert_test.py
+++ b/python/ct/crypto/cert_test.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # coding=utf-8
 
+import unittest
+
 import gflags
 import time
-import unittest
 import sys
 from ct.crypto import cert
 from ct.crypto import error

--- a/python/ct/crypto/merkle_test.py
+++ b/python/ct/crypto/merkle_test.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
+import unittest
+
 from collections import namedtuple
 import hashlib
 import math
-import unittest
 
 from ct.crypto import error
 from ct.crypto import merkle

--- a/python/ct/crypto/pem_test.py
+++ b/python/ct/crypto/pem_test.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
+import unittest
+
 import os
 from tempfile import mkstemp
-import unittest
 from ct.crypto import pem
 
 

--- a/python/ct/crypto/verify_test.py
+++ b/python/ct/crypto/verify_test.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 
+import unittest
+
 import base64
 import gflags
 import os
 import sys
-import unittest
 
 from ct.crypto import cert
 from ct.crypto import error


### PR DESCRIPTION
There's no need for a magic marker in that case.