### PR TITLE
Disable Keep-Alive header.

### DIFF
--- a/go/client/logclient.go
+++ b/go/client/logclient.go
@@ -124,7 +124,6 @@ func (c *LogClient) fetchAndParse(uri string, res interface{}) error {
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Keep-Alive", "timeout=15, max=100")
 	resp, err := c.httpClient.Do(req)
 	var body []byte
 	if resp != nil {


### PR DESCRIPTION
On Go1.6, this causes problems when talking to Google's CT logs.

Fixes #1136 