### PR TITLE
Get rid of the Java MerkleLeafType enum.

### DIFF
--- a/java/ct.proto
+++ b/java/ct.proto
@@ -56,8 +56,3 @@ message SignedCertificateTimestamp {
   optional DigitallySigned signature = 4;
   optional bytes extensions = 5;
 }
-
-enum MerkleLeafType {
-  TIMESTAMPED_ENTRY = 0;
-  UNKNOWN_LEAF_TYPE = 256;
-}

--- a/java/src/org/certificatetransparency/ctlog/MerkleTreeLeaf.java
+++ b/java/src/org/certificatetransparency/ctlog/MerkleTreeLeaf.java
@@ -6,12 +6,10 @@ import org.certificatetransparency.ctlog.proto.Ct;
 
 public class MerkleTreeLeaf {
   public Ct.Version version;
-  public Ct.MerkleLeafType type;
   public TimestampedEntry timestampedEntry;
 
-  public MerkleTreeLeaf(Ct.Version version, Ct.MerkleLeafType type, TimestampedEntry timestamped_entry) {
+  public MerkleTreeLeaf(Ct.Version version, TimestampedEntry timestamped_entry) {
     this.version = version;
-    this.type = type;
     this.timestampedEntry = timestamped_entry;
   }
 }

--- a/java/src/org/certificatetransparency/ctlog/serialization/Deserializer.java
+++ b/java/src/org/certificatetransparency/ctlog/serialization/Deserializer.java
@@ -24,6 +24,8 @@ import java.io.InputStream;
  * Converting binary data to CT structures.
  */
 public class Deserializer {
+  public static final int TIMESTAMPED_ENTRY_LEAF_TYPE = 0;
+
   /**
    * Parses a SignedCertificateTimestamp from binary encoding.
    * @param inputStream byte stream of binary encoding.
@@ -144,11 +146,11 @@ public class Deserializer {
     }
 
     int leafType = (int) readNumber(in, 1);
-    if (leafType != Ct.MerkleLeafType.TIMESTAMPED_ENTRY_VALUE) {
+    if (leafType != TIMESTAMPED_ENTRY_LEAF_TYPE) {
       throw new SerializationException(String.format("Unknown entry type: %d", leafType));
     }
 
-    return new MerkleTreeLeaf(Ct.Version.valueOf(version), Ct.MerkleLeafType.valueOf(leafType), parseTimestampedEntry(in));
+    return new MerkleTreeLeaf(Ct.Version.valueOf(version), parseTimestampedEntry(in));
   }
 
   /**


### PR DESCRIPTION
Not converting to a POJO, as it's either 0, or we raise an exception. So I'm converting it to nothingness, which has most excellent maintainability characteristics. :wink: 