### PR TITLE
Python: Fix submit_chain to work with all logs

### DIFF
--- a/python/utilities/submit_chain/submit_chain.py
+++ b/python/utilities/submit_chain/submit_chain.py
@@ -56,10 +56,8 @@ def _map_log_id_to_verifier(log_list):
     """Returns a map from log id to verifier object from the log_list."""
     log_id_to_verifier = {}
     for log_key in log_list.values():
+        key_info = verify.create_key_info_from_raw_key(log_key)
         key_id = hashlib.sha256(log_key).digest()
-        key_info = client_pb2.KeyInfo()
-        key_info.type = client_pb2.KeyInfo.ECDSA
-        key_info.pem_key = pem.to_pem(log_key, 'PUBLIC KEY')
         log_id_to_verifier[key_id] = verify.LogVerifier(key_info)
     return log_id_to_verifier
 


### PR DESCRIPTION
This is done by making it use verify.create_key_info_from_raw_key
which can cope with RSA and ECDSA key.