### PR TITLE
Check "ct connect" flags

### DIFF
--- a/cpp/client/ct.cc
+++ b/cpp/client/ct.cc
@@ -573,6 +573,9 @@ static void WriteSSLClientCTData(const SSLClientCTData& ct_data,
 static SSLClient::HandshakeResult Connect() {
   LogVerifier* verifier = GetLogVerifierFromFlags();
 
+  CHECK(!FLAGS_ssl_server.empty()) << "Must specify --ssl_server";
+  CHECK_NE(0, FLAGS_ssl_server_port) << "Must specify --ssl_server_port";
+
   SSLClient client(FLAGS_ssl_server, FLAGS_ssl_server_port,
                    FLAGS_ssl_client_trusted_cert_dir, verifier);
 


### PR DESCRIPTION
Checks that --ssl_server and --ssl_server_port are specified when using the "ct connect" command. Avoids the more cryptic error message of `Check failed: 1 == inet_aton(server_.c_str(), &server_socket.sin_addr) (1 vs. 0) Can't parse server address: `