### PR TITLE
Python: Parse flags in more tests.

### DIFF
--- a/python/ct/client/async_log_client_test.py
+++ b/python/ct/client/async_log_client_test.py
@@ -190,8 +190,10 @@ class AsyncLogClientTest(unittest.TestCase):
         return consumer
 
     def pump_get_entries(self,
-                     delay=FLAGS.get_entries_retry_delay,
+                     delay=None,
                      pumps=1):
+        if not delay:
+            delay = FLAGS.get_entries_retry_delay
         # Helper method which advances time past get_entries delay
         for _ in range(0, pumps):
             self.clock.pump([0, delay])
@@ -384,5 +386,5 @@ class AsyncLogClientTest(unittest.TestCase):
         self.pump_get_entries()
         self.assertTrue(consumer.result.check(ValueError))
 
-if __name__ == "__main__":
+if __name__ == "__main__" or __name__ == "ct.client.async_log_client_test":
     sys.argv = FLAGS(sys.argv)

--- a/python/ct/client/db_reporter_test.py
+++ b/python/ct/client/db_reporter_test.py
@@ -2,7 +2,9 @@
 import unittest
 
 import mock
+import sys
 from ct.client import db_reporter
+import gflags
 
 
 class DbReporterTest(unittest.TestCase):
@@ -26,4 +28,5 @@ class DbReporterTest(unittest.TestCase):
         self.assertEqual(db.store_certs_desc.call_count, 2)
 
 if __name__ == '__main__':
+    sys.argv = gflags.FLAGS(sys.argv)
     unittest.main()

--- a/python/ct/client/monitor_test.py
+++ b/python/ct/client/monitor_test.py
@@ -507,5 +507,5 @@ class MonitorTest(unittest.TestCase):
                 ).addCallback(try_again_with_all_entries).addCallback(lambda _:
                     fake_fetch.assert_called_once_with(15, 19))
 
-if __name__ == "__main__":
+if __name__ == "__main__" or __name__ == "ct.client.monitor_test":
     sys.argv = FLAGS(sys.argv)


### PR DESCRIPTION
The travis CI either fails or has its log filled with Python errors
about accessing flags prior to parsing them (this is an error in
gflags 3.0.4 and above).

This commit fixes the tests by parsing the flags.
Note that for twisted-based tests running using trial the test is
imported so it is not effective to rely on the module name being __main__.