### PR TITLE
gclient woes: Fix Linux build.

### DIFF
--- a/build/Makefile.unwind
+++ b/build/Makefile.unwind
@@ -2,7 +2,7 @@ all: Makefile
 	$(MAKE) install
 
 Makefile: configure
-	./configure --prefix=$(INSTALL_DIR) --disable-shared --enable-static CXXFLAGS="-fPIC" CFLAGS="-fPIC"
+	./configure --prefix=$(INSTALL_DIR) --disable-minidebuginfo --disable-shared --enable-static CXXFLAGS="-fPIC" CFLAGS="-fPIC"
 	# Don't really want to install latex:
 	sed -e 's/latex2man/echo/' -e 's/pdflatex/echo/' -ibak doc/Makefile
 


### PR DESCRIPTION
Done by:
- Configuring libunwind such that it does not require liblzma
- Explicitly stating that tcmalloc should link libunwind