### PR TITLE
Use a no-spaces JSON encoding for hashing.

### DIFF
--- a/cpp/util/json_wrapper.h
+++ b/cpp/util/json_wrapper.h
@@ -101,7 +101,7 @@ class JsonObject {
   }
 
   const char* ToString() const {
-    return json_object_to_json_string(obj_);
+    return json_object_to_json_string_ext(obj_, JSON_C_TO_STRING_PLAIN);
   }
 
   std::string DebugString() const {


### PR DESCRIPTION
Standard JSON implementations do not emit spaces when marshing objects.
This change allows other langues and libraries to compute matching
ToString values and thus properly perform hash based lookups.