### PR TITLE
Have MerkleVerifier take a unique_ptr<SerialHasher>.

### DIFF
--- a/cpp/client/ct.cc
+++ b/cpp/client/ct.cc
@@ -173,7 +173,8 @@ static LogVerifier* GetLogVerifierFromFlags() {
                    << pkey.status();
 
   return new LogVerifier(new LogSigVerifier(pkey.ValueOrDie()),
-                         new MerkleVerifier(new Sha256Hasher()));
+                         new MerkleVerifier(
+                             unique_ptr<Sha256Hasher>(new Sha256Hasher)));
 }
 
 // Adds the data to the cert as an extension, formatted as a single

--- a/cpp/fetcher/remote_peer_test.cc
+++ b/cpp/fetcher/remote_peer_test.cc
@@ -117,9 +117,9 @@ class RemotePeerTest : public ::testing::Test {
     peer_.reset(new RemotePeer(
         unique_ptr<AsyncLogClient>(
             new AsyncLogClient(&pool_, &fetcher_, kLogUrl)),
-        unique_ptr<LogVerifier>(
-            new LogVerifier(TestSigner::DefaultLogSigVerifier(),
-                            new MerkleVerifier(new Sha256Hasher))),
+        unique_ptr<LogVerifier>(new LogVerifier(
+            TestSigner::DefaultLogSigVerifier(),
+            new MerkleVerifier(unique_ptr<Sha256Hasher>(new Sha256Hasher)))),
         bind(&RemotePeerTest::OnNewSTH, this, _1), task_.task()));
   }
 

--- a/cpp/log/frontend_signer_test.cc
+++ b/cpp/log/frontend_signer_test.cc
@@ -61,7 +61,8 @@ class FrontendSignerTest : public ::testing::Test {
       : test_db_(),
         test_signer_(),
         verifier_(TestSigner::DefaultLogSigVerifier(),
-                  new MerkleVerifier(new Sha256Hasher())),
+                  new MerkleVerifier(
+                      unique_ptr<Sha256Hasher>(new Sha256Hasher))),
         base_(make_shared<libevent::Base>()),
         event_pump_(base_),
         etcd_client_(base_.get()),

--- a/cpp/log/frontend_test.cc
+++ b/cpp/log/frontend_test.cc
@@ -94,7 +94,8 @@ class FrontendTest : public ::testing::Test {
       : test_db_(),
         test_signer_(),
         verifier_(TestSigner::DefaultLogSigVerifier(),
-                  new MerkleVerifier(new Sha256Hasher())),
+                  new MerkleVerifier(
+                      unique_ptr<Sha256Hasher>(new Sha256Hasher))),
         checker_(),
         base_(make_shared<libevent::Base>()),
         event_pump_(base_),

--- a/cpp/log/log_lookup_test.cc
+++ b/cpp/log/log_lookup_test.cc
@@ -67,7 +67,8 @@ class LogLookupTest : public ::testing::Test {
                          unique_ptr<Sha256Hasher>(new Sha256Hasher))),
                      &store_, log_signer_.get()),
         verifier_(TestSigner::DefaultLogSigVerifier(),
-                  new MerkleVerifier(new Sha256Hasher())) {
+                  new MerkleVerifier(
+                      unique_ptr<Sha256Hasher>(new Sha256Hasher))) {
     // Set some noddy STH so that we can call UpdateTree on the Tree Signer.
     store_.SetServingSTH(ct::SignedTreeHead());
     // Force an empty sequence mapping file:

--- a/cpp/log/tree_signer_test.cc
+++ b/cpp/log/tree_signer_test.cc
@@ -62,8 +62,9 @@ class TreeSignerTest : public ::testing::Test {
 
   void SetUp() {
     test_db_.reset(new TestDB<T>);
-    verifier_.reset(new LogVerifier(TestSigner::DefaultLogSigVerifier(),
-                                    new MerkleVerifier(new Sha256Hasher())));
+    verifier_.reset(new LogVerifier(
+        TestSigner::DefaultLogSigVerifier(),
+        new MerkleVerifier(unique_ptr<Sha256Hasher>(new Sha256Hasher))));
     store_.reset(new EtcdConsistentStore<LoggedEntry>(
         base_.get(), &pool_, &etcd_client_, &election_, "/root", "id"));
     log_signer_.reset(TestSigner::DefaultLogSigner());

--- a/cpp/merkletree/merkle_tree_test.cc
+++ b/cpp/merkletree/merkle_tree_test.cc
@@ -593,7 +593,9 @@ TEST_F(CompactMerkleTreeTest, TestCloneEmptyTreeProducesWorkingTree) {
 class MerkleVerifierTest : public MerkleTreeTest {
  protected:
   MerkleVerifier verifier_;
-  MerkleVerifierTest() : MerkleTreeTest(), verifier_(new Sha256Hasher) {
+  MerkleVerifierTest()
+      : MerkleTreeTest(),
+        verifier_(unique_ptr<Sha256Hasher>(new Sha256Hasher)) {
   }
 
   void VerifierCheck(int leaf, int tree_size, const std::vector<string>& path,

--- a/cpp/merkletree/merkle_verifier.cc
+++ b/cpp/merkletree/merkle_verifier.cc
@@ -4,8 +4,10 @@
 #include <vector>
 
 using std::string;
+using std::unique_ptr;
 
-MerkleVerifier::MerkleVerifier(SerialHasher* hasher) : treehasher_(hasher) {
+MerkleVerifier::MerkleVerifier(unique_ptr<SerialHasher> hasher)
+    : treehasher_(hasher.release()) {
 }
 
 MerkleVerifier::~MerkleVerifier() {

--- a/cpp/merkletree/merkle_verifier.h
+++ b/cpp/merkletree/merkle_verifier.h
@@ -2,6 +2,7 @@
 #define MERKLEVERIFIER_H
 
 #include <stddef.h>
+#include <memory>
 #include <vector>
 
 #include "merkletree/tree_hasher.h"
@@ -13,8 +14,7 @@ class SerialHasher;
 
 class MerkleVerifier {
  public:
-  // Takes ownership of the SerialHasher.
-  MerkleVerifier(SerialHasher* hasher);
+  MerkleVerifier(std::unique_ptr<SerialHasher> hasher);
   ~MerkleVerifier();
 
   // Verify Merkle path. Return true iff the path is a valid proof for

--- a/cpp/server/ct-mirror.cc
+++ b/cpp/server/ct-mirror.cc
@@ -282,7 +282,8 @@ int main(int argc, char* argv[]) {
                      << pubkey.status();
 
   const LogVerifier log_verifier(new LogSigVerifier(pubkey.ValueOrDie()),
-                                 new MerkleVerifier(new Sha256Hasher));
+                                 new MerkleVerifier(unique_ptr<Sha256Hasher>(
+                                     new Sha256Hasher)));
 
   ThreadPool http_pool(FLAGS_num_http_server_threads);
 
@@ -353,9 +354,9 @@ int main(int argc, char* argv[]) {
   const shared_ptr<RemotePeer> peer(make_shared<RemotePeer>(
       unique_ptr<AsyncLogClient>(
           new AsyncLogClient(&pool, &url_fetcher, FLAGS_target_log_uri)),
-      unique_ptr<LogVerifier>(
-          new LogVerifier(new LogSigVerifier(pubkey.ValueOrDie()),
-                          new MerkleVerifier(new Sha256Hasher))),
+      unique_ptr<LogVerifier>(new LogVerifier(
+          new LogSigVerifier(pubkey.ValueOrDie()),
+          new MerkleVerifier(unique_ptr<Sha256Hasher>(new Sha256Hasher)))),
       new_sth, fetcher_task.task()->AddChild(
                    [](Task*) { LOG(INFO) << "RemotePeer exited."; })));
 

--- a/cpp/server/ct-mirror_v2.cc
+++ b/cpp/server/ct-mirror_v2.cc
@@ -280,7 +280,8 @@ int main(int argc, char* argv[]) {
                      << pubkey.status();
 
   const LogVerifier log_verifier(new LogSigVerifier(pubkey.ValueOrDie()),
-                                 new MerkleVerifier(new Sha256Hasher));
+                                 new MerkleVerifier(unique_ptr<Sha256Hasher>(
+                                     new Sha256Hasher)));
 
   ThreadPool http_pool(FLAGS_num_http_server_threads);
 
@@ -351,9 +352,9 @@ int main(int argc, char* argv[]) {
   const shared_ptr<RemotePeer> peer(make_shared<RemotePeer>(
       unique_ptr<AsyncLogClient>(
           new AsyncLogClient(&pool, &url_fetcher, FLAGS_target_log_uri)),
-      unique_ptr<LogVerifier>(
-          new LogVerifier(new LogSigVerifier(pubkey.ValueOrDie()),
-                          new MerkleVerifier(new Sha256Hasher))),
+      unique_ptr<LogVerifier>(new LogVerifier(
+          new LogSigVerifier(pubkey.ValueOrDie()),
+          new MerkleVerifier(unique_ptr<Sha256Hasher>(new Sha256Hasher)))),
       new_sth, fetcher_task.task()->AddChild(
                    [](Task*) { LOG(INFO) << "RemotePeer exited."; })));
 

--- a/cpp/server/ct-server.cc
+++ b/cpp/server/ct-server.cc
@@ -129,7 +129,8 @@ int main(int argc, char* argv[]) {
                                     &url_fetcher));
 
   const LogVerifier log_verifier(new LogSigVerifier(pkey.ValueOrDie()),
-                                 new MerkleVerifier(new Sha256Hasher));
+                                 new MerkleVerifier(unique_ptr<Sha256Hasher>(
+                                     new Sha256Hasher)));
 
   ThreadPool http_pool(FLAGS_num_http_server_threads);
 

--- a/cpp/server/ct-server_v2.cc
+++ b/cpp/server/ct-server_v2.cc
@@ -136,7 +136,8 @@ int main(int argc, char* argv[]) {
                                     &url_fetcher));
 
   const LogVerifier log_verifier(new LogSigVerifier(pkey.ValueOrDie()),
-                                 new MerkleVerifier(new Sha256Hasher));
+                                 new MerkleVerifier(unique_ptr<Sha256Hasher>(
+                                     new Sha256Hasher)));
 
   ThreadPool http_pool(FLAGS_num_http_server_threads);
 

--- a/cpp/server/xjson-server.cc
+++ b/cpp/server/xjson-server.cc
@@ -121,7 +121,8 @@ int main(int argc, char* argv[]) {
                                     &url_fetcher));
 
   const LogVerifier log_verifier(new LogSigVerifier(pkey.ValueOrDie()),
-                                 new MerkleVerifier(new Sha256Hasher));
+                                 new MerkleVerifier(unique_ptr<Sha256Hasher>(
+                                     new Sha256Hasher)));
 
   ThreadPool http_pool(FLAGS_num_http_server_threads);
 


### PR DESCRIPTION
This makes ownership explicit (and verified at compile-time).