### PR TITLE
Use io.ReadFull instead of raw Read

### DIFF
--- a/go/serialization.go
+++ b/go/serialization.go
@@ -80,12 +80,11 @@ func readVarBytes(r io.Reader, numLenBytes int) ([]byte, error) {
 		return nil, err
 	}
 	data := make([]byte, l)
-	n, err := r.Read(data)
-	if err != nil {
+	if n, err := io.ReadFull(r, data);  err != nil {
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			return nil, fmt.Errorf("short read: expected %d but got %d", l, n)
+		}
 		return nil, err
-	}
-	if n != int(l) {
-		return nil, fmt.Errorf("short read: expected %d but got %d", l, n)
 	}
 	return data, nil
 }


### PR DESCRIPTION
The tests current fail at go tip version `9af8346` because of commit [`13831bda`](https://github.com/golang/go/commit/01182425f847e4c98a53c60d0994175e21fd06dd#diff-13831bda8554c4b666cc2aa1a410087b). Fundamentally the issue is that the code does not respect the API for io.Reader. That is, an io.Reader does not guarantee that it can read all bytes possible to fill the input buffer. Thus, we should use io.ReadFull here instead.



