### PR TITLE
Python: Make more tests use test_config

### DIFF
--- a/python/ct/cert_analysis/common_name_test.py
+++ b/python/ct/cert_analysis/common_name_test.py
@@ -8,6 +8,7 @@ from ct.cert_analysis import common_name
 from ct.cert_analysis import tld_check
 from ct.cert_analysis import tld_list
 from ct.crypto import cert
+from ct.test import test_config
 
 def gen_common_name(name):
     common_name = mock.Mock()
@@ -19,9 +20,6 @@ def cert_with_urls(*args):
     certificate.subject_common_names = mock.Mock(return_value=list(args))
     return certificate
 
-tlds = tld_list.TLDList(tld_dir="ct/cert_analysis/test_data/",
-                        tld_file_name="test_tld_list")
-
 EXAMPLE = gen_common_name("example.com")
 NOT_TLD = gen_common_name("asdf.asdf")
 CA_NAME = gen_common_name("Trusty CA Ltd.")
@@ -31,7 +29,7 @@ NON_UNICODE_TLD = gen_common_name("\xff\x00.com")
 class CommonNameTest(base_check_test.BaseCheckTest):
     def setUp(self):
         tld_check.CheckTldMatches.TLD_LIST_ = tld_list.TLDList(
-                tld_dir="ct/cert_analysis/test_data/",
+                tld_dir=test_config.get_tld_directory(),
                 tld_file_name="test_tld_list")
 
     def test_common_name_tld_match(self):

--- a/python/ct/cert_analysis/dnsnames_test.py
+++ b/python/ct/cert_analysis/dnsnames_test.py
@@ -7,6 +7,7 @@ from ct.cert_analysis import base_check_test
 from ct.cert_analysis import dnsnames
 from ct.cert_analysis import tld_list
 from ct.cert_analysis import tld_check
+from ct.test import test_config
 
 def gen_dns_name(name):
     dns_name = mock.Mock()
@@ -17,9 +18,6 @@ def cert_with_urls(*args):
     certificate = mock.MagicMock()
     certificate.subject_dns_names = mock.Mock(return_value=list(args))
     return certificate
-
-tlds = tld_list.TLDList(tld_dir="ct/cert_analysis/test_data/",
-                        tld_file_name="test_tld_list")
 
 EXAMPLE = gen_dns_name("example.com")
 EXAMPLE_WILDCARD = gen_dns_name("*.example.com")
@@ -34,7 +32,7 @@ NON_UNICODE_TLD = gen_dns_name("\xff\x00.com")
 class DnsnamesTest(base_check_test.BaseCheckTest):
     def setUp(self):
         tld_check.CheckTldMatches.TLD_LIST_ = tld_list.TLDList(
-                tld_dir="ct/cert_analysis/test_data/",
+                tld_dir=test_config.get_tld_directory(),
                 tld_file_name="test_tld_list")
 
     def test_dnsnames_valid(self):

--- a/python/ct/cert_analysis/tld_list_test.py
+++ b/python/ct/cert_analysis/tld_list_test.py
@@ -3,13 +3,13 @@
 import unittest
 
 from ct.cert_analysis import tld_list
+from ct.test import test_config
 
-TLD_DIR = "ct/cert_analysis/test_data/"
 TLD_FILE  = "test_tld_list"
 
 class TLDListTest(unittest.TestCase):
     def default_list(self):
-        return tld_list.TLDList(tld_dir=TLD_DIR,
+        return tld_list.TLDList(tld_dir=test_config.get_tld_directory(),
                                 tld_file_name=TLD_FILE)
 
     def test_tld_list_example_matches(self):

--- a/python/ct/client/db_reporter_test.py
+++ b/python/ct/client/db_reporter_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
-import mock
 import unittest
+
+import mock
 from ct.client import db_reporter
 
 

--- a/python/ct/crypto/cert_test.py
+++ b/python/ct/crypto/cert_test.py
@@ -3,18 +3,13 @@
 
 import unittest
 
-import gflags
 import time
-import sys
 from ct.crypto import cert
 from ct.crypto import error
 from ct.crypto.asn1 import oid
 from ct.crypto.asn1 import x509_extension as x509_ext
 from ct.crypto.asn1 import x509_name
-
-FLAGS = gflags.FLAGS
-gflags.DEFINE_string("testdata_dir", "ct/crypto/testdata",
-                     "Location of test certs")
+from ct.test import test_config
 
 class CertificateTest(unittest.TestCase):
     _PEM_FILE = "google_cert.pem"
@@ -111,10 +106,10 @@ class CertificateTest(unittest.TestCase):
 
     @property
     def pem_file(self):
-        return FLAGS.testdata_dir + "/" + self._PEM_FILE
+        return test_config.get_test_file_path(self._PEM_FILE)
 
     def get_file(self, filename):
-        return FLAGS.testdata_dir + "/" + filename
+        return test_config.get_test_file_path(filename)
 
     def cert_from_pem_file(self, filename, strict=True):
         return cert.Certificate.from_pem_file(
@@ -745,5 +740,4 @@ class CertificateTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.argv = FLAGS(sys.argv)
     unittest.main()

--- a/python/ct/test/test_config.py
+++ b/python/ct/test/test_config.py
@@ -3,6 +3,10 @@
 import os
 
 CRYPTO_TEST_DATA_DIR = "ct/crypto/testdata/"
+CERT_ANALYSIS_DATA_DIR = "ct/cert_analysis/test_data"
 
 def get_test_file_path(filename):
     return os.path.join(os.curdir, CRYPTO_TEST_DATA_DIR, filename)
+
+def get_tld_directory():
+    return os.path.join(os.curdir, CERT_ANALYSIS_DATA_DIR)


### PR DESCRIPTION
Tests that need a test TLDList have been converted, as well as a few tests that
were left behind on the previous round.