### PR TITLE
Convert HTTPLogClient::GetSTH to use StatusOr.

### DIFF
--- a/cpp/client/http_log_client.h
+++ b/cpp/client/http_log_client.h
@@ -10,6 +10,7 @@
 #include "client/async_log_client.h"
 #include "proto/ct.pb.h"
 #include "util/libevent_wrapper.h"
+#include "util/statusor.h"
 #include "util/thread_pool.h"
 
 namespace cert_trans {
@@ -25,7 +26,7 @@ class HTTPLogClient {
                                           bool pre,
                                           ct::SignedCertificateTimestamp* sct);
 
-  AsyncLogClient::Status GetSTH(ct::SignedTreeHead* sth);
+  util::StatusOr<ct::SignedTreeHead> GetSTH();
 
   AsyncLogClient::Status GetRoots(std::vector<std::unique_ptr<Cert>>* roots);
 


### PR DESCRIPTION
First in a series to convert `HTTPLogClient` (why does that class name have HTTP in it?!?) to `util::StatusOr`, with the actual goal being to convert `AsyncLogClient` to use `util::Task` (instead of its homegrown callback/status mechanism with no cancellation support), and it makes sense to eliminate the `AsyncLogClient::Status` here first.

I've got this in a series of easy commits, if you prefer, I could put them all in a single pull request that converts `HTTPLogClient` completely? Your call.