### PR TITLE
Disable Keep-Alive header from postAndParse

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -30,6 +30,7 @@ Deyan Bektchiev <deyan.bektchiev@venafi.com> <deyan@bektchiev.net>
 Ed Maste <emaste@freebsd.org>
 Emilia Kasper <ekasper@google.com>
 Eran Messeri <eranm@google.com> <eran.mes@gmail.com>
+Fiaz Hossain <fiaz.hossain@salesforce.com>
 Jeff Trawick <trawick@gmail.com>
 Joe Tsai <joetsai@digital-static.net>
 Kat Joyce <katjoyce@google.com>

--- a/go/client/logclient.go
+++ b/go/client/logclient.go
@@ -161,7 +161,6 @@ func (c *LogClient) postAndParse(uri string, req interface{}, res interface{}) (
 	if err != nil {
 		return nil, "", err
 	}
-	httpReq.Header.Set("Keep-Alive", "timeout=15, max=100")
 	httpReq.Header.Set("Content-Type", "application/json")
 	resp, err := c.httpClient.Do(httpReq)
 	// Read all of the body, if there is one, so that the http.Client can do


### PR DESCRIPTION
@jsha here is the pull request to fix requests to Googles CT logs when using postAndParse