### PR TITLE
Pass a non-const  MerkleTree as a pointer.

### DIFF
--- a/cpp/log/log_lookup.cc
+++ b/cpp/log/log_lookup.cc
@@ -205,7 +205,7 @@ unique_ptr<CompactMerkleTree> LogLookup::GetCompactMerkleTree(
     SerialHasher* hasher) {
   lock_guard<mutex> lock(lock_);
   return unique_ptr<CompactMerkleTree>(
-      new CompactMerkleTree(cert_tree_, unique_ptr<SerialHasher>(hasher)));
+      new CompactMerkleTree(&cert_tree_, unique_ptr<SerialHasher>(hasher)));
 }
 
 

--- a/cpp/merkletree/compact_merkle_tree.h
+++ b/cpp/merkletree/compact_merkle_tree.h
@@ -29,7 +29,13 @@ class CompactMerkleTree : public cert_trans::MerkleTreeInterface {
 
   // Creates a new CompactMerkleTree based on the data present in the
   // (non-compact) MerkleTree |model|.
-  CompactMerkleTree(MerkleTree& model, std::unique_ptr<SerialHasher> hasher);
+  // Takes ownership of |hasher|, does not use |model| after the
+  // construction.
+  // TODO(pphaneuf): This should take a const reference to the model,
+  // but implementation details currently make this too difficult.
+  // TODO(pphaneuf): It should also get its |hasher| from |model|,
+  // somehow.
+  CompactMerkleTree(MerkleTree* model, std::unique_ptr<SerialHasher> hasher);
 
   virtual ~CompactMerkleTree();
 

--- a/cpp/merkletree/merkle_tree_test.cc
+++ b/cpp/merkletree/merkle_tree_test.cc
@@ -386,7 +386,7 @@ TEST_F(CompactMerkleTreeTest, TestCopyCtorWithRootTestVectors) {
   EXPECT_EQ(tree1.LevelCount(), kLevelCounts[7]);
   EXPECT_STREQ(H(tree1.CurrentRoot()).c_str(), kSHA256Roots[7].str);
 
-  CompactMerkleTree ctree1(tree1, NewSha256Hasher());
+  CompactMerkleTree ctree1(&tree1, NewSha256Hasher());
   EXPECT_EQ(tree1.LeafCount(), ctree1.LeafCount());
   EXPECT_EQ(tree1.LevelCount(), ctree1.LevelCount());
   EXPECT_EQ(tree1.CurrentRoot(), ctree1.CurrentRoot());
@@ -403,7 +403,7 @@ TEST_F(CompactMerkleTreeTest, TestCopyCtorThenAddLeafWithRootTestVectors) {
   EXPECT_EQ(tree.LeafCount(), 5U);
   EXPECT_EQ(tree.LevelCount(), kLevelCounts[4]);
   EXPECT_STREQ(H(tree.CurrentRoot()).c_str(), kSHA256Roots[4].str);
-  CompactMerkleTree ctree(tree, NewSha256Hasher());
+  CompactMerkleTree ctree(&tree, NewSha256Hasher());
   EXPECT_EQ(tree.LeafCount(), ctree.LeafCount());
   EXPECT_EQ(tree.LevelCount(), ctree.LevelCount());
   EXPECT_EQ(tree.CurrentRoot(), ctree.CurrentRoot());
@@ -431,7 +431,7 @@ TEST_F(CompactMerkleTreeFuzzTest, CopyCtorForLargerTreesThenAppend) {
     }
     EXPECT_EQ(tree.LeafCount(), tree_size);
     // Now build a CompactMerkleTree using |tree| as the model
-    CompactMerkleTree ctree(tree, NewSha256Hasher());
+    CompactMerkleTree ctree(&tree, NewSha256Hasher());
     // And check that the public interface concurs
     EXPECT_EQ(tree.LeafCount(), ctree.LeafCount());
     EXPECT_EQ(tree.LevelCount(), ctree.LevelCount());
@@ -584,7 +584,7 @@ TEST_F(MerkleTreeTest, AddLeafHash) {
 
 TEST_F(CompactMerkleTreeTest, TestCloneEmptyTreeProducesWorkingTree) {
   MerkleTree tree(NewSha256Hasher());
-  CompactMerkleTree compact(tree, NewSha256Hasher());
+  CompactMerkleTree compact(&tree, NewSha256Hasher());
   EXPECT_STREQ(H(compact.CurrentRoot()).c_str(), kSHA256EmptyTreeHash.str);
 }
 


### PR DESCRIPTION
To avoid surprises, as recommended by the style guide:

https://google.github.io/styleguide/cppguide.html#Reference_Arguments