### PR TITLE
Convert HTTPLogClient::GetEntries to use StatusOr.

### DIFF
--- a/cpp/client/async_log_client.h
+++ b/cpp/client/async_log_client.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "base/macros.h"
@@ -33,6 +34,11 @@ class AsyncLogClient {
   };
 
   struct Entry {
+    Entry() = default;
+    Entry(Entry&& src)
+        : leaf(src.leaf), entry(src.entry), sct(std::move(src.sct)) {
+    }
+
     ct::MerkleTreeLeaf leaf;
     ct::LogEntry entry;
     std::unique_ptr<ct::SignedCertificateTimestamp> sct;

--- a/cpp/client/ct.cc
+++ b/cpp/client/ct.cc
@@ -851,17 +851,16 @@ static void WriteCertificate(const std::string& cert, int entry,
 void GetEntries() {
   CHECK_NE(FLAGS_ct_server, "");
   HTTPLogClient client(FLAGS_ct_server);
-  std::vector<AsyncLogClient::Entry> entries;
-  AsyncLogClient::Status error =
-      client.GetEntries(FLAGS_get_first, FLAGS_get_last, &entries);
-  CHECK_EQ(error, AsyncLogClient::OK);
+  const StatusOr<vector<AsyncLogClient::Entry>> entries(
+      client.GetEntries(FLAGS_get_first, FLAGS_get_last));
+  CHECK_EQ(entries.status(), Status::OK);
 
   CHECK(!FLAGS_certificate_base.empty());
 
   int e = FLAGS_get_first;
-  for (std::vector<AsyncLogClient::Entry>::const_iterator
-           entry = entries.begin();
-       entry != entries.end(); ++entry, ++e) {
+  for (vector<AsyncLogClient::Entry>::const_iterator
+           entry = entries.ValueOrDie().begin();
+       entry != entries.ValueOrDie().end(); ++entry, ++e) {
     if (entry->leaf.timestamped_entry().entry_type() == ct::X509_ENTRY) {
       WriteCertificate(entry->leaf.timestamped_entry().signed_entry().x509(),
                        e, 0, "x509");

--- a/cpp/client/http_log_client.h
+++ b/cpp/client/http_log_client.h
@@ -35,10 +35,8 @@ class HTTPLogClient {
   util::StatusOr<std::vector<std::string>> GetSTHConsistency(int64_t size1,
                                                              int64_t size2);
 
-  // This does not clear |entries| before appending the retrieved
-  // entries.
-  AsyncLogClient::Status GetEntries(
-      int first, int last, std::vector<AsyncLogClient::Entry>* entries);
+  util::StatusOr<std::vector<AsyncLogClient::Entry>> GetEntries(int first,
+                                                                int last);
 
  private:
   const std::unique_ptr<libevent::Base> base_;


### PR DESCRIPTION
I'm finding `HTTPLogClient::GetEntries` highly suspect, but I think this maintains its current semantics, whatever they might be.