### PR TITLE
Make Cert more robust.

### DIFF
--- a/cpp/client/async_log_client.cc
+++ b/cpp/client/async_log_client.cc
@@ -127,9 +127,8 @@ void DoneGetRoots(UrlFetcher::Response* resp, vector<unique_ptr<Cert>>* roots,
     if (!jcert.Ok())
       return done(AsyncLogClient::BAD_RESPONSE);
 
-    unique_ptr<Cert> cert(new Cert);
-    const util::Status status(cert->LoadFromDerString(jcert.FromBase64()));
-    if (!status.ok()) {
+    unique_ptr<Cert> cert(Cert::FromDerString(jcert.FromBase64()));
+    if (!cert) {
       return done(AsyncLogClient::BAD_RESPONSE);
     }
 

--- a/cpp/client/ssl_client.cc
+++ b/cpp/client/ssl_client.cc
@@ -174,8 +174,8 @@ int SSLClient::VerifyCallback(X509_STORE_CTX* ctx, void* arg) {
   // Should contain at least the leaf.
   CHECK_GE(chain_size, 1);
   for (int i = 0; i < chain_size; ++i) {
-    chain.AddCert(unique_ptr<Cert>(
-        new Cert(ScopedX509(X509_dup(sk_X509_value(ctx->chain, i))))));
+    chain.AddCert(
+        Cert::FromX509(ScopedX509(X509_dup(sk_X509_value(ctx->chain, i)))));
   }
 
   CHECK_NOTNULL(ctx->untrusted);
@@ -183,8 +183,8 @@ int SSLClient::VerifyCallback(X509_STORE_CTX* ctx, void* arg) {
   // Should contain at least the leaf.
   CHECK_GE(chain_size, 1);
   for (int i = 0; i < chain_size; ++i) {
-    input_chain.AddCert(unique_ptr<Cert>(
-        new Cert(ScopedX509(X509_dup(sk_X509_value(ctx->untrusted, i))))));
+    input_chain.AddCert(Cert::FromX509(
+        ScopedX509(X509_dup(sk_X509_value(ctx->untrusted, i)))));
   }
 
   string serialized_scts;

--- a/cpp/log/cert.cc
+++ b/cpp/log/cert.cc
@@ -210,16 +210,16 @@ unique_ptr<Cert> Cert::Clone() const {
 }
 
 
-util::Status Cert::LoadFromDerString(const string& der_string) {
+unique_ptr<Cert> Cert::FromDerString(const string& der_string) {
   const unsigned char* start =
       reinterpret_cast<const unsigned char*>(der_string.data());
-  x509_.reset(d2i_X509(nullptr, &start, der_string.size()));
-  if (!x509_) {
+  ScopedX509 x509(d2i_X509(nullptr, &start, der_string.size()));
+  if (!x509) {
     LOG(WARNING) << "Input is not a valid DER-encoded certificate";
     LOG_OPENSSL_ERRORS(WARNING);
-    return util::Status(Code::INVALID_ARGUMENT, "Not a valid encoded cert");
+    return nullptr;
   }
-  return util::Status::OK;
+  return unique_ptr<Cert>(new Cert(move(x509)));
 }
 
 

--- a/cpp/log/cert.cc
+++ b/cpp/log/cert.cc
@@ -209,7 +209,7 @@ unique_ptr<Cert> Cert::Clone() const {
       LOG_OPENSSL_ERRORS(ERROR);
     }
   }
-  return unique_ptr<Cert>(new Cert(move(x509)));
+  return x509 ? unique_ptr<Cert>(new Cert(move(x509))) : nullptr;
 }
 
 

--- a/cpp/log/cert.h
+++ b/cpp/log/cert.h
@@ -23,8 +23,7 @@ bool IsValidRedactedHost(const std::string& hostname);
 class Cert {
  public:
   // The following factory static methods return null if the input is
-  // not valid, but otherwise, the object is guaranteed to be loaded
-  // (if non-null, no need to check IsLoaded()).
+  // not valid.
   static std::unique_ptr<Cert> FromDerString(const std::string& der_string);
   // Caller still owns the BIO afterwards.
   static std::unique_ptr<Cert> FromDerBio(BIO* bio_in);
@@ -32,12 +31,7 @@ class Cert {
   // Will return null if |x509| is null.
   static std::unique_ptr<Cert> FromX509(ScopedX509 x509);
 
-  bool IsLoaded() const {
-    return x509_ != nullptr;
-  }
-
-  // Returns null if there was a problem with the underlying copy, but
-  // IsLoaded() is always true if it returns non-null.
+  // Returns null if there was a problem with the underlying copy.
   std::unique_ptr<Cert> Clone() const;
 
   // These just return an empty string if an error occurs.

--- a/cpp/log/cert.h
+++ b/cpp/log/cert.h
@@ -22,10 +22,12 @@ bool IsValidRedactedHost(const std::string& hostname);
 
 class Cert {
  public:
-  // Returns null if the input is not valid, but otherwise, the object
-  // is guaranteed to be loaded (if non-null, no need to check
-  // IsLoaded()).
+  // The following factory static methods return null if the input is
+  // not valid, but otherwise, the object is guaranteed to be loaded
+  // (if non-null, no need to check IsLoaded()).
   static std::unique_ptr<Cert> FromDerString(const std::string& der_string);
+  // Caller still owns the BIO afterwards.
+  static std::unique_ptr<Cert> FromDerBio(BIO* bio_in);
 
   // If |x509| comes directly from a copy, it is advisable to check
   // IsLoaded() after construction to verify the copy operation
@@ -45,10 +47,6 @@ class Cert {
   // Never returns NULL but check IsLoaded() after Clone to verify the
   // underlying copy succeeded.
   std::unique_ptr<Cert> Clone() const;
-
-  // Frees the old X509 and attempts to load from BIO in DER form. Caller
-  // still owns the BIO afterwards.
-  util::Status LoadFromDerBio(BIO* bio_in);
 
   // These just return an empty string if an error occurs.
   std::string PrintVersion() const;

--- a/cpp/log/cert.h
+++ b/cpp/log/cert.h
@@ -22,6 +22,11 @@ bool IsValidRedactedHost(const std::string& hostname);
 
 class Cert {
  public:
+  // Returns null if the input is not valid, but otherwise, the object
+  // is guaranteed to be loaded (if non-null, no need to check
+  // IsLoaded()).
+  static std::unique_ptr<Cert> FromDerString(const std::string& der_string);
+
   // If |x509| comes directly from a copy, it is advisable to check
   // IsLoaded() after construction to verify the copy operation
   // succeeded.
@@ -40,9 +45,6 @@ class Cert {
   // Never returns NULL but check IsLoaded() after Clone to verify the
   // underlying copy succeeded.
   std::unique_ptr<Cert> Clone() const;
-
-  // Frees the old X509 and attempts to load a new one.
-  util::Status LoadFromDerString(const std::string& der_string);
 
   // Frees the old X509 and attempts to load from BIO in DER form. Caller
   // still owns the BIO afterwards.

--- a/cpp/log/cert.h
+++ b/cpp/log/cert.h
@@ -37,8 +37,7 @@ class Cert {
   // so caller should check IsLoaded() before doing anything else.
   // All attempts to operate on an unloaded cert will fail with ERROR.
   explicit Cert(const std::string& pem_string);
-  Cert() {
-  }
+  Cert() = delete;
 
   bool IsLoaded() const {
     return x509_ != nullptr;

--- a/cpp/log/cert.h
+++ b/cpp/log/cert.h
@@ -40,8 +40,8 @@ class Cert {
     return x509_ != nullptr;
   }
 
-  // Never returns NULL but check IsLoaded() after Clone to verify the
-  // underlying copy succeeded.
+  // Returns null if there was a problem with the underlying copy, but
+  // IsLoaded() is always true if it returns non-null.
   std::unique_ptr<Cert> Clone() const;
 
   // These just return an empty string if an error occurs.

--- a/cpp/log/cert.h
+++ b/cpp/log/cert.h
@@ -29,12 +29,8 @@ class Cert {
   // Caller still owns the BIO afterwards.
   static std::unique_ptr<Cert> FromDerBio(BIO* bio_in);
   static std::unique_ptr<Cert> FromPemString(const std::string& pem_string);
-
-  // If |x509| comes directly from a copy, it is advisable to check
-  // IsLoaded() after construction to verify the copy operation
-  // succeeded.
-  explicit Cert(ScopedX509 x509);
-  Cert() = delete;
+  // Will return null if |x509| is null.
+  static std::unique_ptr<Cert> FromX509(ScopedX509 x509);
 
   bool IsLoaded() const {
     return x509_ != nullptr;
@@ -204,6 +200,10 @@ class Cert {
   FRIEND_TEST(CtExtensionsTest, TestPrecertSigning);
 
  private:
+  // Will CHECK-fail if |x509| is null.
+  explicit Cert(ScopedX509 x509);
+  Cert() = delete;
+
   util::StatusOr<int> ExtensionIndex(int extension_nid) const;
   util::StatusOr<X509_EXTENSION*> GetExtension(int extension_nid) const;
   util::StatusOr<void*> ExtensionStructure(int extension_nid) const;
@@ -213,7 +213,7 @@ class Cert {
   static std::string PrintName(X509_NAME* name);
   static std::string PrintTime(ASN1_TIME* when);
   static util::Status DerEncodedName(X509_NAME* name, std::string* result);
-  ScopedX509 x509_;
+  const ScopedX509 x509_;
 
   DISALLOW_COPY_AND_ASSIGN(Cert);
 };

--- a/cpp/log/cert.h
+++ b/cpp/log/cert.h
@@ -28,15 +28,12 @@ class Cert {
   static std::unique_ptr<Cert> FromDerString(const std::string& der_string);
   // Caller still owns the BIO afterwards.
   static std::unique_ptr<Cert> FromDerBio(BIO* bio_in);
+  static std::unique_ptr<Cert> FromPemString(const std::string& pem_string);
 
   // If |x509| comes directly from a copy, it is advisable to check
   // IsLoaded() after construction to verify the copy operation
   // succeeded.
   explicit Cert(ScopedX509 x509);
-  // May fail, but we don't want to die on invalid inputs,
-  // so caller should check IsLoaded() before doing anything else.
-  // All attempts to operate on an unloaded cert will fail with ERROR.
-  explicit Cert(const std::string& pem_string);
   Cert() = delete;
 
   bool IsLoaded() const {

--- a/cpp/log/cert_checker.cc
+++ b/cpp/log/cert_checker.cc
@@ -245,7 +245,7 @@ Status CertChecker::CheckPreCertChain(PreCertChain* chain,
 
 Status CertChecker::GetTrustedCa(CertChain* chain) const {
   const Cert* subject = chain->LastCert();
-  if (!subject || !subject->IsLoaded()) {
+  if (!subject) {
     LOG(ERROR) << "Chain has no valid certs";
     return Status(util::error::INTERNAL, "chain has no valid certificate");
   }

--- a/cpp/log/cert_checker.cc
+++ b/cpp/log/cert_checker.cc
@@ -81,7 +81,7 @@ bool CertChecker::LoadTrustedCertificatesFromBIO(BIO* bio_in) {
     if (x509) {
       // TODO(ekasper): check that the issuing CA cert is temporally valid
       // and at least warn if it isn't.
-      unique_ptr<Cert> cert(new Cert(move(x509)));
+      unique_ptr<Cert> cert(Cert::FromX509(move(x509)));
       string subject_name;
       const StatusOr<bool> is_trusted(IsTrusted(*cert, &subject_name));
       if (!is_trusted.ok()) {

--- a/cpp/log/cert_submission_handler.cc
+++ b/cpp/log/cert_submission_handler.cc
@@ -26,10 +26,6 @@ namespace {
 
 
 bool SerializedTbs(const Cert& cert, string* result) {
-  if (!cert.IsLoaded()) {
-    return false;
-  }
-
   const StatusOr<bool> has_embedded_proof = cert.HasExtension(
       cert_trans::NID_ctEmbeddedSignedCertificateTimestampList);
   if (!has_embedded_proof.ok()) {

--- a/cpp/log/cert_test.cc
+++ b/cpp/log/cert_test.cc
@@ -360,7 +360,6 @@ TEST_F(CertTest, LoadValidFromDer) {
   ASSERT_OK(leaf_cert_->DerEncoding(&der));
   const unique_ptr<Cert> second(Cert::FromDerString(der));
   EXPECT_TRUE(second.get());
-  EXPECT_TRUE(second->IsLoaded());
 }
 
 TEST_F(CertTest, LoadInvalidFromDer) {

--- a/cpp/log/cert_test.cc
+++ b/cpp/log/cert_test.cc
@@ -362,9 +362,9 @@ TEST_F(CertTest, LoadValidFromDer) {
   Cert leaf(leaf_pem_);
   string der;
   ASSERT_OK(leaf.DerEncoding(&der));
-  Cert second;
-  EXPECT_OK(second.LoadFromDerString(der));
-  EXPECT_TRUE(second.IsLoaded());
+  const unique_ptr<Cert> second(Cert::FromDerString(der));
+  EXPECT_TRUE(second.get());
+  EXPECT_TRUE(second->IsLoaded());
 }
 
 TEST_F(CertTest, LoadInvalidFromDer) {
@@ -372,10 +372,8 @@ TEST_F(CertTest, LoadInvalidFromDer) {
   // Make it look almost good for extra fun.
   string der;
   ASSERT_OK(leaf.DerEncoding(&der));
-  Cert second;
-  EXPECT_THAT(second.LoadFromDerString(der.substr(2)),
-              StatusIs(util::error::INVALID_ARGUMENT));
-  EXPECT_FALSE(second.IsLoaded());
+  const unique_ptr<Cert> second(Cert::FromDerString(der.substr(2)));
+  EXPECT_FALSE(second.get());
 }
 
 TEST_F(CertTest, PrintVersion) {

--- a/cpp/log/cms_verifier.cc
+++ b/cpp/log/cms_verifier.cc
@@ -14,11 +14,6 @@ util::StatusOr<bool> CmsVerifier::IsCmsSignedByCert(BIO* cms_bio_in,
                                                     const Cert& cert) const {
   CHECK_NOTNULL(cms_bio_in);
 
-  if (!cert.IsLoaded()) {
-    LOG(ERROR) << "Can't check cert signer as it's not loaded";
-    return Status(util::error::FAILED_PRECONDITION, "Cert not loaded");
-  }
-
   ScopedCMS_ContentInfo cms_content_info(d2i_CMS_bio(cms_bio_in, nullptr));
 
   if (!cms_content_info) {
@@ -48,11 +43,6 @@ util::StatusOr<bool> CmsVerifier::IsCmsSignedByCert(BIO* cms_bio_in,
 StatusOr<bool> CmsVerifier::IsCmsSignedByCert(const string& cms_object,
                                               const Cert* cert) const {
   CHECK_NOTNULL(cert);
-
-  if (!cert->IsLoaded()) {
-    LOG(ERROR) << "Can't check cert signer as it's not loaded";
-    return Status(util::error::FAILED_PRECONDITION, "Cert not loaded");
-  }
 
   // Load a source bio with the CMS signed data object and parse it
   ScopedBIO source_bio(BIO_new(BIO_s_mem()));
@@ -112,11 +102,6 @@ StatusOr<bool> CmsVerifier::IsCmsSignedByCert(const string& cms_object,
 util::Status CmsVerifier::UnpackCmsDerBio(BIO* cms_bio_in, const Cert& cert,
                                           BIO* cms_bio_out) {
   CHECK_NOTNULL(cms_bio_in);
-
-  if (!cert.IsLoaded()) {
-    LOG(ERROR) << "Cert for CMS verify not loaded";
-    return Status(util::error::FAILED_PRECONDITION, "Cert not loaded");
-  }
 
   ScopedCMS_ContentInfo cms_content_info(d2i_CMS_bio(cms_bio_in, nullptr));
 

--- a/cpp/log/cms_verifier.cc
+++ b/cpp/log/cms_verifier.cc
@@ -204,15 +204,15 @@ Cert* CmsVerifier::UnpackCmsSignedCertificate(BIO* cms_bio_in,
                                               const Cert& verify_cert) {
   CHECK_NOTNULL(cms_bio_in);
   ScopedBIO unpacked_bio(BIO_new(BIO_s_mem()));
-  unique_ptr<Cert> cert(new Cert());
+  unique_ptr<Cert> cert;
 
   if (UnpackCmsDerBio(cms_bio_in, verify_cert, unpacked_bio.get()).ok()) {
     // The unpacked data should be a valid DER certificate.
     // TODO: The RFC does not yet define this as the format so this may
     // need to change.
-    util::Status status = cert->LoadFromDerBio(unpacked_bio.get());
+    cert = Cert::FromDerBio(unpacked_bio.get());
 
-    if (!status.ok()) {
+    if (!cert) {
       LOG(WARNING) << "Could not unpack cert from CMS DER encoded data";
     }
   } else {
@@ -228,15 +228,15 @@ Cert* CmsVerifier::UnpackCmsSignedCertificate(const string& cms_object) {
   BIO_write(source_bio.get(), cms_object.c_str(), cms_object.length());
 
   ScopedBIO unpacked_bio(BIO_new(BIO_s_mem()));
-  unique_ptr<Cert> cert(new Cert);
+  unique_ptr<Cert> cert;
 
   if (UnpackCmsDerBio(source_bio.get(), unpacked_bio.get()).ok()) {
     // The unpacked data should be a valid DER certificate.
     // TODO: The RFC does not yet define this as the format so this may
     // need to change.
-    const Status status = cert->LoadFromDerBio(unpacked_bio.get());
+    cert = Cert::FromDerBio(unpacked_bio.get());
 
-    if (!status.ok()) {
+    if (!cert) {
       LOG(WARNING) << "Could not unpack cert from CMS DER encoded data";
     }
   } else {

--- a/cpp/log/cms_verifier.h
+++ b/cpp/log/cms_verifier.h
@@ -31,14 +31,15 @@ class CmsVerifier {
   // Checks that a CMS_ContentInfo has a signer that matches a specified
   // certificate. Does not verify the signature or check the payload.
   virtual util::StatusOr<bool> IsCmsSignedByCert(const std::string& cms_object,
-                                                 const Cert* cert) const;
+                                                 const Cert& cert) const;
 
   // Unpacks a CMS signed data object that is assumed to contain a certificate
   // Does not do any checks on signatures or cert validity at this point,
   // the caller must do these separately. Returns a new Cert object built from
   // the unpacked data, which will only be valid if we successfully unpacked
   // the CMS blob.
-  virtual Cert* UnpackCmsSignedCertificate(const std::string& cms_object);
+  virtual std::unique_ptr<Cert> UnpackCmsSignedCertificate(
+      const std::string& cms_object);
 
   // Unpacks a CMS signed data object that is assumed to contain a certificate
   // If the CMS signature verifies as being signed by the supplied Cert
@@ -49,8 +50,8 @@ class CmsVerifier {
   // NOTE: Certificate validity checks must be done separately. This
   // only checks that the CMS signature is validly made by the supplied
   // certificate.
-  virtual Cert* UnpackCmsSignedCertificate(BIO* cms_bio_in,
-                                           const Cert& verify_cert);
+  virtual std::unique_ptr<Cert> UnpackCmsSignedCertificate(
+      BIO* cms_bio_in, const Cert& verify_cert);
 
  private:
   // Verifies that data from a DER BIO is signed by a given certificate.

--- a/cpp/log/cms_verifier_test.cc
+++ b/cpp/log/cms_verifier_test.cc
@@ -123,7 +123,7 @@ TEST_F(CmsVerifierTest, CmsVerifyTestCase2) {
   unique_ptr<Cert> unpacked_cert(
       verifier_.UnpackCmsSignedCertificate(bio.get(), cert));
 
-  ASSERT_FALSE(unpacked_cert->IsLoaded());
+  ASSERT_FALSE(unpacked_cert.get());
 }
 
 
@@ -155,7 +155,7 @@ TEST_F(CmsVerifierTest, CmsVerifyTestCase4) {
   unique_ptr<Cert> unpacked_cert(
       verifier_.UnpackCmsSignedCertificate(bio.get(), cert));
 
-  ASSERT_FALSE(unpacked_cert->IsLoaded());
+  ASSERT_FALSE(unpacked_cert.get());
 }
 
 
@@ -168,6 +168,7 @@ TEST_F(CmsVerifierTest, CmsVerifyTestCase5) {
   unique_ptr<Cert> unpacked_cert(
       verifier_.UnpackCmsSignedCertificate(bio.get(), cert));
 
+  ASSERT_TRUE(unpacked_cert.get());
   ASSERT_FALSE(unpacked_cert->HasBasicConstraintCATrue().ValueOrDie());
   ASSERT_TRUE(
       unpacked_cert->HasExtension(NID_authority_key_identifier).ValueOrDie());
@@ -187,7 +188,7 @@ TEST_F(CmsVerifierTest, CmsVerifyTestCase7) {
   unique_ptr<Cert> unpacked_cert(
       verifier_.UnpackCmsSignedCertificate(bio.get(), cert));
 
-  ASSERT_FALSE(unpacked_cert->IsLoaded());
+  ASSERT_FALSE(unpacked_cert.get());
 }
 
 
@@ -200,7 +201,7 @@ TEST_F(CmsVerifierTest, CmsVerifyTestCase8) {
   unique_ptr<Cert> unpacked_cert(
       verifier_.UnpackCmsSignedCertificate(bio.get(), cert));
 
-  ASSERT_FALSE(unpacked_cert->IsLoaded());
+  ASSERT_FALSE(unpacked_cert.get());
 }
 
 }  // namespace

--- a/cpp/server/certificate_handler.cc
+++ b/cpp/server/certificate_handler.cc
@@ -58,9 +58,8 @@ bool ExtractChain(libevent::Base* base, evhttp_request* req,
       return false;
     }
 
-    unique_ptr<Cert> cert(new Cert);
-    cert->LoadFromDerString(json_cert.FromBase64());
-    if (!cert->IsLoaded()) {
+    unique_ptr<Cert> cert(Cert::FromDerString(json_cert.FromBase64()));
+    if (!cert) {
       SendJsonError(base, req, HTTP_BADREQUEST,
                     "Unable to parse provided chain.");
       return false;


### PR DESCRIPTION
The idea here is to reduce the state space of the `Cert` object by making it absolutely certain that `x509_` is always non-null. At the moment, `Cert` behaves a bit like a smart pointer for `X509` (with "extra features"), while being also often put inside a smart pointer, so it's easy to check that one isn't null, and then just go on, while forgetting to check the other level.

I *strongly* recommend reviewing this one commit at a time! Each commit makes sense, and could be merged individually (as long as they're kept in sequence, anyway), I could merge this either as a merge commit or fast-forwarded, let me know if you have a preference?