### PR TITLE
Simplified SCT list serialization

### DIFF
--- a/go/serialization.go
+++ b/go/serialization.go
@@ -514,6 +514,10 @@ func SerializeSTHSignatureInput(sth SignedTreeHead) ([]byte, error) {
 
 // SCTListSerializedLength determines the length of the required buffer should a SCT List need to be serialized
 func SCTListSerializedLength(scts []SignedCertificateTimestamp) (int, error) {
+	if len(scts) == 0 {
+		return 0, fmt.Errorf("SCT List empty")
+	}
+
 	sctListLen := 2
 	for i, sct := range scts {
 		n, err := sct.SerializedLength()
@@ -524,10 +528,6 @@ func SCTListSerializedLength(scts []SignedCertificateTimestamp) (int, error) {
 			return 0, fmt.Errorf("SCT in position %d too large: %d", i, n)
 		}
 		sctListLen += 2 + n
-	}
-
-	if sctListLen == 2 {
-		return 0, fmt.Errorf("SCT List empty")
 	}
 
 	if sctListLen > MaxSCTListLength+2 {

--- a/go/serialization.go
+++ b/go/serialization.go
@@ -23,6 +23,8 @@ const (
 const (
 	MaxCertificateLength = (1 << 24) - 1
 	MaxExtensionsLength  = (1 << 16) - 1
+	MaxSCTInListLength   = (1 << 16) - 1
+	MaxSCTListLength     = (1 << 16) - 1
 )
 
 func writeUint(w io.Writer, value uint64, numBytes int) error {
@@ -518,32 +520,31 @@ func SCTListSerializedLength(scts []SignedCertificateTimestamp) (int, error) {
 		if err != nil {
 			return 0, fmt.Errorf("unable to determine length of SCT in position %d: %v", i, err)
 		}
-		if n > 0xFFFF {
+		if n > MaxSCTInListLength {
 			return 0, fmt.Errorf("SCT in position %d too large: %d", i, n)
 		}
-		sctListLen += n + 2
+		sctListLen += 2 + n
 	}
 
 	if sctListLen == 2 {
 		return 0, fmt.Errorf("SCT List empty")
 	}
 
-	if sctListLen > 0xFFFF+2 {
+	if sctListLen > MaxSCTListLength+2 {
 		return 0, fmt.Errorf("SCT List too large to serialize: %d", sctListLen)
 	}
 	return sctListLen, nil
 }
 
-// SerializeSCTListHere serializes the passed in slice of SignedCertificateTimestamp in the
-// SCT List structure. If the passed in byte slice is not nil it will be used, otherwise
-// a buffer will be allocated and returned
+// SerializeSCTListHere serializes the passed-in slice of SignedCertificateTimestamp into the
+// here byte slice as a SignedCertificateTimestampList (see RFC6962 Section 3.3)
 func SerializeSCTListHere(scts []SignedCertificateTimestamp, here []byte) ([]byte, error) {
 	sctListOutLen, err := SCTListSerializedLength(scts)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(here) == 0 {
+	if here == nil {
 		here = make([]byte, sctListOutLen)
 	}
 
@@ -556,11 +557,16 @@ func SerializeSCTListHere(scts []SignedCertificateTimestamp, here []byte) ([]byt
 	binary.BigEndian.PutUint16(here[0:2], uint16(sctListOutLen-2))
 	sctListPos := 2
 	for i, sct := range scts {
-		n, _ := sct.SerializedLength()
-		// Error conditions for SerializedLength checked in SCTListSerializedLength above
+		n, err := sct.SerializedLength()
+		if err != nil {
+			return nil, fmt.Errorf("unable to determine length of SCT in position %d: %v", i, err)
+		}
+		if n > MaxSCTInListLength {
+			return nil, fmt.Errorf("SCT in position %d too large: %d", i, n)
+		}
 		binary.BigEndian.PutUint16(here[sctListPos:sctListPos+2], uint16(n))
 		sctListPos += 2
-		_, err := SerializeSCTHere(sct, here[sctListPos:sctListPos+n])
+		_, err = SerializeSCTHere(sct, here[sctListPos:sctListPos+n])
 		if err != nil {
 			return nil, fmt.Errorf("unable to serialize SCT in position %d: %v", i, err)
 		}
@@ -571,4 +577,11 @@ func SerializeSCTListHere(scts []SignedCertificateTimestamp, here []byte) ([]byt
 		return nil, fmt.Errorf("SCTList size expected %d got %d", sctListOutLen, sctListPos)
 	}
 	return here, nil
+}
+
+// SerializeSCTListHere serializes the passed-in slice of SignedCertificateTimestamp as a
+// SignedCertificateTimestampList (see RFC6962 Section 3.3)
+// Equivalent to SerializeSCTListHere(scts, nil)
+func SerializeSCTList(scts []SignedCertificateTimestamp) ([]byte, error) {
+	return SerializeSCTListHere(scts, nil)
 }

--- a/go/serialization_test.go
+++ b/go/serialization_test.go
@@ -235,15 +235,7 @@ const (
 		// signature, 9 bytes
 		"7369676e6174757265"
 
-	defaultSCTListHexString string =
-	// Total length, 2 bytes
-	"0074" +
-		// defaultSCTLength, 2 bytes
-		"0038" +
-		defaultSCTHexString +
-		// defaultSCTLength, 2 bytes
-		"0038" +
-		defaultSCTHexString
+	defaultSCTListHexString string = "0476007400380069616d617075626c69636b657973686174776f6669766573697864696765737400000000000004d20000040300097369676e617475726500380069616d617075626c69636b657973686174776f6669766573697864696765737400000000000004d20000040300097369676e6174757265"
 )
 
 func defaultSCTLogID() SHA256Hash {
@@ -447,7 +439,7 @@ func TestSerializeSCT(t *testing.T) {
 }
 
 func TestSerializeSCTList(t *testing.T) {
-	b, err := SerializeSCTListHere([]SignedCertificateTimestamp{defaultSCT(), defaultSCT()}, nil)
+	b, err := SerializeSCTList([]SignedCertificateTimestamp{defaultSCT(), defaultSCT()})
 	if err != nil {
 		t.Fatalf("Failed to serialize SCT List: %v", err)
 	}

--- a/go/serialization_test.go
+++ b/go/serialization_test.go
@@ -234,6 +234,16 @@ const (
 		"0009" +
 		// signature, 9 bytes
 		"7369676e6174757265"
+
+	defaultSCTListHexString string =
+	// Total length, 2 bytes
+	"0074" +
+		// defaultSCTLength, 2 bytes
+		"0038" +
+		defaultSCTHexString +
+		// defaultSCTLength, 2 bytes
+		"0038" +
+		defaultSCTHexString
 )
 
 func defaultSCTLogID() SHA256Hash {
@@ -433,6 +443,16 @@ func TestSerializeSCT(t *testing.T) {
 	}
 	if bytes.Compare(mustDehex(t, defaultSCTHexString), b) != 0 {
 		t.Fatalf("Serialized SCT differs from expected KA. Expected:\n%v\nGot:\n%v", mustDehex(t, defaultSCTHexString), b)
+	}
+}
+
+func TestSerializeSCTList(t *testing.T) {
+	b, err := SerializeSCTListHere([]SignedCertificateTimestamp{defaultSCT(), defaultSCT()}, nil)
+	if err != nil {
+		t.Fatalf("Failed to serialize SCT List: %v", err)
+	}
+	if bytes.Compare(mustDehex(t, defaultSCTListHexString), b) != 0 {
+		t.Fatalf("Serialized SCT differs from expected KA. Expected:\n%v\nGot:\n%v", mustDehex(t, defaultSCTListHexString), b)
 	}
 }
 

--- a/go/serialization_test.go
+++ b/go/serialization_test.go
@@ -446,6 +446,28 @@ func TestSerializeSCTList(t *testing.T) {
 	if bytes.Compare(mustDehex(t, defaultSCTListHexString), b) != 0 {
 		t.Fatalf("Serialized SCT differs from expected KA. Expected:\n%v\nGot:\n%v", mustDehex(t, defaultSCTListHexString), b)
 	}
+
+	// Test list too large
+	d := defaultSCT()
+	len, err := d.SerializedLength()
+	if err != nil {
+		t.Fatalf("SerializedLength failed: %s", err)
+	}
+	list := []SignedCertificateTimestamp{}
+	for l := 2; l < MaxSCTListLength; {
+		list = append(list, d)
+		l += len + 2
+	}
+	_, err = SerializeSCTList(list)
+	if err == nil {
+		t.Fatal("SerializeSCTList didn't fail with too large of a serialized SCT list")
+	}
+	// Test SCT too large
+	d.Extensions = make(CTExtensions, MaxSCTInListLength-len)
+	_, err = SerializeSCTList(list)
+	if err == nil {
+		t.Fatal("SerializeSCTList didn't fail with too large of a individual SCT")
+	}
 }
 
 func TestDeserializeSCT(t *testing.T) {


### PR DESCRIPTION
Builds off the work of #1124 but trims the public interface a bit. Since the SCT list is a mix of TLS and ASN.1 encoding styles (thanks to `cloudflare/cfssl` for reminding me of this) we can't just use `encoding/asn1`, in the places where TLS style encoding is required I've just reused existing functions (i.e. `writeVarBytes`/`writeUint`).

This also updates the test case as the previous one did not parse correctly under other SCT implementations (namely OpenSSL, the easiest way to test this is to generate a OCSP response/cert that contains the SCT extension which OpenSSL will happily parse + print). Since there are no explicit test vectors for SCT/list serialization I've just used one I generated that parsed properly with OpenSSL.