### PR TITLE
Separate url client from log client

### DIFF
--- a/go/fixchain/fix_and_log.go
+++ b/go/fixchain/fix_and_log.go
@@ -74,12 +74,12 @@ func (fl *FixAndLog) Wait() {
 // are added to its queue, and then log them to the Certificate Transparency log
 // found at the given url.  Any errors encountered along the way are pushed to
 // the given errors channel.
-func NewFixAndLog(fixerWorkerCount int, loggerWorkerCount int, errors chan<- *FixError, client *http.Client, logURL string, limiter Limiter, logStats bool) *FixAndLog {
+func NewFixAndLog(fixerWorkerCount int, loggerWorkerCount int, errors chan<- *FixError, client *http.Client, logClient *http.Client, logURL string, limiter Limiter, logStats bool) *FixAndLog {
 	chains := make(chan []*x509.Certificate)
 	fl := &FixAndLog{
 		fixer:  NewFixer(fixerWorkerCount, chains, errors, client, logStats),
 		chains: chains,
-		logger: NewLogger(loggerWorkerCount, logURL, errors, client, limiter, logStats),
+		logger: NewLogger(loggerWorkerCount, logURL, errors, logClient, limiter, logStats),
 		done:   newLockedMap(),
 	}
 

--- a/go/fixchain/fix_and_log_test.go
+++ b/go/fixchain/fix_and_log_test.go
@@ -184,7 +184,8 @@ func TestNewFixAndLog(t *testing.T) {
 	for i, test := range newFixAndLogTests {
 		seen := make([]bool, len(test.expLoggedChains))
 		errors := make(chan *FixError)
-		fl := NewFixAndLog(1, 1, errors, &http.Client{Transport: &testRoundTripper{t: t, test: &test, testIndex: i, seen: seen}}, test.url, newNilLimiter(), false)
+		client := &http.Client{Transport: &testRoundTripper{t: t, test: &test, testIndex: i, seen: seen}}
+		fl := NewFixAndLog(1, 1, errors, client, client, test.url, newNilLimiter(), false)
 
 		var wg sync.WaitGroup
 		wg.Add(1)

--- a/go/fixchain/main/fixchain.go
+++ b/go/fixchain/main/fixchain.go
@@ -103,7 +103,8 @@ func main() {
 	go logStringErrors(&wg, errors, errDir)
 
 	limiter := ratelimiter.NewLimiter(1000)
-	fl := fixchain.NewFixAndLog(100, 100, errors, &http.Client{}, logURL, limiter, true)
+	client := &http.Client{}
+	fl := fixchain.NewFixAndLog(100, 100, errors, client, client, logURL, limiter, true)
 
 	processChains(chainsFile, fl)
 


### PR DESCRIPTION
Has been tested by running fixchain package tests, and running preloader with these changes internally.