### PR TITLE
Have CompactMerkleTree take a unique_ptr<SerialHasher>.

### DIFF
--- a/cpp/fetcher/remote_peer_test.cc
+++ b/cpp/fetcher/remote_peer_test.cc
@@ -100,8 +100,8 @@ class RemotePeerTest : public ::testing::Test {
         store_(base_.get(), &pool_, &etcd_client_, &election_, "/root", "id"),
         log_signer_(TestSigner::DefaultLogSigner()),
         tree_signer_(std::chrono::duration<double>(0), test_db_.db(),
-                     unique_ptr<CompactMerkleTree>(
-                         new CompactMerkleTree(new Sha256Hasher)),
+                     unique_ptr<CompactMerkleTree>(new CompactMerkleTree(
+                         unique_ptr<Sha256Hasher>(new Sha256Hasher))),
                      &store_, log_signer_.get()),
         task_(&pool_) {
     FLAGS_remote_peer_sth_refresh_interval_seconds = 1;

--- a/cpp/log/log_lookup.cc
+++ b/cpp/log/log_lookup.cc
@@ -205,7 +205,7 @@ unique_ptr<CompactMerkleTree> LogLookup::GetCompactMerkleTree(
     SerialHasher* hasher) {
   lock_guard<mutex> lock(lock_);
   return unique_ptr<CompactMerkleTree>(
-      new CompactMerkleTree(cert_tree_, hasher));
+      new CompactMerkleTree(cert_tree_, unique_ptr<SerialHasher>(hasher)));
 }
 
 

--- a/cpp/log/log_lookup_test.cc
+++ b/cpp/log/log_lookup_test.cc
@@ -63,8 +63,8 @@ class LogLookupTest : public ::testing::Test {
         test_signer_(),
         log_signer_(TestSigner::DefaultLogSigner()),
         tree_signer_(std::chrono::duration<double>(0), db(),
-                     unique_ptr<CompactMerkleTree>(
-                         new CompactMerkleTree(new Sha256Hasher)),
+                     unique_ptr<CompactMerkleTree>(new CompactMerkleTree(
+                         unique_ptr<Sha256Hasher>(new Sha256Hasher))),
                      &store_, log_signer_.get()),
         verifier_(TestSigner::DefaultLogSigVerifier(),
                   new MerkleVerifier(new Sha256Hasher())) {

--- a/cpp/log/tree_signer_test.cc
+++ b/cpp/log/tree_signer_test.cc
@@ -67,10 +67,11 @@ class TreeSignerTest : public ::testing::Test {
     store_.reset(new EtcdConsistentStore<LoggedEntry>(
         base_.get(), &pool_, &etcd_client_, &election_, "/root", "id"));
     log_signer_.reset(TestSigner::DefaultLogSigner());
-    tree_signer_.reset(new TS(std::chrono::duration<double>(0), db(),
-                              unique_ptr<CompactMerkleTree>(
-                                  new CompactMerkleTree(new Sha256Hasher)),
-                              store_.get(), log_signer_.get()));
+    tree_signer_.reset(
+        new TS(std::chrono::duration<double>(0), db(),
+               unique_ptr<CompactMerkleTree>(new CompactMerkleTree(
+                   unique_ptr<Sha256Hasher>(new Sha256Hasher))),
+               store_.get(), log_signer_.get()));
     // Set a default empty STH so that we can call UpdateTree() on the signer.
     store_->SetServingSTH(SignedTreeHead());
     // Force an empty sequence mapping file:
@@ -114,7 +115,8 @@ class TreeSignerTest : public ::testing::Test {
   TS* GetSimilar() {
     return new TS(std::chrono::duration<double>(0), db(),
                   unique_ptr<CompactMerkleTree>(new CompactMerkleTree(
-                      *tree_signer_->cert_tree_, new Sha256Hasher)),
+                      *tree_signer_->cert_tree_,
+                      unique_ptr<Sha256Hasher>(new Sha256Hasher))),
                   store_.get(), log_signer_.get());
   }
 

--- a/cpp/merkletree/compact_merkle_tree.cc
+++ b/cpp/merkletree/compact_merkle_tree.cc
@@ -9,20 +9,22 @@
 
 using cert_trans::MerkleTreeInterface;
 using std::string;
+using std::unique_ptr;
 
-CompactMerkleTree::CompactMerkleTree(SerialHasher* hasher)
+CompactMerkleTree::CompactMerkleTree(unique_ptr<SerialHasher> hasher)
     : MerkleTreeInterface(),
-      treehasher_(hasher),
+      treehasher_(hasher.release()),
       leaf_count_(0),
       leaves_processed_(0),
       level_count_(0),
       root_(treehasher_.HashEmpty()) {
 }
 
-CompactMerkleTree::CompactMerkleTree(MerkleTree& model, SerialHasher* hasher)
+CompactMerkleTree::CompactMerkleTree(MerkleTree& model,
+                                     unique_ptr<SerialHasher> hasher)
     : MerkleTreeInterface(),
       tree_(std::max<int64_t>(0, model.LevelCount() - 1)),
-      treehasher_(hasher),
+      treehasher_(hasher.release()),
       leaf_count_(model.LeafCount()),
       leaves_processed_(0),
       level_count_(model.LevelCount()),
@@ -95,9 +97,9 @@ CompactMerkleTree::CompactMerkleTree(MerkleTree& model, SerialHasher* hasher)
 
 
 CompactMerkleTree::CompactMerkleTree(const CompactMerkleTree& other,
-                                     SerialHasher* hasher)
+                                     unique_ptr<SerialHasher> hasher)
     : tree_(other.tree_),
-      treehasher_(hasher),
+      treehasher_(hasher.release()),
       leaf_count_(other.leaf_count_),
       leaves_processed_(other.leaves_processed_),
       level_count_(other.level_count_),

--- a/cpp/merkletree/compact_merkle_tree.h
+++ b/cpp/merkletree/compact_merkle_tree.h
@@ -2,6 +2,7 @@
 #define COMPACT_MERKLETREE_H
 
 #include <stddef.h>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -20,16 +21,15 @@ class CompactMerkleTree : public cert_trans::MerkleTreeInterface {
  public:
   // The constructor takes a pointer to some concrete hash function
   // instantiation of the SerialHasher abstract class.
-  // Takes ownership of the hasher.
-  explicit CompactMerkleTree(SerialHasher* hasher);
-  CompactMerkleTree(const CompactMerkleTree& other, SerialHasher* hasher);
+  explicit CompactMerkleTree(std::unique_ptr<SerialHasher> hasher);
+  CompactMerkleTree(const CompactMerkleTree& other,
+                    std::unique_ptr<SerialHasher> hasher);
 
   explicit CompactMerkleTree(CompactMerkleTree&& other) = default;
 
   // Creates a new CompactMerkleTree based on the data present in the
   // (non-compact) MerkleTree |model|.
-  // Takes ownership of |hasher|.
-  CompactMerkleTree(MerkleTree& model, SerialHasher* hasher);
+  CompactMerkleTree(MerkleTree& model, std::unique_ptr<SerialHasher> hasher);
 
   virtual ~CompactMerkleTree();
 

--- a/cpp/merkletree/merkle_tree_test.cc
+++ b/cpp/merkletree/merkle_tree_test.cc
@@ -183,7 +183,7 @@ TEST_F(MerkleTreeFuzzTest, RootFuzz) {
 
 TEST_F(CompactMerkleTreeTest, RootFuzz) {
   for (size_t tree_size = 1; tree_size <= data_.size(); ++tree_size) {
-    CompactMerkleTree tree(new Sha256Hasher());
+    CompactMerkleTree tree(NewSha256Hasher());
     for (size_t j = 0; j < tree_size; ++j) {
       tree.AddLeaf(data_[j]);
       // Since the tree is evaluated lazily, the tree state is significant
@@ -334,7 +334,7 @@ TEST_F(MerkleTreeTest, RootTestVectors) {
 
 TEST_F(CompactMerkleTreeTest, RootTestVectors) {
   // The first tree: add nodes one by one.
-  CompactMerkleTree tree1(new Sha256Hasher());
+  CompactMerkleTree tree1(NewSha256Hasher());
   EXPECT_EQ(tree1.LeafCount(), 0U);
   EXPECT_EQ(tree1.LevelCount(), 0U);
   EXPECT_STREQ(H(tree1.CurrentRoot()).c_str(), kSHA256EmptyTreeHash.str);
@@ -346,7 +346,7 @@ TEST_F(CompactMerkleTreeTest, RootTestVectors) {
   }
 
   // The second tree: add all nodes at once.
-  CompactMerkleTree tree2(new Sha256Hasher());
+  CompactMerkleTree tree2(NewSha256Hasher());
   for (int i = 0; i < 8; ++i) {
     tree2.AddLeaf(S(kInputs[i]));
   }
@@ -355,7 +355,7 @@ TEST_F(CompactMerkleTreeTest, RootTestVectors) {
   EXPECT_STREQ(H(tree2.CurrentRoot()).c_str(), kSHA256Roots[7].str);
 
   // The third tree: add nodes in two chunks.
-  CompactMerkleTree tree3(new Sha256Hasher());
+  CompactMerkleTree tree3(NewSha256Hasher());
   // Add three nodes.
   for (int i = 0; i < 3; ++i) {
     tree3.AddLeaf(S(kInputs[i]));
@@ -374,7 +374,7 @@ TEST_F(CompactMerkleTreeTest, RootTestVectors) {
 
 TEST_F(CompactMerkleTreeTest, TestCopyCtorWithRootTestVectors) {
   MerkleTree tree1(NewSha256Hasher());
-  CompactMerkleTree refctree1(new Sha256Hasher());
+  CompactMerkleTree refctree1(NewSha256Hasher());
   EXPECT_EQ(tree1.LeafCount(), 0U);
   EXPECT_EQ(tree1.LevelCount(), 0U);
   EXPECT_STREQ(H(tree1.CurrentRoot()).c_str(), kSHA256EmptyTreeHash.str);
@@ -386,7 +386,7 @@ TEST_F(CompactMerkleTreeTest, TestCopyCtorWithRootTestVectors) {
   EXPECT_EQ(tree1.LevelCount(), kLevelCounts[7]);
   EXPECT_STREQ(H(tree1.CurrentRoot()).c_str(), kSHA256Roots[7].str);
 
-  CompactMerkleTree ctree1(tree1, new Sha256Hasher());
+  CompactMerkleTree ctree1(tree1, NewSha256Hasher());
   EXPECT_EQ(tree1.LeafCount(), ctree1.LeafCount());
   EXPECT_EQ(tree1.LevelCount(), ctree1.LevelCount());
   EXPECT_EQ(tree1.CurrentRoot(), ctree1.CurrentRoot());
@@ -403,7 +403,7 @@ TEST_F(CompactMerkleTreeTest, TestCopyCtorThenAddLeafWithRootTestVectors) {
   EXPECT_EQ(tree.LeafCount(), 5U);
   EXPECT_EQ(tree.LevelCount(), kLevelCounts[4]);
   EXPECT_STREQ(H(tree.CurrentRoot()).c_str(), kSHA256Roots[4].str);
-  CompactMerkleTree ctree(tree, new Sha256Hasher());
+  CompactMerkleTree ctree(tree, NewSha256Hasher());
   EXPECT_EQ(tree.LeafCount(), ctree.LeafCount());
   EXPECT_EQ(tree.LevelCount(), ctree.LevelCount());
   EXPECT_EQ(tree.CurrentRoot(), ctree.CurrentRoot());
@@ -431,7 +431,7 @@ TEST_F(CompactMerkleTreeFuzzTest, CopyCtorForLargerTreesThenAppend) {
     }
     EXPECT_EQ(tree.LeafCount(), tree_size);
     // Now build a CompactMerkleTree using |tree| as the model
-    CompactMerkleTree ctree(tree, new Sha256Hasher());
+    CompactMerkleTree ctree(tree, NewSha256Hasher());
     // And check that the public interface concurs
     EXPECT_EQ(tree.LeafCount(), ctree.LeafCount());
     EXPECT_EQ(tree.LevelCount(), ctree.LevelCount());
@@ -584,7 +584,7 @@ TEST_F(MerkleTreeTest, AddLeafHash) {
 
 TEST_F(CompactMerkleTreeTest, TestCloneEmptyTreeProducesWorkingTree) {
   MerkleTree tree(NewSha256Hasher());
-  CompactMerkleTree compact(tree, new Sha256Hasher);
+  CompactMerkleTree compact(tree, NewSha256Hasher());
   EXPECT_STREQ(H(compact.CurrentRoot()).c_str(), kSHA256EmptyTreeHash.str);
 }
 
@@ -593,7 +593,7 @@ TEST_F(CompactMerkleTreeTest, TestCloneEmptyTreeProducesWorkingTree) {
 class MerkleVerifierTest : public MerkleTreeTest {
  protected:
   MerkleVerifier verifier_;
-  MerkleVerifierTest() : MerkleTreeTest(), verifier_(new Sha256Hasher()) {
+  MerkleVerifierTest() : MerkleTreeTest(), verifier_(new Sha256Hasher) {
   }
 
   void VerifierCheck(int leaf, int tree_size, const std::vector<string>& path,

--- a/cpp/tools/clustertool_main.cc
+++ b/cpp/tools/clustertool_main.cc
@@ -89,7 +89,8 @@ unique_ptr<TreeSigner<LoggedEntry>> BuildTreeSigner(
     LogSigner* log_signer) {
   return unique_ptr<TreeSigner<LoggedEntry>>(new TreeSigner<LoggedEntry>(
       std::chrono::duration<double>(0), db,
-      unique_ptr<CompactMerkleTree>(new CompactMerkleTree(new Sha256Hasher)),
+      unique_ptr<CompactMerkleTree>(
+          new CompactMerkleTree(unique_ptr<Sha256Hasher>(new Sha256Hasher))),
       consistent_store, log_signer));
 }
 


### PR DESCRIPTION
This makes ownership explicit (and verified at compile-time).