### PR TITLE
Remove temporary BORINGSSL_YYYYMM #ifdefs.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -7,7 +7,7 @@ vars = {
 
      # SSL implementation alternatives:
      "openssl": 				 "https://github.com/openssl/openssl.git@OpenSSL_1_0_2d",
-     "boringssl":        "https://boringssl.googlesource.com/boringssl.git@2661"
+     "boringssl":        "https://boringssl.googlesource.com/boringssl.git@2883"
 }
 
 deps = {

--- a/cpp/log/cert_test.cc
+++ b/cpp/log/cert_test.cc
@@ -493,8 +493,7 @@ TEST_F(CertTest, SignatureAlgorithmMatches) {
 TEST_F(CertTest, IllegalSignatureAlgorithmParameter) {
   const unique_ptr<Cert> cert(
       Cert::FromPemString(kIllegalSigAlgParameterCertString));
-#if defined(OPENSSL_IS_BORINGSSL) && \
-    (defined(BORINGSSL_201603) || defined(BORINGSSL_201512))
+#if defined(OPENSSL_IS_BORINGSSL)
   EXPECT_FALSE(cert.get());
 #else
   EXPECT_TRUE(cert.get());


### PR DESCRIPTION
We can assume a new enough BoringSSL now.
