### PR TITLE
Do not skip bytes when reading a precert.

### DIFF
--- a/java/src/org/certificatetransparency/ctlog/serialization/Deserializer.java
+++ b/java/src/org/certificatetransparency/ctlog/serialization/Deserializer.java
@@ -174,9 +174,7 @@ public class Deserializer {
       preCert.issuerKeyHash = readFixedLength(in, 32);
 
       // set tbs certificate
-      byte[] arr = readFixedLength(in, 2);
       int length = (int) readNumber(in, 2);
-
       preCert.tbsCertificate = readFixedLength(in, length);
 
       signedEntry.preCert = preCert;


### PR DESCRIPTION
I hear this is wrong, so let's make it less wrong? :smiley: 