### PR TITLE
Python: Remove the Observations message.

### DIFF
--- a/python/ct/client/db/cert_desc.py
+++ b/python/ct/client/db/cert_desc.py
@@ -8,7 +8,7 @@ from ct.crypto.asn1 import x509_common
 from ct.proto import certificate_pb2
 
 
-def from_cert(certificate, observations=[]):
+def from_cert(certificate):
     """Pulls out interesting fields from certificate, so format of data will
     be similar in every database implementation."""
     proto = certificate_pb2.X509Description()
@@ -84,14 +84,6 @@ def from_cert(certificate, observations=[]):
         pass
 
     proto.sha256_hash = hashlib.sha256(proto.der).digest()
-
-    for observation in observations:
-        proto_obs = proto.observations.add()
-        if observation.description:
-            proto_obs.description = observation.description
-        if observation.reason:
-            proto_obs.reason = observation.reason
-        proto_obs.details = observation.details_to_proto()
 
     return proto
 

--- a/python/ct/client/db/sqlite_cert_db.py
+++ b/python/ct/client/db/sqlite_cert_db.py
@@ -23,10 +23,7 @@ class SQLiteCertDB(cert_db.CertDB):
             # subject common names and dnsnames for easy lookup of given
             # domain name
             ("subject_names", [("name", "TEXT")]),
-            ("root_issuer", [("type", "TEXT"), ("name", "TEXT")]),
-            ("observations", [("description", "TEXT"),
-                              ("reason", "TEXT"),
-                              ("details", "BLOB")])]
+            ("root_issuer", [("type", "TEXT"), ("name", "TEXT")])]
         cert_single_field_tables = [("version", "INTEGER"),
                                     ("serial_number", "TEXT")]
         with self.__mgr.get_connection() as conn:
@@ -115,12 +112,6 @@ class SQLiteCertDB(cert_db.CertDB):
             cursor.execute("INSERT INTO root_issuer(log, cert_id, type, name)"
                            "VALUES(?, ?, ?, ?)",
                            (log_key, index, iss.type, iss.value))
-
-        for obs in cert.observations:
-            cursor.execute("INSERT INTO observations(log, cert_id, description, "
-                           "reason, details) VALUES(?, ?, ?, ?, ?)",
-                           (log_key, index, obs.description, obs.reason,
-                            sqlite3.Binary(obs.details)))
 
     def store_certs_desc(self, certs, log_key):
         """Store certificates using their descriptions.

--- a/python/ct/client/reporter.py
+++ b/python/ct/client/reporter.py
@@ -21,9 +21,6 @@ gflags.DEFINE_integer("reporter_workers", multiprocessing.cpu_count(),
 gflags.DEFINE_integer("reporter_queue_size", 50,
                       "Size of entry queue in reporter")
 
-gflags.DEFINE_bool("reporter_disable_checks", False,
-                   "Disable cert_analysis checks.")
-
 
 def _scan_der_cert(der_certs):
     current = -1
@@ -117,7 +114,8 @@ class CertificateReport(object):
         """Clean up report."""
 
     def scan_der_certs(self, der_certs):
-        """Scans certificates in der form for all supported observations.
+        """Scans certificates in der form, parsing them to produce
+        X509Description for each.
 
         Args:
             der_certs: non empty array of

--- a/python/ct/proto/certificate.proto
+++ b/python/ct/proto/certificate.proto
@@ -24,15 +24,6 @@ message DNAttribute {
   optional string value = 2;
 }
 
-// TODO(eran): Remove this message.
-message Observation {
-  optional string description = 1;
-
-  optional string reason = 2;
-
-  optional bytes details = 3;
-}
-
 message X509Description {
   optional string version = 1;
 
@@ -58,8 +49,7 @@ message X509Description {
   // SHA256 hash from DER form.
   optional bytes sha256_hash = 10;
 
-  // Deprecated - The code to fill this field in was removed.
-  repeated Observation observations = 11;
+  // Field 11 was Observation, no longer produced.
 
   repeated DNAttribute root_issuer = 12;
 


### PR DESCRIPTION
Now that the observation gathering code is gone, this message is
redundant.