### PR TITLE
Python: Use a helper module for test files path.

### DIFF
--- a/python/ct/cert_analysis/crl_pointers_test.py
+++ b/python/ct/cert_analysis/crl_pointers_test.py
@@ -5,12 +5,12 @@ import mock
 from ct.cert_analysis import base_check_test
 from ct.cert_analysis import crl_pointers
 from ct.crypto import cert
+from ct.test import test_config
 
-CRYPTO_TEST_DATA_DIR = "ct/crypto/testdata/"
-CERT_WITH_CRL = cert.Certificate.from_pem_file(CRYPTO_TEST_DATA_DIR +
-                                                "aia.pem")
-CERT_WITHOUT_CRL = cert.Certificate.from_pem_file(CRYPTO_TEST_DATA_DIR +
-                                                   "promise_com.pem")
+CERT_WITH_CRL = cert.Certificate.from_pem_file(
+        test_config.get_test_file_path("aia.pem"))
+CERT_WITHOUT_CRL = cert.Certificate.from_pem_file(
+        test_config.get_test_file_path("promise_com.pem"))
 
 class CrlPointersTest(base_check_test.BaseCheckTest):
     def test_crl_existence_exist(self):

--- a/python/ct/cert_analysis/ocsp_pointers_test.py
+++ b/python/ct/cert_analysis/ocsp_pointers_test.py
@@ -5,12 +5,12 @@ import mock
 from ct.cert_analysis import base_check_test
 from ct.cert_analysis import ocsp_pointers
 from ct.crypto import cert
+from ct.test import test_config
 
-CRYPTO_TEST_DATA_DIR = "ct/crypto/testdata/"
-CERT_WITH_OCSP = cert.Certificate.from_pem_file(CRYPTO_TEST_DATA_DIR +
-                                                "aia.pem")
-CERT_WITHOUT_OCSP = cert.Certificate.from_pem_file(CRYPTO_TEST_DATA_DIR +
-                                                   "promise_com.pem")
+CERT_WITH_OCSP = cert.Certificate.from_pem_file(
+        test_config.get_test_file_path("aia.pem"))
+CERT_WITHOUT_OCSP = cert.Certificate.from_pem_file(
+        test_config.get_test_file_path("promise_com.pem"))
 
 class OcspPointersTest(base_check_test.BaseCheckTest):
     def test_ocsp_existence_exist(self):

--- a/python/ct/client/db/cert_desc_test.py
+++ b/python/ct/client/db/cert_desc_test.py
@@ -8,13 +8,18 @@ from ct.client.db import cert_desc
 from ct.crypto import cert
 from ct.cert_analysis import all_checks
 from ct.cert_analysis import observation
+from ct.test import test_config
 from ct.test import time_utils
 import gflags
 
-CERT = cert.Certificate.from_der_file("ct/crypto/testdata/google_cert.der")
-CA_CERT = cert.Certificate.from_pem_file("ct/crypto/testdata/verisign_intermediate.pem")
-DSA_SHA256_CERT = cert.Certificate.from_der_file("ct/crypto/testdata/dsa_with_sha256.der")
-BAD_UTF8_CERT = cert.Certificate.from_pem_file("ct/crypto/testdata/cert_bad_utf8_subject.pem")
+CERT = cert.Certificate.from_der_file(
+        test_config.get_test_file_path("google_cert.der"))
+CA_CERT = cert.Certificate.from_pem_file(
+        test_config.get_test_file_path("verisign_intermediate.pem"))
+DSA_SHA256_CERT = cert.Certificate.from_der_file(
+        test_config.get_test_file_path("dsa_with_sha256.der"))
+BAD_UTF8_CERT = cert.Certificate.from_pem_file(
+        test_config.get_test_file_path("cert_bad_utf8_subject.pem"))
 
 class CertificateDescriptionTest(unittest.TestCase):
     def get_observations(self, source):

--- a/python/ct/client/reporter_test.py
+++ b/python/ct/client/reporter_test.py
@@ -12,19 +12,20 @@ from ct.client.db import sqlite_connection as sqlitecon
 from ct.crypto import cert
 from ct.proto import certificate_pb2
 from ct.proto import client_pb2
+from ct.test import test_config
 import gflags
 
 STRICT_DER = cert.Certificate.from_der_file(
-                    'ct/crypto/testdata/google_cert.der', False).to_der()
+        test_config.get_test_file_path('google_cert.der'), False).to_der()
 NON_STRICT_DER = cert.Certificate.from_pem_file(
-                    'ct/crypto/testdata/invalid_ip.pem', False).to_der()
+        test_config.get_test_file_path('invalid_ip.pem'), False).to_der()
 
-CHAIN_FILE = 'ct/crypto/testdata/google_chain.pem'
+CHAIN_FILE = test_config.get_test_file_path('google_chain.pem')
 
 CHAIN_DERS = [c.to_der() for c in cert.certs_from_pem_file(CHAIN_FILE)]
 
 SELF_SIGNED_ROOT_DER = cert.Certificate.from_pem_file(
-                    'ct/crypto/testdata/subrigo_net.pem', False).to_der()
+        test_config.get_test_file_path('subrigo_net.pem'), False).to_der()
 
 def readable_dn(dn_attribs):
     return ",".join(["%s=%s" % (attr.type, attr.value) for attr in dn_attribs])

--- a/python/ct/test/test_config.py
+++ b/python/ct/test/test_config.py
@@ -1,0 +1,8 @@
+"""Test meta-data and configuration."""
+
+import os
+
+CRYPTO_TEST_DATA_DIR = "ct/crypto/testdata/"
+
+def get_test_file_path(filename):
+    return os.path.join(os.curdir, CRYPTO_TEST_DATA_DIR, filename)


### PR DESCRIPTION
This change encapsulates a method to find out where test data files
are. It allows changing the mechanism through which these paths are
supplied in a centralized manner.