### PR TITLE
Have MerkleTree take a unique_ptr<SerialHasher>.

### DIFF
--- a/cpp/log/log_lookup.cc
+++ b/cpp/log/log_lookup.cc
@@ -38,7 +38,7 @@ static const int kCtimeBufSize = 26;
 
 LogLookup::LogLookup(ReadOnlyDatabase* db)
     : db_(CHECK_NOTNULL(db)),
-      cert_tree_(new Sha256Hasher),
+      cert_tree_(unique_ptr<Sha256Hasher>(new Sha256Hasher)),
       latest_tree_head_(),
       update_from_sth_cb_(bind(&LogLookup::UpdateFromSTH, this, _1)) {
   db_->AddNotifySTHCallback(&update_from_sth_cb_);

--- a/cpp/merkletree/merkle_tree.cc
+++ b/cpp/merkletree/merkle_tree.cc
@@ -9,10 +9,11 @@
 
 using cert_trans::MerkleTreeInterface;
 using std::string;
+using std::unique_ptr;
 
-MerkleTree::MerkleTree(SerialHasher* hasher)
+MerkleTree::MerkleTree(unique_ptr<SerialHasher> hasher)
     : MerkleTreeInterface(),
-      treehasher_(hasher),
+      treehasher_(hasher.release()),
       leaves_processed_(0),
       level_count_(0) {
 }

--- a/cpp/merkletree/merkle_tree.h
+++ b/cpp/merkletree/merkle_tree.h
@@ -3,6 +3,7 @@
 #define MERKLETREE_H
 
 #include <stddef.h>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -24,8 +25,7 @@ class MerkleTree : public cert_trans::MerkleTreeInterface {
  public:
   // The constructor takes a pointer to some concrete hash function
   // instantiation of the SerialHasher abstract class.
-  // Takes ownership of the hasher.
-  explicit MerkleTree(SerialHasher* hasher);
+  explicit MerkleTree(std::unique_ptr<SerialHasher> hasher);
   virtual ~MerkleTree();
 
   // Length of a node (i.e., a hash), in bytes.

--- a/cpp/merkletree/merkle_tree_large_test.cc
+++ b/cpp/merkletree/merkle_tree_large_test.cc
@@ -14,6 +14,7 @@
 namespace {
 
 using std::string;
+using std::unique_ptr;
 
 class MerkleTreeLargeTest : public ::testing::Test {
  protected:
@@ -33,7 +34,8 @@ TEST_F(MerkleTreeLargeTest, BuildLargeTree) {
     struct rusage ru;
     getrusage(RUSAGE_SELF, &ru);
     long max_rss_before = ru.ru_maxrss;
-    MerkleTree* tree = new MerkleTree(new Sha256Hasher());
+    MerkleTree* tree(
+        new MerkleTree(unique_ptr<Sha256Hasher>(new Sha256Hasher)));
     trees.push_back(tree);
     uint64_t time_before = util::TimeInMilliseconds();
 

--- a/cpp/monitor/monitor.cc
+++ b/cpp/monitor/monitor.cc
@@ -199,7 +199,7 @@ Monitor::ConfirmResult Monitor::ConfirmTreeInternal() {
 
 Monitor::ConfirmResult Monitor::ConfirmTreeInternal(
     const ct::SignedTreeHead& sth) {
-  MerkleTree mt(new Sha256Hasher);
+  MerkleTree mt(std::unique_ptr<Sha256Hasher>(new Sha256Hasher));
 
   Database::VerificationLevel lvl;
   CHECK_EQ(db_->LookupVerificationLevel(sth, &lvl), Database::LOOKUP_OK);

--- a/go/merkletree/merkle_tree_go.cc
+++ b/go/merkletree/merkle_tree_go.cc
@@ -3,6 +3,7 @@
 #include <assert.h>
 #include <cstdlib>
 #include <cstring>
+#include <memory>
 #include <vector>
 
 #include "_cgo_export.h"
@@ -31,7 +32,7 @@ HASHER NewSha256Hasher() {
 }
 
 TREE NewMerkleTree(HASHER hasher) {
-  return new MerkleTree(H(hasher));
+  return new MerkleTree(std::unique_ptr<SerialHasher>(H(hasher)));
 }
 
 void DeleteMerkleTree(TREE tree) {


### PR DESCRIPTION
This makes ownership explicit (and verified at compile-time).