### PR TITLE
Remove 'duplicate' fixed chains.

### DIFF
--- a/go/fixchain/fixer.go
+++ b/go/fixchain/fixer.go
@@ -3,7 +3,6 @@ package fixchain
 import (
 	"bytes"
 	"log"
-	"math"
 	"net/http"
 	"sort"
 	"sync"
@@ -87,12 +86,19 @@ type chainSlice struct {
 	chains [][]*x509.Certificate
 }
 
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
 // sort.Sort(data Interface) for chainSlice - uses data.Len, data.Less & data.Swap.
 func (c chainSlice) Len() int { return len(c.chains) }
 func (c chainSlice) Less(i, j int) bool {
 	chi := c.chains[i]
 	chj := c.chains[j]
-	for k := 0; k < int(math.Min(float64(len(chi)), float64(len(chj)))); k++ {
+	for k := 0; k < min(len(chi), len(chj)); k++ {
 		if !chi[k].Equal(chj[k]) {
 			return bytes.Compare(chi[k].Raw, chj[k].Raw) < 0
 		}

--- a/go/fixchain/fixer_test.go
+++ b/go/fixchain/fixer_test.go
@@ -102,6 +102,88 @@ func TestFixServer(t *testing.T) {
 	wg.Wait()
 }
 
+func TestRemoveSuperChains(t *testing.T) {
+	superChainsTests := []struct {
+		chains         [][]string
+		expectedChains [][]string
+	}{
+		{
+			chains: [][]string{
+				[]string{googleLeaf, thawteIntermediate},
+				[]string{googleLeaf},
+			},
+			expectedChains: [][]string{
+				[]string{"Google"},
+			},
+		},
+		{
+			chains: [][]string{
+				[]string{googleLeaf, verisignRoot},
+				[]string{googleLeaf, thawteIntermediate},
+				[]string{googleLeaf},
+			},
+			expectedChains: [][]string{
+				[]string{"Google"},
+			},
+		},
+		{
+			chains: [][]string{
+				[]string{googleLeaf, thawteIntermediate, verisignRoot},
+				[]string{googleLeaf, thawteIntermediate},
+				[]string{googleLeaf},
+			},
+			expectedChains: [][]string{
+				[]string{"Google"},
+			},
+		},
+		{
+			chains: [][]string{
+				[]string{googleLeaf, thawteIntermediate, verisignRoot},
+				[]string{googleLeaf},
+			},
+			expectedChains: [][]string{
+				[]string{"Google"},
+			},
+		},
+		{
+			chains: [][]string{
+				[]string{googleLeaf, thawteIntermediate, verisignRoot},
+				[]string{googleLeaf, verisignRoot},
+				[]string{googleLeaf, thawteIntermediate},
+			},
+			expectedChains: [][]string{
+				[]string{"Google", "Thawte"},
+				[]string{"Google", "VeriSign"},
+			},
+		},
+		{
+			chains: [][]string{
+				[]string{testLeaf, testIntermediate2},
+				[]string{googleLeaf, thawteIntermediate, verisignRoot},
+				[]string{testLeaf, testIntermediate2, testIntermediate1, testRoot},
+				[]string{googleLeaf, verisignRoot},
+				[]string{testLeaf, testIntermediate2, testIntermediate1},
+				[]string{googleLeaf, thawteIntermediate},
+				[]string{testLeaf, googleLeaf, thawteIntermediate, verisignRoot},
+			},
+			expectedChains: [][]string{
+				[]string{"Google", "Thawte"},
+				[]string{"Google", "VeriSign"},
+				[]string{"Leaf", "Intermediate2"},
+				[]string{"Leaf", "Google", "Thawte", "VeriSign"},
+			},
+		},
+	}
+
+	for i, test := range superChainsTests {
+		var chains [][]*x509.Certificate
+		for _, chain := range test.chains {
+			chains = append(chains, extractTestChain(t, i, chain))
+		}
+		matchTestChainList(t, i, test.expectedChains, removeSuperChains(chains))
+	}
+}
+
 // Fixer.updateCounters() tests
 func TestUpdateCounters(t *testing.T) {
 	counterTests := []struct {

--- a/go/fixchain/fixer_test.go
+++ b/go/fixchain/fixer_test.go
@@ -208,7 +208,7 @@ func TestUpdateCounters(t *testing.T) {
 		for _, err := range test.errors {
 			ferrs = append(ferrs, &FixError{Type: err})
 		}
-		f.updateCounters(ferrs)
+		f.updateCounters(nil, ferrs)
 
 		if f.reconstructed != test.reconstructed {
 			t.Errorf("#%d: Incorrect value for reconstructed, wanted %d, got %d", i, test.reconstructed, f.reconstructed)


### PR DESCRIPTION
...where duplicate means that one chain is a subchain of another.
e.g. A -> B is a subchain of A -> B -> C.  However, we do not
consider A -> B to be a subchain of Z -> A -> B.  The subchains
must at the leaf.

This is to prevent the preloader logging more chain than it needs to.