### PR TITLE
Add issuer cn matcher to scanner + print whole chains option

### DIFF
--- a/go/scanner/main/scanner.go
+++ b/go/scanner/main/scanner.go
@@ -53,11 +53,7 @@ func chainToString(certs []ct.ASN1Cert) string {
 	return base64.StdEncoding.EncodeToString(output)
 }
 
-func logCertChain(entry *ct.LogEntry) {
-	log.Printf("Index %d: Chain: %s", entry.Index, chainToString(entry.Chain))
-}
-
-func logPrecertChain(entry *ct.LogEntry) {
+func logFullChain(entry *ct.LogEntry) {
 	log.Printf("Index %d: Chain: %s", entry.Index, chainToString(entry.Chain))
 }
 
@@ -117,7 +113,7 @@ func main() {
 	scanner := scanner.NewScanner(logClient, opts)
 
 	if *printChains {
-		scanner.Scan(logCertChain, logPrecertChain)
+		scanner.Scan(logFullChain, logFullChain)
 	} else {
 		scanner.Scan(logCertInfo, logPrecertInfo)
 	}

--- a/go/scanner/main/scanner.go
+++ b/go/scanner/main/scanner.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"regexp"
 
+	"encoding/base64"
 	"github.com/google/certificate-transparency/go"
 	"github.com/google/certificate-transparency/go/client"
 	"github.com/google/certificate-transparency/go/scanner"
@@ -19,6 +20,7 @@ const (
 
 var logUri = flag.String("log_uri", "http://ct.googleapis.com/aviator", "CT log base URI")
 var matchSubjectRegex = flag.String("match_subject_regex", ".*", "Regex to match CN/SAN")
+var matchIssuerRegex = flag.String("match_issuer_regex", "", "Regex to match in issuer CN")
 var precertsOnly = flag.Bool("precerts_only", false, "Only match precerts")
 var serialNumber = flag.String("serial_number", "", "Serial number of certificate of interest")
 var batchSize = flag.Int("batch_size", 1000, "Max number of entries to request at per call to get-entries")
@@ -26,6 +28,7 @@ var numWorkers = flag.Int("num_workers", 2, "Number of concurrent matchers")
 var parallelFetch = flag.Int("parallel_fetch", 2, "Number of concurrent GetEntries fetches")
 var startIndex = flag.Int64("start_index", 0, "Log index to start scanning at")
 var quiet = flag.Bool("quiet", false, "Don't print out extra logging messages, only matches.")
+var printChains = flag.Bool("print_chains", false, "If true prints the whole chain rather than a summary")
 
 // Prints out a short bit of info about |cert|, found at |index| in the
 // specified log
@@ -40,7 +43,45 @@ func logPrecertInfo(entry *ct.LogEntry) {
 		entry.Precert.TBSCertificate.Subject.CommonName, entry.Precert.TBSCertificate.Issuer.CommonName)
 }
 
+func chainToString(certs []ct.ASN1Cert) string {
+	var output []byte
+
+	for _, cert := range certs {
+		output = append(output, cert...)
+	}
+
+	return base64.StdEncoding.EncodeToString(output)
+}
+
+func logCertChain(entry *ct.LogEntry) {
+	log.Printf("Index %d: Chain: %s", entry.Index, chainToString(entry.Chain))
+}
+
+func logPrecertChain(entry *ct.LogEntry) {
+	log.Printf("Index %d: Chain: %s", entry.Index, chainToString(entry.Chain))
+}
+
+func createRegexes(regexValue string) (*regexp.Regexp, *regexp.Regexp) {
+	// Make a regex matcher
+	var certRegex *regexp.Regexp
+	precertRegex := regexp.MustCompile(regexValue)
+	switch *precertsOnly {
+	case true:
+		certRegex = regexp.MustCompile(MatchesNothingRegex)
+	case false:
+		certRegex = precertRegex
+	}
+
+	return certRegex, precertRegex
+}
+
 func createMatcherFromFlags() (scanner.Matcher, error) {
+	if *matchIssuerRegex != "" {
+		certRegex, precertRegex := createRegexes(*matchIssuerRegex)
+		return scanner.MatchIssuerRegex{
+			CertificateIssuerRegex:    certRegex,
+			PrecertificateIssuerRegex: precertRegex}, nil
+	}
 	if *serialNumber != "" {
 		log.Printf("Using SerialNumber matcher on %s", *serialNumber)
 		var sn big.Int
@@ -50,15 +91,7 @@ func createMatcherFromFlags() (scanner.Matcher, error) {
 		}
 		return scanner.MatchSerialNumber{SerialNumber: sn}, nil
 	} else {
-		// Make a regex matcher
-		var certRegex *regexp.Regexp
-		precertRegex := regexp.MustCompile(*matchSubjectRegex)
-		switch *precertsOnly {
-		case true:
-			certRegex = regexp.MustCompile(MatchesNothingRegex)
-		case false:
-			certRegex = precertRegex
-		}
+		certRegex, precertRegex := createRegexes(*matchSubjectRegex)
 		return scanner.MatchSubjectRegex{
 			CertificateSubjectRegex:    certRegex,
 			PrecertificateSubjectRegex: precertRegex}, nil
@@ -82,5 +115,10 @@ func main() {
 		Quiet:         *quiet,
 	}
 	scanner := scanner.NewScanner(logClient, opts)
-	scanner.Scan(logCertInfo, logPrecertInfo)
+
+	if *printChains {
+		scanner.Scan(logCertChain, logPrecertChain)
+	} else {
+		scanner.Scan(logCertInfo, logPrecertInfo)
+	}
 }

--- a/go/scanner/scanner.go
+++ b/go/scanner/scanner.go
@@ -95,6 +95,20 @@ func (m MatchSubjectRegex) PrecertificateMatches(p *ct.Precertificate) bool {
 	return false
 }
 
+// Matches on issuer cn by regex
+type MatchIssuerRegex struct {
+	CertificateIssuerRegex    *regexp.Regexp
+	PrecertificateIssuerRegex *regexp.Regexp
+}
+
+func (m MatchIssuerRegex) CertificateMatches(c *x509.Certificate) bool {
+	return m.CertificateIssuerRegex.FindStringIndex(c.Issuer.CommonName) != nil
+}
+
+func (m MatchIssuerRegex) PrecertificateMatches(p *ct.Precertificate) bool {
+	return m.PrecertificateIssuerRegex.FindStringIndex(p.TBSCertificate.Issuer.CommonName) != nil
+}
+
 // ScannerOptions holds configuration options for the Scanner
 type ScannerOptions struct {
 	// Custom matcher for x509 Certificates, functor will be called for each


### PR DESCRIPTION
Adds a flag to match certs by issuer CN to Go scanner. Also adds the option to output the whole chain for matches in base64.