### PR TITLE
Make SerialHasher::Create return a unique_ptr.

### DIFF
--- a/cpp/merkletree/serial_hasher.cc
+++ b/cpp/merkletree/serial_hasher.cc
@@ -4,6 +4,7 @@
 #include <stddef.h>
 
 using std::string;
+using std::unique_ptr;
 
 const size_t Sha256Hasher::kDigestSize = SHA256_DIGEST_LENGTH;
 
@@ -32,8 +33,8 @@ string Sha256Hasher::Final() {
   return string(reinterpret_cast<char*>(hash), SHA256_DIGEST_LENGTH);
 }
 
-SerialHasher* Sha256Hasher::Create() const {
-  return new Sha256Hasher;
+unique_ptr<SerialHasher> Sha256Hasher::Create() const {
+  return unique_ptr<SerialHasher>(new Sha256Hasher);
 }
 
 // static

--- a/cpp/merkletree/serial_hasher.h
+++ b/cpp/merkletree/serial_hasher.h
@@ -3,6 +3,7 @@
 
 #include <openssl/sha.h>
 #include <stddef.h>
+#include <memory>
 #include <string>
 
 #include "base/macros.h"
@@ -26,8 +27,8 @@ class SerialHasher {
   // Finalize the hash context and return the binary digest blob.
   virtual std::string Final() = 0;
 
-  // A virtual constructor.  The caller gets ownership of the returned object.
-  virtual SerialHasher* Create() const = 0;
+  // A virtual constructor, creates a new instance of the same type.
+  virtual std::unique_ptr<SerialHasher> Create() const = 0;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(SerialHasher);
@@ -44,11 +45,10 @@ class Sha256Hasher : public SerialHasher {
   void Reset();
   void Update(const std::string& data);
   std::string Final();
-  SerialHasher* Create() const;
+  std::unique_ptr<SerialHasher> Create() const;
 
   // Create a new hasher and call Reset(), Update(), and Final().
   static std::string Sha256Digest(const std::string& data);
-
 
  private:
   SHA256_CTX ctx_;
@@ -57,4 +57,5 @@ class Sha256Hasher : public SerialHasher {
 
   DISALLOW_COPY_AND_ASSIGN(Sha256Hasher);
 };
+
 #endif

--- a/cpp/merkletree/serial_hasher_test.cc
+++ b/cpp/merkletree/serial_hasher_test.cc
@@ -9,6 +9,7 @@
 namespace {
 
 using std::string;
+using std::unique_ptr;
 
 const char kTestString[] = "Hello world!";
 const size_t kTestStringLength = 12;
@@ -97,13 +98,12 @@ TYPED_TEST(SerialHasherTest, Create) {
   string input, output, digest;
 
   for (size_t i = 0; this->test_vectors_[i].input != NULL; ++i) {
-    SerialHasher* new_hasher = this->hasher_->Create();
+    unique_ptr<SerialHasher> new_hasher(this->hasher_->Create());
     new_hasher->Reset();
     new_hasher->Update(
         S(this->test_vectors_[i].input, this->test_vectors_[i].input_length));
     digest = new_hasher->Final();
     EXPECT_STREQ(H(digest).c_str(), this->test_vectors_[i].output);
-    delete new_hasher;
   }
 }
 


### PR DESCRIPTION
This enforces the ownership transfer at compile-time.