### PR TITLE
Use getaddrinfo instead of inet_aton in Client::Connect

### DIFF
--- a/cpp/client/client.cc
+++ b/cpp/client/client.cc
@@ -2,6 +2,7 @@
 
 #include <arpa/inet.h>
 #include <glog/logging.h>
+#include <netdb.h>
 #include <netinet/in.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -15,7 +16,7 @@
 
 using std::string;
 
-Client::Client(const string& server, uint16_t port)
+Client::Client(const string& server, const string& port)
     : server_(server), port_(port), fd_(-1) {
 }
 
@@ -26,24 +27,42 @@ Client::~Client() {
 bool Client::Connect() {
   CHECK(!Connected());
 
-  fd_ = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
-  PCHECK(fd_ >= 0) << "Socket creation failed";
+  static const addrinfo server_addr_hints = {
+    AI_ADDRCONFIG, /* ai_flags */
+    AF_UNSPEC,     /* ai_family */
+    SOCK_STREAM,   /* ai_socktype */
+    IPPROTO_TCP    /* ai_protocol */
+  };
 
-  static struct sockaddr_in server_socket;
-  memset(&server_socket, 0, sizeof server_socket);
-  server_socket.sin_family = AF_INET;
-  server_socket.sin_port = htons(port_);
-  CHECK_EQ(1, inet_aton(server_.c_str(), &server_socket.sin_addr))
-      << "Can't parse server address: " << server_;
+  struct addrinfo* server_addr;
 
-  int ret =
-      connect(fd_, (struct sockaddr*)&server_socket, sizeof server_socket);
-  if (ret < 0) {
+  int ret = getaddrinfo(server_.c_str(), port_.c_str(), &server_addr_hints,
+                        &server_addr);
+  CHECK_EQ(0, ret) << "Invalid server address '" << server_
+                   << "' and/or port '" << port_ << "': "
+                   << gai_strerror(ret);
+
+  bool is_connected = false;
+  while (!is_connected && server_addr != NULL) {
+    fd_ = socket(server_addr->ai_family,
+                 server_addr->ai_socktype,
+                 server_addr->ai_protocol);
+    PCHECK(fd_ >= 0) << "Socket creation failed";
+
+    if (connect(fd_, server_addr->ai_addr, server_addr->ai_addrlen) == 0) {
+      is_connected = true;
+    } else {
+      server_addr = server_addr->ai_next; // Try next address
+    }
+  }
+  freeaddrinfo(server_addr);
+
+  if (!is_connected) {
+    PLOG(ERROR) << "Connection to [" << server_ << "]:" << port_ << " failed";
     Disconnect();
-    PLOG(ERROR) << "Connection to " << server_ << ":" << port_ << " failed";
     return false;
   }
-  LOG(INFO) << "Connected to " << server_ << ":" << port_;
+  LOG(INFO) << "Connected to [" << server_ << "]:" << port_;
   return true;
 }
 
@@ -54,7 +73,7 @@ bool Client::Connected() const {
 void Client::Disconnect() {
   if (fd_ > 0) {
     close(fd_);
-    LOG(INFO) << "Disconnected from " << server_ << ":" << port_;
+    LOG(INFO) << "Disconnected from [" << server_ << "]:" << port_;
     fd_ = -1;
   }
 }

--- a/cpp/client/client.cc
+++ b/cpp/client/client.cc
@@ -36,8 +36,8 @@ bool Client::Connect() {
 
   struct addrinfo* server_addr;
 
-  int ret = getaddrinfo(server_.c_str(), port_.c_str(), &server_addr_hints,
-                        &server_addr);
+  const int ret = getaddrinfo(server_.c_str(), port_.c_str(),
+                              &server_addr_hints, &server_addr);
   CHECK_EQ(0, ret) << "Invalid server address '" << server_
                    << "' and/or port '" << port_ << "': "
                    << gai_strerror(ret);

--- a/cpp/client/client.h
+++ b/cpp/client/client.h
@@ -9,7 +9,7 @@
 // Socket creation for client connections.
 class Client {
  public:
-  Client(const std::string& server, uint16_t port);
+  Client(const std::string& server, const std::string& port);
 
   ~Client();
 
@@ -34,7 +34,7 @@ class Client {
 
  private:
   const std::string server_;
-  const uint16_t port_;
+  const std::string port_;
   int fd_;
 
   DISALLOW_COPY_AND_ASSIGN(Client);

--- a/cpp/client/ct.cc
+++ b/cpp/client/ct.cc
@@ -43,7 +43,7 @@ DEFINE_string(ssl_client_trusted_cert_dir, "",
 DEFINE_string(ct_server_public_key, "",
               "PEM-encoded public key file of the CT log server");
 DEFINE_string(ssl_server, "", "SSL server to connect to");
-DEFINE_string(ssl_server_port, "", "SSL server port");
+DEFINE_string(ssl_server_port, "https", "SSL server port");
 DEFINE_string(ct_server_submission, "",
               "Certificate chain to submit to a CT log server. "
               "The file must consist of concatenated PEM certificates.");

--- a/cpp/client/ct.cc
+++ b/cpp/client/ct.cc
@@ -997,6 +997,7 @@ int Monitor() {
 int main(int argc, char** argv) {
   google::SetUsageMessage(argv[0] + string(kUsage));
   util::InitCT(&argc, &argv);
+  ConfigureSerializerForV1CT();
 
   const string main_command(argv[0]);
   if (argc < 2) {

--- a/cpp/client/ct.cc
+++ b/cpp/client/ct.cc
@@ -43,7 +43,7 @@ DEFINE_string(ssl_client_trusted_cert_dir, "",
 DEFINE_string(ct_server_public_key, "",
               "PEM-encoded public key file of the CT log server");
 DEFINE_string(ssl_server, "", "SSL server to connect to");
-DEFINE_int32(ssl_server_port, 0, "SSL server port");
+DEFINE_string(ssl_server_port, "", "SSL server port");
 DEFINE_string(ct_server_submission, "",
               "Certificate chain to submit to a CT log server. "
               "The file must consist of concatenated PEM certificates.");
@@ -575,7 +575,7 @@ static SSLClient::HandshakeResult Connect() {
   LogVerifier* verifier = GetLogVerifierFromFlags();
 
   CHECK(!FLAGS_ssl_server.empty()) << "Must specify --ssl_server";
-  CHECK_NE(0, FLAGS_ssl_server_port) << "Must specify --ssl_server_port";
+  CHECK(!FLAGS_ssl_server_port.empty()) << "Must specify --ssl_server_port";
 
   SSLClient client(FLAGS_ssl_server, FLAGS_ssl_server_port,
                    FLAGS_ssl_client_trusted_cert_dir, verifier);

--- a/cpp/client/ct.cc
+++ b/cpp/client/ct.cc
@@ -163,7 +163,8 @@ static string SCTToList(const string& serialized_sct) {
 }
 
 static LogVerifier* GetLogVerifierFromFlags() {
-  CHECK(!FLAGS_ct_server_public_key.empty());
+  CHECK(!FLAGS_ct_server_public_key.empty()) <<
+    "Please give a CT server public key file with --ct_server_public_key";
 
   StatusOr<EVP_PKEY*> pkey(ReadPublicKey(FLAGS_ct_server_public_key));
   CHECK(pkey.ok()) << "could not read CT server public key file: "

--- a/cpp/client/ssl_client.cc
+++ b/cpp/client/ssl_client.cc
@@ -65,8 +65,8 @@ int SSLClient::ExtensionCallback(SSL*, unsigned ext_type,
 }
 
 // TODO(ekasper): handle Cert::Status errors.
-SSLClient::SSLClient(const string& server, uint16_t port, const string& ca_dir,
-                     LogVerifier* verifier)
+SSLClient::SSLClient(const string& server, const string& port,
+                     const string& ca_dir, LogVerifier* verifier)
     : client_(server, port),
       ctx_(CHECK_NOTNULL(SSL_CTX_new(TLSv1_client_method()))),
       verify_args_(verifier),

--- a/cpp/client/ssl_client.cc
+++ b/cpp/client/ssl_client.cc
@@ -80,7 +80,8 @@ SSLClient::SSLClient(const string& server, const string& port,
              SSL_CTX_load_verify_locations(ctx_.get(), NULL, ca_dir.c_str()))
         << "Unable to load trusted CA certificates.";
   } else {
-    LOG(WARNING) << "No trusted CA certificates given.";
+    SSL_CTX_set_default_verify_paths(ctx_.get());
+    LOG(INFO) << "Using system trusted CA certificates.";
   }
 
   SSL_CTX_set_cert_verify_callback(ctx_.get(), &VerifyCallback, &verify_args_);

--- a/cpp/client/ssl_client.cc
+++ b/cpp/client/ssl_client.cc
@@ -155,7 +155,9 @@ int SSLClient::VerifyCallback(X509_STORE_CTX* ctx, void* arg) {
 
   int vfy = X509_verify_cert(ctx);
   if (vfy != 1) {
-    LOG(ERROR) << "Certificate verification failed.";
+    int error = X509_STORE_CTX_get_error(ctx);
+    LOG(ERROR) << "Certificate verification failed: "
+               << X509_verify_cert_error_string(error);
     return vfy;
   }
 

--- a/cpp/client/ssl_client.h
+++ b/cpp/client/ssl_client.h
@@ -22,7 +22,7 @@ class SSLClient {
   // Takes ownership of the verifier. This client can currently
   // only verify SCTs from a single log at a time.
   // TODO(ekasper): implement a proper multi-log auditor.
-  SSLClient(const std::string& server, uint16_t port,
+  SSLClient(const std::string& server, const std::string& port,
             const std::string& ca_dir, LogVerifier* verifier);
 
   ~SSLClient();


### PR DESCRIPTION
This following are now supported, in addition to IPv4 addresses:
- hostnames
- IPv6 addresses
- service names instead of port numbers

Also fixes a couple of deficiencies:
- Initializes the serializer, allowing the ct tool to deserialize v1 SCTs.
- Loads the system CA roots by default, which allows most certificates to be verified.