### PR TITLE
Python: ASN1 parsing of UTC time missing the Z suffix

### DIFF
--- a/python/ct/crypto/asn1/x509_time.py
+++ b/python/ct/crypto/asn1/x509_time.py
@@ -13,7 +13,7 @@ class BaseTime(types.ASN1String):
         super(BaseTime, self).__init__(value=value,
                                        serialized_value=serialized_value,
                                        strict=strict)
-        self._gmtime = self._decode_gmtime()
+        self._gmtime = self._decode_gmtime(strict=strict)
         # This is a lenient "strict": if we were able to decode the time,
         # even if it didn't fully conform to the standard, then we'll allow it.
         # If the time string is garbage then we raise.
@@ -34,7 +34,7 @@ class BaseTime(types.ASN1String):
         return self._gmtime
 
     @abc.abstractmethod
-    def _decode_gmtime(self):
+    def _decode_gmtime(self, strict):
         pass
 
     def __str__(self):
@@ -59,7 +59,7 @@ class UTCTime(BaseTime):
     # YYMMDDHHMMSS
     _UTC_NO_Z_LENGTH = 12
 
-    def _decode_gmtime(self):
+    def _decode_gmtime(self, strict):
         """GMT time.
 
         Returns:
@@ -103,6 +103,9 @@ class UTCTime(BaseTime):
             #
             format = "%Y%m%d%H%M%S%Z"
             string_time = string_time[0:self._ASN1_LENGTH]
+        elif (len(string_time) == self._UTC_NO_Z_LENGTH) and not strict:
+            string_time += "Z"
+            format = "%Y%m%d%H%M%S%Z"
         else:
             return None
 
@@ -131,7 +134,7 @@ class GeneralizedTime(BaseTime):
     # YYYYMMDDHHMMSSZ
     _ASN1_LENGTH = 15
 
-    def _decode_gmtime(self):
+    def _decode_gmtime(self, strict):
         """GMT time.
 
         Returns:

--- a/python/ct/crypto/asn1/x509_time_test.py
+++ b/python/ct/crypto/asn1/x509_time_test.py
@@ -52,6 +52,12 @@ class TimeTest(unittest.TestCase):
         t = x509_time.UTCTime(value="121214093107+1234").gmtime()
         self.verify_time(t, 2012, 12, 14, 9, 31, 7)
 
+    def test_time_missing_z(self):
+        self.assertRaises(x509_time.UTCTime, value="130822153902", strict=True)
+
+        t2 = x509_time.UTCTime(value="130822153902", strict=False).gmtime()
+        self.verify_time(t2, 2013, 8, 22, 15, 39, 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
In non-strict mode, parse ASN1 UTC Time which does not end with 'Z'.
Based on the code in pull request 1080, but re-written to only do this
in non-strict mode.