### PR TITLE
Add support for DSA signature checking under BoringSSL + tests

### DIFF
--- a/cpp/log/cert.cc
+++ b/cpp/log/cert.cc
@@ -44,6 +44,102 @@ static int X509_get_signature_nid(const X509* x) {
 #endif
 
 
+namespace {
+#if defined(OPENSSL_IS_BORINGSSL)
+// BoringSSL doesn't have DSA hooked up so to accept these certs we have
+// to do the work ourselves. Can be called with a non DSA issuer key but will
+// always return false in that case.
+//
+// cert is the certificate that is to be checked
+// issuer_key is the public key of the certificate issuer (should be DSA)
+// Returns true if the DSA signature was correctly verified or false if
+// it did not or there was any error along the way.
+StatusOr<bool> check_dsa_signature(const X509* cert,
+                                   EVP_PKEY* issuer_key) {
+  // Before we start rummaging about through pointers ensure everything we need
+  // is present
+  if (!cert || !issuer_key || !X509_get_cert_info(cert)) {
+    return ::util::Status(Code::FAILED_PRECONDITION,
+                          "cert is null or missing cert_info");
+  }
+
+  X509_CINF* cert_info = X509_get_cert_info(cert);
+  const X509_ALGOR* sig = X509_CINF_get_signature(cert_info);
+
+  if (!sig) {
+    return ::util::Status(Code::FAILED_PRECONDITION,
+                          "cert is missing a signature");
+  }
+
+  // If the following breaks at some future point it might need to be
+  // replaced by EVP_PKEY_base_id(issuer_key)
+  if (EVP_PKEY_type(issuer_key->type) != EVP_PKEY_DSA ||
+      X509_get_signature_type(cert) != EVP_PKEY_DSA) {
+    return ::util::Status(Code::FAILED_PRECONDITION,
+                          "cert or issuer does not have a DSA public key");
+  }
+
+  const int alg_nid = OBJ_obj2nid(sig->algorithm);
+
+  int digest_nid;
+  // We need the nid of the digest so we can create an EVP_MD for it later.
+  // Should succeed as we already checked we have a DSA key
+  if (!OBJ_find_sigid_algs(alg_nid, &digest_nid, nullptr)) {
+    return ::util::Status(Code::INTERNAL, "lookup sigid for algorithm failed");
+  }
+
+  // Get the DER encoded certificate info from the cert
+  std::unique_ptr<unsigned char*> der_buf_ptr(nullptr);
+  const int der_length = i2d_X509_CINF(cert_info, der_buf_ptr.get());
+  if (der_length < 0) {
+    // What does this return value mean? Let's assume it means the cert
+    // is bad until proven otherwise.
+    LOG(WARNING) << "Failed to serialize the CINF component";
+    LOG_OPENSSL_ERRORS(WARNING);
+    return ::util::Status(Code::INVALID_ARGUMENT,
+                          "failed to serialize cert info");
+  }
+
+  // If the key is missing parameters we don't accept it. This is allowed
+  // by RFC 3279 but we have not found any examples in the wild where it's
+  // used.
+  if (EVP_PKEY_missing_parameters(issuer_key)) {
+    LOG(WARNING) << "DSA sig check needs key params but not available";
+    return ::util::Status(Code::INVALID_ARGUMENT,
+                          "DSA key in cert has missing parameters");
+  }
+
+  const DSA* dsa = EVP_PKEY_get0_DSA(issuer_key);
+  const EVP_MD* md = EVP_get_digestbynid(digest_nid);
+
+  if (dsa == nullptr || md == nullptr) {
+    return ::util::Status(Code::INTERNAL,
+                          "failed to create hasher or get DSA sig");
+  }
+
+  unsigned char md_buffer[EVP_MAX_MD_SIZE];
+  unsigned int md_size;
+
+  // Build the digest of the cert info. Can't use higher level APIs for
+  // this unfortunately as DSA is not connected up.
+  if (!EVP_Digest(der_buf_ptr.get(), der_length, md_buffer, &md_size, md,
+                  nullptr)) {
+    return ::util::Status(Code::INTERNAL, "digest failed");
+  }
+
+  int out_valid;
+  if (!DSA_check_signature(&out_valid, md_buffer, md_size,
+                           cert->signature->data, cert->signature->length,
+                           dsa)) {
+    return ::util::Status(Code::INTERNAL, "failed to check DSA signature");
+  }
+
+  return out_valid != 0;
+}
+
+#endif
+}
+
 namespace cert_trans {
 
 
@@ -370,6 +466,24 @@ StatusOr<bool> Cert::IsSignedBy(const Cert& issuer) const {
   if (ret == 1) {
     return true;
   }
+
+#if defined(OPENSSL_IS_BORINGSSL)
+  // With BoringSSL we might have a signature algorithm that is not supported
+  // by X509_verify but we still want to accept into a log. This is a weaker
+  // check than x509_verify but sufficient for our needs as we are rejecting
+  // spam rather than intending to trust the certificate.
+  // Let's see if we can verify a DSA signature
+  const StatusOr<bool> is_valid_dsa_sig =
+      check_dsa_signature(x509_.get(), issuer_key.get());
+
+  if (is_valid_dsa_sig.ok() && is_valid_dsa_sig.ValueOrDie()) {
+    ClearOpenSSLErrors();
+    return true;
+  }
+
+  LOG(ERROR) << "check_dsa_signature returned: " << is_valid_dsa_sig.status();
+#endif
+
   unsigned long err = ERR_peek_last_error();
   const int reason = ERR_GET_REASON(err);
   const int lib = ERR_GET_LIB(err);
@@ -381,6 +495,7 @@ StatusOr<bool> Cert::IsSignedBy(const Cert& issuer) const {
     ClearOpenSSLErrors();
     return false;
   }
+
   if (lib == ERR_LIB_EVP &&
       (reason == EVP_R_UNKNOWN_MESSAGE_DIGEST_ALGORITHM ||
        reason == EVP_R_UNKNOWN_SIGNATURE_ALGORITHM)) {
@@ -1061,7 +1176,6 @@ util::Status Cert::IsValidNameConstrainedIntermediateCa() const {
   return util::Status::OK;
 }
 
-
 TbsCertificate::TbsCertificate(const Cert& cert) {
   if (!cert.IsLoaded()) {
     LOG(ERROR) << "Cert not loaded";
@@ -1373,7 +1487,8 @@ util::Status CertChain::IsValidSignatureChain() const {
     const unique_ptr<Cert>& subject = *it;
     const unique_ptr<Cert>& issuer = *(it + 1);
 
-    const StatusOr<bool> status = subject->IsSignedBy(*issuer);
+    const StatusOr<bool> status =
+        subject->IsSignedBy(*issuer);
 
     // Propagate any failure status if we get one. This includes
     // UNIMPLEMENTED for unsupported algorithms. This can happen

--- a/cpp/log/cert_checker_test.cc
+++ b/cpp/log/cert_checker_test.cc
@@ -101,6 +101,193 @@ static const char kIntermediateCertPem[] =
     "iBEUO5P6TnqH3TfhOF8sKQg=\n"
     "-----END CERTIFICATE-----\n";
 
+static const char kDsaPrecertChain[] =
+"-----BEGIN CERTIFICATE-----\n"
+"MIIGbzCCBhWgAwIBAgIQQyzKVQswSJU51uhTRKJOcjALBglghkgBZQMEAwIwQDEL\n"
+"MAkGA1UEBhMCVVMxFTATBgNVBAoTDHRoYXd0ZSwgSW5jLjEaMBgGA1UEAxMRdGhh\n"
+"d3RlIERTQSBTU0wgQ0EwHhcNMTUxMjI5MDAwMDAwWhcNMTcxMjI3MjM1OTU5WjCB\n"
+"pzETMBEGCysGAQQBgjc8AgEDEwJHRTEdMBsGA1UEDxMUUHJpdmF0ZSBPcmdhbml6\n"
+"YXRpb24xEzARBgNVBAoUClVuaVBBWSBMVEQxEjAQBgNVBAUTCTQwMTk1Mzk5OTEL\n"
+"MAkGA1UEBhMCR0UxEDAOBgNVBAgTB1RiaWxpc2kxEDAOBgNVBAcUB1RiaWxpc2kx\n"
+"FzAVBgNVBAMUDnd3dy51bmlwYXkuY29tMIIDRzCCAjoGByqGSM44BAEwggItAoIB\n"
+"AQClyTxv5WDYR4Dv2+pCaEEFTtEayHGtbMmaHG3RR24DVgxtlS//xmk6z4fO03uj\n"
+"EdxylJ7UDZp1GrYxJXts2bixxH2jsoiuzs/PiCyS1TGsrdkD5Vi/y3wkYRzM3iBt\n"
+"abKu23ZANP6WansDX4jILYxOs2cc4GEQepOsuHqn2LWCBvxGP3KmTo0YwuV+sSO8\n"
+"IFTvHsGb0ZFKzZdFfjqPxXbGXiCGHHhuispi23SKqHEXdRjlyuWRjCDHJsyefKTk\n"
+"HW+1nx7lSZIBBB6tPXxdtk/cNcJESoZmXl9aNsYdo/63mQI5aA6iUXX09/FNTIMh\n"
+"dp3aoQHePhdGRRTOxoADIrVNAiEA45OTlEY+5SayLLZyqvLduEKEzOntK0ssMIUp\n"
+"GIXGMo8CggEBAJlGxvWVGST03IYlimBHX4VNpkuKqXGyMSnjNP0niqxVYmEjDUeN\n"
+"cqyoBoBEJO1wsT2/v4IUQXQoQ5yW95D/sfXEF806MLqkgzOPNhXHZsyjqntHMAKj\n"
+"t4hi9XOfjHUKXDINGpk0AwAk1Aajj4DavWjZ/8gBZWgkNHjNnV9UuBnIeBJmOO7C\n"
+"s57cQ98p3TpGHgk0l8+r3ELnaLf/UhJRr6C7SGIEdddMXGbnR1w968IRVZygL7lx\n"
+"3UF9XJFGcR6TuKt5/PA8oxqU+Phl+EEJm7TJ/+pT5KLEo+o0DghM4GVKC6h9u/gg\n"
+"4gBdsEQ4OtkLZ1pSU+Nvyz22TVWTz3D35XoDggEFAAKCAQA//na/RFHzfeuYBoaY\n"
+"0v4SkKwNwAInGn7pAvaF8AiENwesVnVTu8l7z+hi1CYv4fEGJNKkf44j6TTwjds8\n"
+"QTjJbGrg5RzXp3LGrJbAzW8zW/CxabF0pMo4eod3NjTC4sSgVTMawpw2oag/1T79\n"
+"LmDeGEJPbajmUUee9tfJJQK/UirzcB1n9/O2GK0Uthu8rH77IQPcM5Y8ambgwbIG\n"
+"eFXMSU1AODKj83kqPJmRvDcAIQs5ShA+yghs6qfA1m9V4At2sQtgf7iVkD6HKH9X\n"
+"v8izGABvDBVlk3ZRW2WXMeTyGeCl1T43+mnXMGs9i4r1KDuFdt/0WbXVA+F7AVYy\n"
+"u/cGo4IBljCCAZIwJQYDVR0RBB4wHIIKdW5pcGF5LmNvbYIOd3d3LnVuaXBheS5j\n"
+"b20wCQYDVR0TBAIwADAOBgNVHQ8BAf8EBAMCB4AwKwYDVR0fBCQwIjAgoB6gHIYa\n"
+"aHR0cDovL3RlLnN5bWNiLmNvbS90ZS5jcmwwcwYDVR0gBGwwajBoBgtghkgBhvhF\n"
+"AQcwATBZMCYGCCsGAQUFBwIBFhpodHRwczovL3d3dy50aGF3dGUuY29tL2NwczAv\n"
+"BggrBgEFBQcCAjAjDCFodHRwczovL3d3dy50aGF3dGUuY29tL3JlcG9zaXRvcnkw\n"
+"HQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFMoTsU3s\n"
+"mn62fEUeuB3k0shyGrEdMFcGCCsGAQUFBwEBBEswSTAfBggrBgEFBQcwAYYTaHR0\n"
+"cDovL3RlLnN5bWNkLmNvbTAmBggrBgEFBQcwAoYaaHR0cDovL3RlLnN5bWNiLmNv\n"
+"bS90ZS5jcnQwEwYKKwYBBAHWeQIEAwEB/wQCBQAwCwYJYIZIAWUDBAMCA0cAMEQC\n"
+"IGqj1ElLQljLIir0ZWTzmr0wOXG2B8X649SNqOHhzXikAiAE9qn9RiIe/fpphfnx\n"
+"jks8c0MAUgqmpKIZWTpvNhja6Q==\n"
+"-----END CERTIFICATE-----\n"
+"-----BEGIN CERTIFICATE-----\n"
+"MIIGJDCCBcmgAwIBAgIQbT3s+pt4qr0oAI3ZcDdjDjALBglghkgBZQMEAwIwga4x\n"
+"CzAJBgNVBAYTAlVTMRUwEwYDVQQKEwx0aGF3dGUsIEluYy4xKDAmBgNVBAsTH0Nl\n"
+"cnRpZmljYXRpb24gU2VydmljZXMgRGl2aXNpb24xODA2BgNVBAsTLyhjKSAyMDEy\n"
+"IHRoYXd0ZSwgSW5jLiAtIEZvciBhdXRob3JpemVkIHVzZSBvbmx5MSQwIgYDVQQD\n"
+"Ext0aGF3dGUgUHJpbWFyeSBSb290IENBIC0gRzQwHhcNMTIxMjIwMDAwMDAwWhcN\n"
+"MjIxMjE5MjM1OTU5WjBAMQswCQYDVQQGEwJVUzEVMBMGA1UEChMMdGhhd3RlLCBJ\n"
+"bmMuMRowGAYDVQQDExF0aGF3dGUgRFNBIFNTTCBDQTCCA0gwggI6BgcqhkjOOAQB\n"
+"MIICLQKCAQEAsOkfT0p9OXj0/j9H+m2Ejyu6VTLpjydK1/dWyl/AQS5WE5GPgy0i\n"
+"6oJQCSEKLcZtJCcnrx9X2WJq/U9sxSydq0oP1R7BqXiRs3fphkJnBhW/OGJNnw13\n"
+"dnBrt9ffmaZNFFRCUQOsGDsSjBPOUQ4tuenBeF3Zs+DAfkDXzxcrK4OQs6qTYubn\n"
+"8QUphcoMaUURJv9aY8VfVpODN3Z5FeamrY72zAcGvc9ajFl45vVlK/dDbu8kMMdp\n"
+"b1wuNMTWUo/dxdPrtgpJA3ZnN9MDSzs2tcGWxYnpWFZTndTePn7xU0b3r/pN/ys7\n"
+"i5FBr1yqYVWelt5uGLMg+ZQ22GQnga8/eQIhAKdVID3cRKJNm0Rd77SM/GgY430w\n"
+"mefDvxS6pQDGnAzXAoIBAQCLQiKLU8kRBsWIkeuRPKlbqwSMkbNwaOYK6/Lh8x5k\n"
+"20djAqPOurHtzNWnAPAvZPYSjL+PR1ydHq4tRDEgjaVYlb5ZZeD8L6v0J/OWNTpS\n"
+"SmeKzHfD1QRP/2dxqiNweivUR4vw7m6wg8Y5ZxOFKbgAfdM08z2hbjkucrCzkbCr\n"
+"0NQUkUy+N4gvMKOIVDYVUiKUFSJmlRiYlCXJNaoIkKWcb4NjRBHjDKbmm4+Isco4\n"
+"PUQ3E7V+CdS6C8hOPdDwhcYm6FPrgbTPcuuoJgEI6YXjgywGCMja6zwEmU1F9NH6\n"
+"9TmpZiKCFDVhrBd5KgOemiiveAE2AAU1ctYz1pkqt2dXA4IBBgACggEBAJzaudYH\n"
+"djJGC5gPXFS+oWZc4SEicF5teHo2ZkI86j8TDGZWBCXHng3m/JrY3qT11tBU4go/\n"
+"XR5AQ9GYtLAiOXZKIdFSjyjrDGVotWNxpoZi1hXpVEsCAEwyWqKdO+47zUF2/tgc\n"
+"QzAnAwbb2NV9D35rg3wKenUKdQfp98PrlWUh2UOmFkae83eLr/7VxEF4nOF+CI/4\n"
+"Kx9y6Qy3So/OHucSp8206yqJ80EyYox9cnAeS81xBwJqn1LIPRFGJ85cEXRldATI\n"
+"+CvgvfdnpWnJaPPUvJoaPF9DVfi4FTGV7aFfeQfi9QemF8WMPq0JpdrFkfrnGVw9\n"
+"wxGzySeiXj7UDhKjggFCMIIBPjASBgNVHRMBAf8ECDAGAQH/AgEAMA4GA1UdDwEB\n"
+"/wQEAwIBBjAyBggrBgEFBQcBAQQmMCQwIgYIKwYBBQUHMAGGFmh0dHA6Ly9vY3Nw\n"
+"LnRoYXd0ZS5jb20wOwYDVR0gBDQwMjAwBgRVHSAAMCgwJgYIKwYBBQUHAgEWGmh0\n"
+"dHBzOi8vd3d3LnRoYXd0ZS5jb20vY3BzMDcGA1UdHwQwMC4wLKAqoCiGJmh0dHA6\n"
+"Ly9jcmwudGhhd3RlLmNvbS9UaGF3dGVQQ0EtRzQuY3JsMC4GA1UdEQQnMCWkIzAh\n"
+"MR8wHQYDVQQDExZTWU1DLURTQS1DQS0yMDQ4LTI1Ni00MB0GA1UdDgQWBBTKE7FN\n"
+"7Jp+tnxFHrgd5NLIchqxHTAfBgNVHSMEGDAWgBTHZ4lkIvGdsfOLg6bCDpmTUXbr\n"
+"ljALBglghkgBZQMEAwIDSAAwRQIhAKb8sDyC2UehqUcEPUQ65bnmmtiplEplDUZt\n"
+"ULqZQweDAiAr4MAcnfC9otwLcBllGVA4vsOKPsFSq5u2EPn3ovIynw==\n"
+"-----END CERTIFICATE-----\n";
+
+// This was generated from the above by manually flipping a bit
+// in one of the signature bytes of the precert.
+static const char kDsaPrecertChainInvalidSig[] =
+"-----BEGIN CERTIFICATE-----\n"
+"MIIGbzCCBhWgAwIBAgIQQyzKVQswSJU51uhTRKJOcjALBglghkgBZQMEAwIwQDEL\n"
+"MAkGA1UEBhMCVVMxFTATBgNVBAoTDHRoYXd0ZSwgSW5jLjEaMBgGA1UEAxMRdGhh\n"
+"d3RlIERTQSBTU0wgQ0EwHhcNMTUxMjI5MDAwMDAwWhcNMTcxMjI3MjM1OTU5WjCB\n"
+"pzETMBEGCysGAQQBgjc8AgEDEwJHRTEdMBsGA1UEDxMUUHJpdmF0ZSBPcmdhbml6\n"
+"YXRpb24xEzARBgNVBAoUClVuaVBBWSBMVEQxEjAQBgNVBAUTCTQwMTk1Mzk5OTEL\n"
+"MAkGA1UEBhMCR0UxEDAOBgNVBAgTB1RiaWxpc2kxEDAOBgNVBAcUB1RiaWxpc2kx\n"
+"FzAVBgNVBAMUDnd3dy51bmlwYXkuY29tMIIDRzCCAjoGByqGSM44BAEwggItAoIB\n"
+"AQClyTxv5WDYR4Dv2+pCaEEFTtEayHGtbMmaHG3RR24DVgxtlS//xmk6z4fO03uj\n"
+"EdxylJ7UDZp1GrYxJXts2bixxH2jsoiuzs/PiCyS1TGsrdkD5Vi/y3wkYRzM3iBt\n"
+"abKu23ZANP6WansDX4jILYxOs2cc4GEQepOsuHqn2LWCBvxGP3KmTo0YwuV+sSO8\n"
+"IFTvHsGb0ZFKzZdFfjqPxXbGXiCGHHhuispi23SKqHEXdRjlyuWRjCDHJsyefKTk\n"
+"HW+1nx7lSZIBBB6tPXxdtk/cNcJESoZmXl9aNsYdo/63mQI5aA6iUXX09/FNTIMh\n"
+"dp3aoQHePhdGRRTOxoADIrVNAiEA45OTlEY+5SayLLZyqvLduEKEzOntK0ssMIUp\n"
+"GIXGMo8CggEBAJlGxvWVGST03IYlimBHX4VNpkuKqXGyMSnjNP0niqxVYmEjDUeN\n"
+"cqyoBoBEJO1wsT2/v4IUQXQoQ5yW95D/sfXEF806MLqkgzOPNhXHZsyjqntHMAKj\n"
+"t4hi9XOfjHUKXDINGpk0AwAk1Aajj4DavWjZ/8gBZWgkNHjNnV9UuBnIeBJmOO7C\n"
+"s57cQ98p3TpGHgk0l8+r3ELnaLf/UhJRr6C7SGIEdddMXGbnR1w968IRVZygL7lx\n"
+"3UF9XJFGcR6TuKt5/PA8oxqU+Phl+EEJm7TJ/+pT5KLEo+o0DghM4GVKC6h9u/gg\n"
+"4gBdsEQ4OtkLZ1pSU+Nvyz22TVWTz3D35XoDggEFAAKCAQA//na/RFHzfeuYBoaY\n"
+"0v4SkKwNwAInGn7pAvaF8AiENwesVnVTu8l7z+hi1CYv4fEGJNKkf44j6TTwjds8\n"
+"QTjJbGrg5RzXp3LGrJbAzW8zW/CxabF0pMo4eod3NjTC4sSgVTMawpw2oag/1T79\n"
+"LmDeGEJPbajmUUee9tfJJQK/UirzcB1n9/O2GK0Uthu8rH77IQPcM5Y8ambgwbIG\n"
+"eFXMSU1AODKj83kqPJmRvDcAIQs5ShA+yghs6qfA1m9V4At2sQtgf7iVkD6HKH9X\n"
+"v8izGABvDBVlk3ZRW2WXMeTyGeCl1T43+mnXMGs9i4r1KDuFdt/0WbXVA+F7AVYy\n"
+"u/cGo4IBljCCAZIwJQYDVR0RBB4wHIIKdW5pcGF5LmNvbYIOd3d3LnVuaXBheS5j\n"
+"b20wCQYDVR0TBAIwADAOBgNVHQ8BAf8EBAMCB4AwKwYDVR0fBCQwIjAgoB6gHIYa\n"
+"aHR0cDovL3RlLnN5bWNiLmNvbS90ZS5jcmwwcwYDVR0gBGwwajBoBgtghkgBhvhF\n"
+"AQcwATBZMCYGCCsGAQUFBwIBFhpodHRwczovL3d3dy50aGF3dGUuY29tL2NwczAv\n"
+"BggrBgEFBQcCAjAjDCFodHRwczovL3d3dy50aGF3dGUuY29tL3JlcG9zaXRvcnkw\n"
+"HQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFMoTsU3s\n"
+"mn62fEUeuB3k0shyGrEdMFcGCCsGAQUFBwEBBEswSTAfBggrBgEFBQcwAYYTaHR0\n"
+"cDovL3RlLnN5bWNkLmNvbTAmBggrBgEFBQcwAoYaaHR0cDovL3RlLnN5bWNiLmNv\n"
+"bS90ZS5jcnQwEwYKKwYBBAHWeQIEAwEB/wQCBQAwCwYJYIZIAWUDBAMCA0cAMEQC\n"
+"IGqj1ElLQljLIir0ZWTzmr0wOXG2B8X649SNqOHhzXikAiAE9qr9RiIe/fpphfnx\n"
+"jks8c0MAUgqmpKIZWTpvNhja6Q==\n"
+"-----END CERTIFICATE-----\n"
+"-----BEGIN CERTIFICATE-----\n"
+"MIIGJDCCBcmgAwIBAgIQbT3s+pt4qr0oAI3ZcDdjDjALBglghkgBZQMEAwIwga4x\n"
+"CzAJBgNVBAYTAlVTMRUwEwYDVQQKEwx0aGF3dGUsIEluYy4xKDAmBgNVBAsTH0Nl\n"
+"cnRpZmljYXRpb24gU2VydmljZXMgRGl2aXNpb24xODA2BgNVBAsTLyhjKSAyMDEy\n"
+"IHRoYXd0ZSwgSW5jLiAtIEZvciBhdXRob3JpemVkIHVzZSBvbmx5MSQwIgYDVQQD\n"
+"Ext0aGF3dGUgUHJpbWFyeSBSb290IENBIC0gRzQwHhcNMTIxMjIwMDAwMDAwWhcN\n"
+"MjIxMjE5MjM1OTU5WjBAMQswCQYDVQQGEwJVUzEVMBMGA1UEChMMdGhhd3RlLCBJ\n"
+"bmMuMRowGAYDVQQDExF0aGF3dGUgRFNBIFNTTCBDQTCCA0gwggI6BgcqhkjOOAQB\n"
+"MIICLQKCAQEAsOkfT0p9OXj0/j9H+m2Ejyu6VTLpjydK1/dWyl/AQS5WE5GPgy0i\n"
+"6oJQCSEKLcZtJCcnrx9X2WJq/U9sxSydq0oP1R7BqXiRs3fphkJnBhW/OGJNnw13\n"
+"dnBrt9ffmaZNFFRCUQOsGDsSjBPOUQ4tuenBeF3Zs+DAfkDXzxcrK4OQs6qTYubn\n"
+"8QUphcoMaUURJv9aY8VfVpODN3Z5FeamrY72zAcGvc9ajFl45vVlK/dDbu8kMMdp\n"
+"b1wuNMTWUo/dxdPrtgpJA3ZnN9MDSzs2tcGWxYnpWFZTndTePn7xU0b3r/pN/ys7\n"
+"i5FBr1yqYVWelt5uGLMg+ZQ22GQnga8/eQIhAKdVID3cRKJNm0Rd77SM/GgY430w\n"
+"mefDvxS6pQDGnAzXAoIBAQCLQiKLU8kRBsWIkeuRPKlbqwSMkbNwaOYK6/Lh8x5k\n"
+"20djAqPOurHtzNWnAPAvZPYSjL+PR1ydHq4tRDEgjaVYlb5ZZeD8L6v0J/OWNTpS\n"
+"SmeKzHfD1QRP/2dxqiNweivUR4vw7m6wg8Y5ZxOFKbgAfdM08z2hbjkucrCzkbCr\n"
+"0NQUkUy+N4gvMKOIVDYVUiKUFSJmlRiYlCXJNaoIkKWcb4NjRBHjDKbmm4+Isco4\n"
+"PUQ3E7V+CdS6C8hOPdDwhcYm6FPrgbTPcuuoJgEI6YXjgywGCMja6zwEmU1F9NH6\n"
+"9TmpZiKCFDVhrBd5KgOemiiveAE2AAU1ctYz1pkqt2dXA4IBBgACggEBAJzaudYH\n"
+"djJGC5gPXFS+oWZc4SEicF5teHo2ZkI86j8TDGZWBCXHng3m/JrY3qT11tBU4go/\n"
+"XR5AQ9GYtLAiOXZKIdFSjyjrDGVotWNxpoZi1hXpVEsCAEwyWqKdO+47zUF2/tgc\n"
+"QzAnAwbb2NV9D35rg3wKenUKdQfp98PrlWUh2UOmFkae83eLr/7VxEF4nOF+CI/4\n"
+"Kx9y6Qy3So/OHucSp8206yqJ80EyYox9cnAeS81xBwJqn1LIPRFGJ85cEXRldATI\n"
+"+CvgvfdnpWnJaPPUvJoaPF9DVfi4FTGV7aFfeQfi9QemF8WMPq0JpdrFkfrnGVw9\n"
+"wxGzySeiXj7UDhKjggFCMIIBPjASBgNVHRMBAf8ECDAGAQH/AgEAMA4GA1UdDwEB\n"
+"/wQEAwIBBjAyBggrBgEFBQcBAQQmMCQwIgYIKwYBBQUHMAGGFmh0dHA6Ly9vY3Nw\n"
+"LnRoYXd0ZS5jb20wOwYDVR0gBDQwMjAwBgRVHSAAMCgwJgYIKwYBBQUHAgEWGmh0\n"
+"dHBzOi8vd3d3LnRoYXd0ZS5jb20vY3BzMDcGA1UdHwQwMC4wLKAqoCiGJmh0dHA6\n"
+"Ly9jcmwudGhhd3RlLmNvbS9UaGF3dGVQQ0EtRzQuY3JsMC4GA1UdEQQnMCWkIzAh\n"
+"MR8wHQYDVQQDExZTWU1DLURTQS1DQS0yMDQ4LTI1Ni00MB0GA1UdDgQWBBTKE7FN\n"
+"7Jp+tnxFHrgd5NLIchqxHTAfBgNVHSMEGDAWgBTHZ4lkIvGdsfOLg6bCDpmTUXbr\n"
+"ljALBglghkgBZQMEAwIDSAAwRQIhAKb8sDyC2UehqUcEPUQ65bnmmtiplEplDUZt\n"
+"ULqZQweDAiAr4MAcnfC9otwLcBllGVA4vsOKPsFSq5u2EPn3ovIynw==\n"
+"-----END CERTIFICATE-----\n";
+
+static const char kDsaPrecertChainRootOnly[] =
+"-----BEGIN CERTIFICATE-----\n"
+"MIIGJDCCBcmgAwIBAgIQbT3s+pt4qr0oAI3ZcDdjDjALBglghkgBZQMEAwIwga4x\n"
+"CzAJBgNVBAYTAlVTMRUwEwYDVQQKEwx0aGF3dGUsIEluYy4xKDAmBgNVBAsTH0Nl\n"
+"cnRpZmljYXRpb24gU2VydmljZXMgRGl2aXNpb24xODA2BgNVBAsTLyhjKSAyMDEy\n"
+"IHRoYXd0ZSwgSW5jLiAtIEZvciBhdXRob3JpemVkIHVzZSBvbmx5MSQwIgYDVQQD\n"
+"Ext0aGF3dGUgUHJpbWFyeSBSb290IENBIC0gRzQwHhcNMTIxMjIwMDAwMDAwWhcN\n"
+"MjIxMjE5MjM1OTU5WjBAMQswCQYDVQQGEwJVUzEVMBMGA1UEChMMdGhhd3RlLCBJ\n"
+"bmMuMRowGAYDVQQDExF0aGF3dGUgRFNBIFNTTCBDQTCCA0gwggI6BgcqhkjOOAQB\n"
+"MIICLQKCAQEAsOkfT0p9OXj0/j9H+m2Ejyu6VTLpjydK1/dWyl/AQS5WE5GPgy0i\n"
+"6oJQCSEKLcZtJCcnrx9X2WJq/U9sxSydq0oP1R7BqXiRs3fphkJnBhW/OGJNnw13\n"
+"dnBrt9ffmaZNFFRCUQOsGDsSjBPOUQ4tuenBeF3Zs+DAfkDXzxcrK4OQs6qTYubn\n"
+"8QUphcoMaUURJv9aY8VfVpODN3Z5FeamrY72zAcGvc9ajFl45vVlK/dDbu8kMMdp\n"
+"b1wuNMTWUo/dxdPrtgpJA3ZnN9MDSzs2tcGWxYnpWFZTndTePn7xU0b3r/pN/ys7\n"
+"i5FBr1yqYVWelt5uGLMg+ZQ22GQnga8/eQIhAKdVID3cRKJNm0Rd77SM/GgY430w\n"
+"mefDvxS6pQDGnAzXAoIBAQCLQiKLU8kRBsWIkeuRPKlbqwSMkbNwaOYK6/Lh8x5k\n"
+"20djAqPOurHtzNWnAPAvZPYSjL+PR1ydHq4tRDEgjaVYlb5ZZeD8L6v0J/OWNTpS\n"
+"SmeKzHfD1QRP/2dxqiNweivUR4vw7m6wg8Y5ZxOFKbgAfdM08z2hbjkucrCzkbCr\n"
+"0NQUkUy+N4gvMKOIVDYVUiKUFSJmlRiYlCXJNaoIkKWcb4NjRBHjDKbmm4+Isco4\n"
+"PUQ3E7V+CdS6C8hOPdDwhcYm6FPrgbTPcuuoJgEI6YXjgywGCMja6zwEmU1F9NH6\n"
+"9TmpZiKCFDVhrBd5KgOemiiveAE2AAU1ctYz1pkqt2dXA4IBBgACggEBAJzaudYH\n"
+"djJGC5gPXFS+oWZc4SEicF5teHo2ZkI86j8TDGZWBCXHng3m/JrY3qT11tBU4go/\n"
+"XR5AQ9GYtLAiOXZKIdFSjyjrDGVotWNxpoZi1hXpVEsCAEwyWqKdO+47zUF2/tgc\n"
+"QzAnAwbb2NV9D35rg3wKenUKdQfp98PrlWUh2UOmFkae83eLr/7VxEF4nOF+CI/4\n"
+"Kx9y6Qy3So/OHucSp8206yqJ80EyYox9cnAeS81xBwJqn1LIPRFGJ85cEXRldATI\n"
+"+CvgvfdnpWnJaPPUvJoaPF9DVfi4FTGV7aFfeQfi9QemF8WMPq0JpdrFkfrnGVw9\n"
+"wxGzySeiXj7UDhKjggFCMIIBPjASBgNVHRMBAf8ECDAGAQH/AgEAMA4GA1UdDwEB\n"
+"/wQEAwIBBjAyBggrBgEFBQcBAQQmMCQwIgYIKwYBBQUHMAGGFmh0dHA6Ly9vY3Nw\n"
+"LnRoYXd0ZS5jb20wOwYDVR0gBDQwMjAwBgRVHSAAMCgwJgYIKwYBBQUHAgEWGmh0\n"
+"dHBzOi8vd3d3LnRoYXd0ZS5jb20vY3BzMDcGA1UdHwQwMC4wLKAqoCiGJmh0dHA6\n"
+"Ly9jcmwudGhhd3RlLmNvbS9UaGF3dGVQQ0EtRzQuY3JsMC4GA1UdEQQnMCWkIzAh\n"
+"MR8wHQYDVQQDExZTWU1DLURTQS1DQS0yMDQ4LTI1Ni00MB0GA1UdDgQWBBTKE7FN\n"
+"7Jp+tnxFHrgd5NLIchqxHTAfBgNVHSMEGDAWgBTHZ4lkIvGdsfOLg6bCDpmTUXbr\n"
+"ljALBglghkgBZQMEAwIDSAAwRQIhAKb8sDyC2UehqUcEPUQ65bnmmtiplEplDUZt\n"
+"ULqZQweDAiAr4MAcnfC9otwLcBllGVA4vsOKPsFSq5u2EPn3ovIynw==\n"
+"-----END CERTIFICATE-----\n";
+
 namespace {
 
 class CertCheckerTest : public ::testing::Test {
@@ -419,6 +606,58 @@ TEST_F(CertCheckerTest, ResolveIssuerCollisions) {
   ASSERT_TRUE(root2->IsLoaded());
   chain2.AddCert(move(root2));
   EXPECT_OK(checker_.CheckCertChain(&chain2));
+}
+
+TEST_F(CertCheckerTest, TestDsaPrecertFailsRootNotTrusted) {
+  // Load CA certs.
+  EXPECT_TRUE(checker_.LoadTrustedCertificates(cert_dir_ + "/" + kCaCert));
+  PreCertChain pre_chain(kDsaPrecertChain);
+  string issuer_key_hash, tbs;
+
+  // With our default roots this should not be accepted, but it shouldn't
+  // fail with an algorithm related error
+  const util::Status status(
+      checker_.CheckPreCertChain(&pre_chain, &issuer_key_hash, &tbs));
+
+  EXPECT_THAT(status,
+              StatusIs(util::error::FAILED_PRECONDITION, "unknown root"));
+}
+
+TEST_F(CertCheckerTest, TestDsaPrecertChain) {
+  // Explicitly set the root of this chain as trusted
+  checker_.ClearAllTrustedCertificates();
+  vector<string> roots;
+  roots.push_back(kDsaPrecertChainRootOnly);
+  checker_.LoadTrustedCertificates(roots);
+
+  PreCertChain pre_chain(kDsaPrecertChain);
+  string issuer_key_hash, tbs;
+
+  EXPECT_OK(checker_.CheckPreCertChain(&pre_chain, &issuer_key_hash, &tbs));
+  // Added a root CA.
+  EXPECT_EQ(2, pre_chain.Length());
+  // And set a SHA256 HASH
+  EXPECT_EQ(32, issuer_key_hash.size());
+  // And the TBS fields
+  EXPECT_FALSE(tbs.empty());
+}
+
+TEST_F(CertCheckerTest, TestDsaPrecertChainRejectsInvalidDsaSig) {
+  // Explicitly set the root of this chain as trusted
+  checker_.ClearAllTrustedCertificates();
+  vector<string> roots;
+  roots.push_back(kDsaPrecertChainRootOnly);
+  checker_.LoadTrustedCertificates(roots);
+
+  // This has a deliberately corrupt signature
+  PreCertChain pre_chain(kDsaPrecertChainInvalidSig);
+  string issuer_key_hash, tbs;
+
+  const util::Status status(
+        checker_.CheckPreCertChain(&pre_chain, &issuer_key_hash, &tbs));
+
+  EXPECT_THAT(status,
+              StatusIs(util::error::INVALID_ARGUMENT, "invalid certificate chain"));
 }
 
 }  // namespace

--- a/cpp/log/cert_checker_test.cc
+++ b/cpp/log/cert_checker_test.cc
@@ -656,8 +656,8 @@ TEST_F(CertCheckerTest, TestDsaPrecertChainRejectsInvalidDsaSig) {
   const util::Status status(
         checker_.CheckPreCertChain(&pre_chain, &issuer_key_hash, &tbs));
 
-  EXPECT_THAT(status,
-              StatusIs(util::error::INVALID_ARGUMENT, "invalid certificate chain"));
+  EXPECT_THAT(status, StatusIs(util::error::INVALID_ARGUMENT,
+                               "invalid certificate chain"));
 }
 
 }  // namespace

--- a/cpp/log/cert_test.cc
+++ b/cpp/log/cert_test.cc
@@ -225,6 +225,7 @@ static const char kMismatchingSigAlgsCertIssuerString[] =
     "+AZxAeKCINT+b72x\n"
     "-----END CERTIFICATE-----\n";
 
+
 namespace {
 
 class CertTest : public ::testing::Test {


### PR DESCRIPTION
BoringSSL does not support DSA signatures via x509_verify so this adds extra handling for that case if x509_verify fails with an unsupported algorithm.