### PR TITLE
Have TreeHasher take a unique_ptr<SerialHasher>.

### DIFF
--- a/cpp/log/test_signer.cc
+++ b/cpp/log/test_signer.cc
@@ -20,9 +20,9 @@
 #include "util/openssl_scoped_types.h"
 #include "util/util.h"
 
-using cert_trans::Signer;
 using cert_trans::LoggedEntry;
 using cert_trans::ScopedBIO;
+using cert_trans::Signer;
 using cert_trans::Verifier;
 using ct::DigitallySigned;
 using ct::LogEntry;
@@ -31,6 +31,7 @@ using ct::SignedCertificateTimestamp;
 using ct::SignedTreeHead;
 using ct::X509ChainEntry;
 using std::string;
+using std::unique_ptr;
 
 namespace {
 
@@ -178,7 +179,7 @@ TestSigner::TestSigner()
     : default_signer_(NULL),
       counter_(0),
       default_cert_(B(kDefaultDerCert)),
-      tree_hasher_(new Sha256Hasher()) {
+      tree_hasher_(unique_ptr<Sha256Hasher>(new Sha256Hasher)) {
   counter_ = util::TimeInMilliseconds();
   srand(counter_);
   EVP_PKEY* pkey = PrivateKeyFromPem(kEcP256PrivateKey);

--- a/cpp/merkletree/compact_merkle_tree.cc
+++ b/cpp/merkletree/compact_merkle_tree.cc
@@ -8,12 +8,13 @@
 #include "merkletree/merkle_tree_math.h"
 
 using cert_trans::MerkleTreeInterface;
+using std::move;
 using std::string;
 using std::unique_ptr;
 
 CompactMerkleTree::CompactMerkleTree(unique_ptr<SerialHasher> hasher)
     : MerkleTreeInterface(),
-      treehasher_(hasher.release()),
+      treehasher_(move(hasher)),
       leaf_count_(0),
       leaves_processed_(0),
       level_count_(0),
@@ -24,7 +25,7 @@ CompactMerkleTree::CompactMerkleTree(MerkleTree& model,
                                      unique_ptr<SerialHasher> hasher)
     : MerkleTreeInterface(),
       tree_(std::max<int64_t>(0, model.LevelCount() - 1)),
-      treehasher_(hasher.release()),
+      treehasher_(move(hasher)),
       leaf_count_(model.LeafCount()),
       leaves_processed_(0),
       level_count_(model.LevelCount()),
@@ -99,7 +100,7 @@ CompactMerkleTree::CompactMerkleTree(MerkleTree& model,
 CompactMerkleTree::CompactMerkleTree(const CompactMerkleTree& other,
                                      unique_ptr<SerialHasher> hasher)
     : tree_(other.tree_),
-      treehasher_(hasher.release()),
+      treehasher_(move(hasher)),
       leaf_count_(other.leaf_count_),
       leaves_processed_(other.leaves_processed_),
       level_count_(other.level_count_),

--- a/cpp/merkletree/merkle_tree.cc
+++ b/cpp/merkletree/merkle_tree.cc
@@ -8,12 +8,13 @@
 #include "merkletree/merkle_tree_math.h"
 
 using cert_trans::MerkleTreeInterface;
+using std::move;
 using std::string;
 using std::unique_ptr;
 
 MerkleTree::MerkleTree(unique_ptr<SerialHasher> hasher)
     : MerkleTreeInterface(),
-      treehasher_(hasher.release()),
+      treehasher_(move(hasher)),
       leaves_processed_(0),
       level_count_(0) {
 }

--- a/cpp/merkletree/merkle_tree_test.cc
+++ b/cpp/merkletree/merkle_tree_test.cc
@@ -129,7 +129,7 @@ class MerkleTreeTest : public ::testing::Test {
  protected:
   TreeHasher tree_hasher_;
   std::vector<string> data_;
-  MerkleTreeTest() : tree_hasher_(new Sha256Hasher()) {
+  MerkleTreeTest() : tree_hasher_(unique_ptr<Sha256Hasher>(new Sha256Hasher)) {
     for (int i = 0; i < 256; ++i)
       data_.push_back(string(1, i));
   }

--- a/cpp/merkletree/merkle_verifier.cc
+++ b/cpp/merkletree/merkle_verifier.cc
@@ -3,11 +3,12 @@
 #include <stddef.h>
 #include <vector>
 
+using std::move;
 using std::string;
 using std::unique_ptr;
 
 MerkleVerifier::MerkleVerifier(unique_ptr<SerialHasher> hasher)
-    : treehasher_(hasher.release()) {
+    : treehasher_(move(hasher)) {
 }
 
 MerkleVerifier::~MerkleVerifier() {

--- a/cpp/merkletree/sparse_merkle_tree.cc
+++ b/cpp/merkletree/sparse_merkle_tree.cc
@@ -32,7 +32,7 @@ const vector<string>* GetNullHashes(const TreeHasher& hasher) {
 
 
 SparseMerkleTree::SparseMerkleTree(SerialHasher* hasher)
-    : treehasher_(hasher),
+    : treehasher_(unique_ptr<SerialHasher>(hasher)),
       null_hashes_(GetNullHashes(treehasher_)) {
 }
 

--- a/cpp/merkletree/sparse_merkle_tree_test.cc
+++ b/cpp/merkletree/sparse_merkle_tree_test.cc
@@ -81,7 +81,7 @@ pair<ScopedBIGNUM, string> Value(uint64_t n, const string& v) {
 class Reference {
  public:
   Reference(SerialHasher* hasher)
-      : tree_hasher_(CHECK_NOTNULL(hasher)),
+      : tree_hasher_(unique_ptr<SerialHasher>(CHECK_NOTNULL(hasher))),
         hStarEmptyCache_{tree_hasher_.HashLeaf("")} {
   }
 
@@ -156,8 +156,8 @@ class Reference {
 class SparseMerkleTreeTest : public testing::Test {
  public:
   SparseMerkleTreeTest()
-      : tree_hasher_(new Sha256Hasher),
-        tree_(new Sha256Hasher()),
+      : tree_hasher_(unique_ptr<Sha256Hasher>(new Sha256Hasher)),
+        tree_(new Sha256Hasher),
         rand_({1234}) {
   }
 

--- a/cpp/merkletree/tree_hasher.cc
+++ b/cpp/merkletree/tree_hasher.cc
@@ -5,8 +5,10 @@
 #include "merkletree/serial_hasher.h"
 
 using std::lock_guard;
+using std::move;
 using std::mutex;
 using std::string;
+using std::unique_ptr;
 
 namespace {
 
@@ -20,8 +22,8 @@ std::string EmptyHash(SerialHasher* hasher) {
 
 }  // namespace
 
-TreeHasher::TreeHasher(SerialHasher* hasher)
-    : hasher_(hasher), empty_hash_(EmptyHash(hasher_.get())) {
+TreeHasher::TreeHasher(unique_ptr<SerialHasher> hasher)
+    : hasher_(move(hasher)), empty_hash_(EmptyHash(hasher_.get())) {
   assert(hasher_);
 }
 

--- a/cpp/merkletree/tree_hasher.h
+++ b/cpp/merkletree/tree_hasher.h
@@ -11,8 +11,7 @@
 
 class TreeHasher {
  public:
-  // Takes ownership of the SerialHasher.
-  TreeHasher(SerialHasher* hasher);
+  TreeHasher(std::unique_ptr<SerialHasher> hasher);
 
   size_t DigestSize() const {
     return hasher_->DigestSize();

--- a/cpp/merkletree/tree_hasher_test.cc
+++ b/cpp/merkletree/tree_hasher_test.cc
@@ -10,6 +10,7 @@
 namespace {
 
 using std::string;
+using std::unique_ptr;
 
 typedef struct {
   size_t input_length;
@@ -69,7 +70,8 @@ class TreeHasherTest : public ::testing::Test {
  protected:
   TreeHasher tree_hasher_;
   TestVector* test_vectors_;
-  TreeHasherTest() : tree_hasher_(new T()), test_vectors_(TestVectors<T>()) {
+  TreeHasherTest()
+      : tree_hasher_(unique_ptr<T>(new T)), test_vectors_(TestVectors<T>()) {
   }
 };
 

--- a/cpp/monitor/database.cc
+++ b/cpp/monitor/database.cc
@@ -11,7 +11,7 @@ Database::WriteResult Database::CreateEntry(
   if (!logged.SerializeForLeaf(&leaf))
     return this->SERIALIZE_FAILED;
 
-  TreeHasher hasher(new Sha256Hasher);
+  TreeHasher hasher(std::unique_ptr<Sha256Hasher>(new Sha256Hasher));
   std::string leaf_hash = hasher.HashLeaf(leaf);
 
   std::string cert = Serializer::LeafData(logged.entry());

--- a/cpp/monitor/database_test.cc
+++ b/cpp/monitor/database_test.cc
@@ -13,6 +13,7 @@ namespace {
 using cert_trans::LoggedEntry;
 using ct::SignedTreeHead;
 using std::string;
+using std::unique_ptr;
 
 template <class T>
 class DBTest : public ::testing::Test {
@@ -103,7 +104,7 @@ TYPED_TEST(DBTest, WriteEntryAndLookupHash) {
 
   string leaf;
   logged.SerializeForLeaf(&leaf);
-  TreeHasher hasher(new Sha256Hasher);
+  TreeHasher hasher(unique_ptr<Sha256Hasher>(new Sha256Hasher));
   std::string leaf_hash = hasher.HashLeaf(leaf);
   EXPECT_EQ(leaf_hash, res);
 }


### PR DESCRIPTION
This makes ownership explicit (and verified at compile-time).