### PR TITLE
Fork the ct.proto file for Java.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -172,7 +172,7 @@
     <mkdir dir="${ctlogclient.generated.dir}"/>
     <exec executable="${protoc.bin}">
       <arg value="--java_out=${ctlogclient.generated.dir}"/>
-      <arg value="proto/ct.proto"/>
+      <arg value="java/ct.proto"/>
     </exec>
   </target>
 

--- a/java/ct.proto
+++ b/java/ct.proto
@@ -1,0 +1,124 @@
+syntax = "proto2";
+
+package ct;
+option java_package = "org.certificatetransparency.ctlog.proto";
+
+// RFC 5246
+message DigitallySigned {
+  enum HashAlgorithm {
+    NONE = 0;
+    MD5 = 1;
+    SHA1 = 2;
+    SHA224 = 3;
+    SHA256 = 4;
+    SHA384 = 5;
+    SHA512 = 6;
+  }
+
+  enum SignatureAlgorithm {
+    ANONYMOUS = 0;
+    RSA = 1;
+    DSA = 2;
+    ECDSA = 3;
+  }
+
+  // 1 byte
+  optional HashAlgorithm hash_algorithm = 1 [ default = NONE ];
+  // 1 byte
+  optional SignatureAlgorithm sig_algorithm = 2 [ default = ANONYMOUS ];
+  // 0..2^16-1 bytes
+  optional bytes signature = 3;
+}
+
+enum LogEntryType {
+  X509_ENTRY = 0;
+  PRECERT_ENTRY = 1;
+  // Not part of the I-D, and outside the valid range.
+  UNKNOWN_ENTRY_TYPE = 65536;
+}
+
+message X509ChainEntry {
+  // For V1 this entry just includes the certificate in the leaf_certificate
+  // field
+  optional bytes leaf_certificate = 1;
+  // A chain from the leaf to a trusted root
+  // (excluding leaf and possibly root).
+  repeated bytes certificate_chain = 2;
+}
+
+message PreCert {
+  optional bytes issuer_key_hash = 1;
+  optional bytes tbs_certificate = 2;
+}
+
+message PrecertChainEntry {
+  // The chain certifying the precertificate, as submitted by the CA.
+  repeated bytes precertificate_chain = 2;
+
+  // PreCert input to the SCT. Can be computed from the above.
+  // Store it alongside the entry data so that the signers don't have to
+  // parse certificates to recompute it.
+  optional PreCert pre_cert = 3;
+}
+
+message LogEntry {
+  optional X509ChainEntry x509_entry = 2;
+  optional PrecertChainEntry precert_entry = 3;
+}
+
+enum Version {
+  V1 = 0;
+  // Not part of the I-D, and outside the valid range.
+  UNKNOWN_VERSION = 256;
+}
+
+message LogID {
+  // 32 bytes
+  optional bytes key_id = 1;
+}
+
+message SignedCertificateTimestamp {
+  optional Version version = 1 [ default = UNKNOWN_VERSION ];
+  optional LogID id = 2;
+  // UTC time in milliseconds, since January 1, 1970, 00:00.
+  optional uint64 timestamp = 3;
+  optional DigitallySigned signature = 4;
+  optional bytes extensions = 5;
+}
+
+enum MerkleLeafType {
+  TIMESTAMPED_ENTRY = 0;
+  UNKNOWN_LEAF_TYPE = 256;
+}
+
+message SignedEntry {
+  optional bytes x509 = 1;
+  optional PreCert precert = 2;
+}
+
+message TimestampedEntry {
+  optional uint64 timestamp = 1;
+  optional LogEntryType entry_type = 2;
+  optional SignedEntry signed_entry = 3;
+}
+
+message MerkleTreeLeaf {
+  optional Version version = 1 [ default = UNKNOWN_VERSION ];
+  optional MerkleLeafType type = 2 [ default = UNKNOWN_LEAF_TYPE ];
+  optional TimestampedEntry timestamped_entry = 3;
+}
+
+message MerkleAuditProof {
+  optional Version version = 1 [ default = UNKNOWN_VERSION ];
+  optional int64 tree_size = 3;
+  optional int64 leaf_index = 5;
+  repeated bytes path_node = 6;
+}
+
+message SignedTreeHead {
+  optional Version version = 1 [ default = UNKNOWN_VERSION ];
+  optional uint64 timestamp = 3;
+  optional int64 tree_size = 4;
+  optional bytes sha256_root_hash = 5;
+  optional DigitallySigned signature = 6;
+}


### PR DESCRIPTION
The Java side (almost) doesn't read or write those, using them as in-memory data structures. Splitting it off allows refactorings to be done more easily, on both sides.