### PR TITLE
Fix (most) warnings found with GCC.

### DIFF
--- a/cpp/log/cert_checker_test.cc
+++ b/cpp/log/cert_checker_test.cc
@@ -628,9 +628,9 @@ TEST_F(CertCheckerTest, TestDsaPrecertChain) {
 
   EXPECT_OK(checker_.CheckPreCertChain(&pre_chain, &issuer_key_hash, &tbs));
   // Added a root CA.
-  EXPECT_EQ(2, pre_chain.Length());
+  EXPECT_EQ(2U, pre_chain.Length());
   // And set a SHA256 HASH
-  EXPECT_EQ(32, issuer_key_hash.size());
+  EXPECT_EQ(32U, issuer_key_hash.size());
   // And the TBS fields
   EXPECT_FALSE(tbs.empty());
 }

--- a/cpp/log/cert_test.cc
+++ b/cpp/log/cert_test.cc
@@ -504,7 +504,7 @@ TEST_F(CertTest, IllegalSignatureAlgorithmParameter) {
 TEST_F(CertTest, TestSubjectAltNames) {
   vector<string> sans;
   EXPECT_OK(google_cert_->SubjectAltNames(&sans));
-  EXPECT_EQ(44, sans.size());
+  EXPECT_EQ(44U, sans.size());
   EXPECT_EQ("*.google.com", sans[0]);
   EXPECT_EQ("*.android.com", sans[1]);
   EXPECT_EQ("youtubeeducation.com", sans[43]);
@@ -513,7 +513,7 @@ TEST_F(CertTest, TestSubjectAltNames) {
 TEST_F(CertTest, SPKI) {
   const StatusOr<string> spki(leaf_cert_->SPKI());
   EXPECT_OK(spki.status());
-  EXPECT_EQ(162, spki.ValueOrDie().size());
+  EXPECT_EQ(162U, spki.ValueOrDie().size());
   EXPECT_EQ("Ojz4hdfbFTowDio/KDGC4/pN9dy/EBfIAsnO2yDbKiE=",
             util::ToBase64(Sha256Hasher::Sha256Digest(spki.ValueOrDie())));
 }

--- a/cpp/log/cms_verifier.cc
+++ b/cpp/log/cms_verifier.cc
@@ -4,7 +4,6 @@
 #include "util/cms_scoped_types.h"
 #include "util/openssl_scoped_types.h"
 
-using std::move;
 using std::string;
 using std::unique_ptr;
 using util::Status;
@@ -203,7 +202,7 @@ unique_ptr<Cert> CmsVerifier::UnpackCmsSignedCertificate(
     LOG_OPENSSL_ERRORS(ERROR);
   }
 
-  return move(cert);
+  return cert;
 }
 
 unique_ptr<Cert> CmsVerifier::UnpackCmsSignedCertificate(
@@ -228,7 +227,7 @@ unique_ptr<Cert> CmsVerifier::UnpackCmsSignedCertificate(
     LOG_OPENSSL_ERRORS(ERROR);
   }
 
-  return move(cert);
+  return cert;
 }
 
 }  // namespace cert_trans

--- a/cpp/merkletree/sparse_merkle_tree.cc
+++ b/cpp/merkletree/sparse_merkle_tree.cc
@@ -21,7 +21,9 @@ const vector<string>* GetNullHashes(const TreeHasher& hasher) {
   static unique_ptr<const vector<string>> null_hashes;
   if (!null_hashes) {
     vector<string> r{hasher.HashLeaf("")};
-    for (int i(1); i < hasher.DigestSize() * 8; ++i) {
+    const int end(hasher.DigestSize() * 8);
+    CHECK_LT(0, end);
+    for (int i(1); i < end; ++i) {
       r.emplace_back(hasher.HashChildren(r.back(), r.back()));
     }
     reverse(r.begin(), r.end());
@@ -135,7 +137,9 @@ string SparseMerkleTree::CalculateSubtreeHash(size_t depth, IndexType index) {
 
       case TreeNode::LEAF: {
         string ret(it->second.hash_);
-        for (int i(kDigestSizeBits - 1); i > depth; --i) {
+        const int64_t signed_depth(depth);
+        CHECK_LE(0, signed_depth);
+        for (int i(kDigestSizeBits - 1); i > signed_depth; --i) {
           if (PathBit(*(it->second.path_), i) == 0) {
             ret = treehasher_.HashChildren(ret, null_hashes_->at(i));
           } else {

--- a/cpp/merkletree/sparse_merkle_tree_test.cc
+++ b/cpp/merkletree/sparse_merkle_tree_test.cc
@@ -187,7 +187,7 @@ class SparseMerkleTreeTest : public testing::Test {
   // Returns a random Path.
   SparseMerkleTree::Path RandomPath() {
     SparseMerkleTree::Path ret;
-    for (int i(0); i < ret.size(); ++i) {
+    for (SparseMerkleTree::Path::size_type i(0); i < ret.size(); ++i) {
       ret[i] = rand_() & 0xff;
     }
     return ret;

--- a/cpp/proto/serializer.cc
+++ b/cpp/proto/serializer.cc
@@ -121,6 +121,7 @@ std::ostream& operator<<(std::ostream& stream, const SerializeResult& r) {
     case SerializeResult::EXTENSIONS_NOT_ORDERED:
       return stream << "EXTENSIONS_NOT_ORDERED";
   }
+  return stream << "<unknown>";
 }
 
 
@@ -153,6 +154,7 @@ std::ostream& operator<<(std::ostream& stream, const DeserializeResult& r) {
     case DeserializeResult::EXTENSIONS_NOT_ORDERED:
       return stream << "EXTENSIONS_NOT_ORDERED";
   }
+  return stream << "<unknown>";
 }
 
 
@@ -491,11 +493,11 @@ SerializeResult CheckExtensionsFormat(const string& extensions) {
 // They must be in ascending order of extension type.
 SerializeResult CheckSthExtensionsFormat(
     const repeated_sth_extension& extension) {
-  if (extension.size() > Serializer::kMaxV2ExtensionsCount) {
+  if (extension.size() > static_cast<int>(Serializer::kMaxV2ExtensionsCount)) {
     return SerializeResult::EXTENSIONS_TOO_LONG;
   }
 
-  int32_t last_type_seen = 0;
+  uint32_t last_type_seen = 0;
 
   for (auto it = extension.begin(); it != extension.end(); ++it) {
     if (it->sth_extension_type() > Serializer::kMaxV2ExtensionType) {
@@ -523,11 +525,11 @@ SerializeResult CheckSthExtensionsFormat(
 // must be in ascending order of extension type
 SerializeResult CheckSctExtensionsFormat(
     const RepeatedPtrField<SctExtension>& extension) {
-  if (extension.size() > Serializer::kMaxV2ExtensionsCount) {
+  if (extension.size() > static_cast<int>(Serializer::kMaxV2ExtensionsCount)) {
     return SerializeResult::EXTENSIONS_TOO_LONG;
   }
 
-  int32_t last_type_seen = 0;
+  uint32_t last_type_seen = 0;
 
   for (auto it = extension.begin(); it != extension.end(); ++it) {
     if (it->sct_extension_data().size() > Serializer::kMaxExtensionsLength) {
@@ -748,7 +750,7 @@ DeserializeResult TLSDeserializer::ReadSctExtension(
     return DeserializeResult::EXTENSIONS_TOO_LONG;
   }
 
-  for (int ext = 0; ext < ext_count; ++ext) {
+  for (uint32_t ext = 0; ext < ext_count; ++ext) {
     uint32_t ext_type;
     if (!ReadUint(kV2ExtensionTypeLengthInBytes, &ext_type)) {
       return DeserializeResult::INPUT_TOO_SHORT;


### PR DESCRIPTION
There's still signed/unsigned comparisons in gtest/gmock themselves, so it cannot really be all fixed, you would still have to use `-Wno-sign-compare`.