### PR TITLE
Preloader

### DIFF
--- a/go/fixchain/logger.go
+++ b/go/fixchain/logger.go
@@ -265,6 +265,7 @@ func NewLogger(workerCount int, url string, errors chan<- *FixError, client *htt
 		postChainCache: newLockedMap(),
 		limiter:        limiter,
 	}
+	l.RootCerts()
 
 	// Start post server pool.
 	for i := 0; i < workerCount; i++ {

--- a/go/fixchain/test_round_trippers.go
+++ b/go/fixchain/test_round_trippers.go
@@ -138,6 +138,19 @@ type postTestRoundTripper struct {
 }
 
 func (rt postTestRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	if strings.Contains(request.URL.Path, "/ct/v1/get-roots") {
+		b := stringRootsToJSON([]string{verisignRoot})
+		return &http.Response{
+			Status:        "200 OK",
+			StatusCode:    200,
+			Proto:         request.Proto,
+			ProtoMajor:    request.ProtoMajor,
+			ProtoMinor:    request.ProtoMinor,
+			Body:          &bytesReadCloser{bytes.NewReader(b)},
+			ContentLength: int64(len(b)),
+			Request:       request,
+		}, nil
+	}
 	// For tests that are checking the correct FixError type is returned:
 	if rt.test.ferr.Type == PostFailed {
 		return nil, errors.New("")
@@ -221,14 +234,15 @@ type newLoggerTestRoundTripper struct{}
 
 func (rt newLoggerTestRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
 	// Return a response
+	b := stringRootsToJSON([]string{verisignRoot})
 	return &http.Response{
 		Status:        "200 OK",
 		StatusCode:    200,
 		Proto:         request.Proto,
 		ProtoMajor:    request.ProtoMajor,
 		ProtoMinor:    request.ProtoMinor,
-		Body:          &bytesReadCloser{bytes.NewReader([]byte(""))},
-		ContentLength: 0,
+		Body:          &bytesReadCloser{bytes.NewReader(b)},
+		ContentLength: int64(len(b)),
 		Request:       request,
 	}, nil
 }


### PR DESCRIPTION
Getting roots during log creation and adding retries to getting roots so that logs (ahem, rocketeer) don't cause the whole preloader run to fail by randomly send a non-200 response just one time.