### PR TITLE
Python: Parse flags in tests.

### DIFF
--- a/python/ct/client/db/cert_desc_test.py
+++ b/python/ct/client/db/cert_desc_test.py
@@ -3,11 +3,13 @@
 import unittest
 
 import time
+import sys
 from ct.client.db import cert_desc
 from ct.crypto import cert
 from ct.cert_analysis import all_checks
 from ct.cert_analysis import observation
 from ct.test import time_utils
+import gflags
 
 CERT = cert.Certificate.from_der_file("ct/crypto/testdata/google_cert.der")
 CA_CERT = cert.Certificate.from_pem_file("ct/crypto/testdata/verisign_intermediate.pem")
@@ -194,4 +196,5 @@ class CertificateDescriptionTest(unittest.TestCase):
                          cert_desc.to_unicode("R\xED\xAF\xA0S"))
 
 if __name__ == "__main__":
+    sys.argv = gflags.FLAGS(sys.argv)
     unittest.main()

--- a/python/ct/client/db/sqlite_cert_db_test.py
+++ b/python/ct/client/db/sqlite_cert_db_test.py
@@ -2,9 +2,11 @@
 
 import unittest
 
+import sys
 from ct.client.db import sqlite_connection as sqlitecon
 from ct.client.db import sqlite_cert_db
 from ct.client.db import cert_db_test
+import gflags
 
 class SQLiteCertDBTest(unittest.TestCase, cert_db_test.CertDBTest):
     def setUp(self):
@@ -14,4 +16,5 @@ class SQLiteCertDBTest(unittest.TestCase, cert_db_test.CertDBTest):
         return self.database
 
 if __name__ == '__main__':
+    sys.argv = gflags.FLAGS(sys.argv)
     unittest.main()

--- a/python/ct/client/reporter_test.py
+++ b/python/ct/client/reporter_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import unittest
 
+import sys
 from collections import defaultdict
 from ct.cert_analysis import asn1
 from ct.cert_analysis import base_check_test
@@ -11,6 +12,7 @@ from ct.client.db import sqlite_connection as sqlitecon
 from ct.crypto import cert
 from ct.proto import certificate_pb2
 from ct.proto import client_pb2
+import gflags
 
 STRICT_DER = cert.Certificate.from_der_file(
                     'ct/crypto/testdata/google_cert.der', False).to_der()
@@ -174,4 +176,5 @@ class CertificateReportTest(base_check_test.BaseCheckTest):
         self.assertEqual(len(report.certs()), 1)
 
 if __name__ == '__main__':
+    sys.argv = gflags.FLAGS(sys.argv)
     unittest.main()


### PR DESCRIPTION
Since these tests import modules that use gflags, flags must be parsed
at some point.