### PR TITLE
6962-bis: Implement OID parsing/serialization.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -105,6 +105,7 @@ TESTS = \
 	cpp/monitoring/gauge_test \
 	cpp/monitoring/registry_test \
 	cpp/proto/serializer_test \
+	cpp/proto/serializer_v2_test \
 	cpp/server/proxy_test \
 	cpp/util/bignum_test \
 	cpp/util/etcd_delete_test \
@@ -189,6 +190,7 @@ cpp_libcore_a_SOURCES = \
 	cpp/net/url_fetcher.cc \
 	cpp/proto/cert_serializer.cc \
 	cpp/proto/serializer.cc \
+	cpp/proto/serializer_v2.cc \
 	cpp/server/metrics.cc \
 	cpp/server/proxy.cc \
 	cpp/server/server.cc \
@@ -706,6 +708,17 @@ cpp_proto_serializer_test_SOURCES = \
 	cpp/proto/cert_serializer.cc \
 	cpp/proto/serializer.cc \
 	cpp/proto/serializer_test.cc \
+	cpp/util/util.cc
+
+cpp_proto_serializer_v2_test_LDADD = \
+	cpp/libcore.a \
+	cpp/libtest.a \
+	$(evhtp_LIBS) \
+	$(libevent_LIBS) \
+	-lprotobuf -lcrypto
+cpp_proto_serializer_v2_test_SOURCES = \
+	cpp/proto/serializer_v2.cc \
+	cpp/proto/serializer_v2_test.cc \
 	cpp/util/util.cc
 
 cpp_server_proxy_test_LDADD = \

--- a/cpp/proto/serializer_v2.cc
+++ b/cpp/proto/serializer_v2.cc
@@ -1,0 +1,117 @@
+/* -*- indent-tabs-mode: nil -*- */
+#include "proto/serializer_v2.h"
+
+#include <glog/logging.h>
+
+#include "util/status.h"
+#include "util/openssl_util.h"
+#include "util/openssl_scoped_types.h"
+
+#if defined(OPENSSL_IS_BORINGSSL)
+#include <openssl/asn1.h>
+#endif
+
+namespace rfc6962_bis {
+using util::StatusOr;
+using util::Status;
+using cert_trans::ScopedOpenSSLBytes;
+
+namespace {
+const char kDerOIDTag = 0x06;
+// OpenSSL documentation recommends 80, see the BUGS section in:
+// https://www.openssl.org/docs/manmaster/crypto/OBJ_obj2txt.html
+const size_t kTextOIDMaxSize = 80;
+}
+
+OID::OID() : oid_(nullptr) {
+}
+
+OID::OID(ASN1_OBJECT* oid) : oid_(oid) {
+  CHECK_NOTNULL(oid_);
+}
+
+OID::OID(const OID& other) : oid_(nullptr) {
+  if (other.oid_ != nullptr) {
+    oid_ = OBJ_dup(other.oid_);
+  }
+}
+
+OID::~OID() {
+  if (oid_ != nullptr) {
+    ASN1_OBJECT_free(oid_);
+  }
+}
+
+util::StatusOr<std::string> OID::ToTagMissingDER() const {
+  if(oid_ == nullptr) {
+    // Uninitialized.
+    return Status(util::error::INVALID_ARGUMENT,
+                  std::string("OID not initialized."));
+  }
+  int encoded_length = i2d_ASN1_OBJECT(oid_, NULL);
+  if (encoded_length <= 0) {
+    return Status(util::error::INVALID_ARGUMENT,
+                  std::string("Failed to encode OID: ") +
+                  util::DumpOpenSSLErrorStack());
+  }
+
+  ScopedOpenSSLBytes encoded_oid(
+      reinterpret_cast<uint8_t*>(OPENSSL_malloc(encoded_length)));
+  // i2d_ASN1_OBJECT will change the pointer, so have to use a temporary.
+  unsigned char* tmp_ptr = encoded_oid.get();
+  encoded_length = i2d_ASN1_OBJECT(oid_, &tmp_ptr);
+  if (encoded_length <= 0) {
+    return Status(util::error::INVALID_ARGUMENT,
+                  std::string("Failed to encode OID: ") +
+                  util::DumpOpenSSLErrorStack());
+  }
+
+  // If the first byte, the tag, does not indicate an OID, then OpenSSL was not
+  // used correctly.
+  CHECK_EQ(encoded_oid.get()[0], kDerOIDTag);
+  // Skip the tag byte.
+  std::string out(reinterpret_cast<char*>(encoded_oid.get() + 1), encoded_length - 1);
+  return std::move(out);
+}
+
+std::string OID::ToString() const {
+  if (oid_ == nullptr) {
+    return "";
+  }
+
+  char output_buffer[kTextOIDMaxSize];
+  int encoded_length = i2t_ASN1_OBJECT(output_buffer, kTextOIDMaxSize, oid_);
+
+  return std::string(output_buffer, encoded_length);
+}
+
+// static
+util::StatusOr<OID> OID::FromString(const std::string& oid_string) {
+  ASN1_OBJECT *oid = OBJ_txt2obj(oid_string.c_str(), 0);
+  if (oid == nullptr) {
+    return Status(util::error::INVALID_ARGUMENT,
+                  std::string("Bad OID: ") + oid_string + " "
+                  + util::DumpOpenSSLErrorStack());
+  }
+
+  return std::move(OID(oid));
+}
+
+// static
+util::StatusOr<OID> OID::FromTagMissingDER(
+    const std::string& missing_tag_oid_der) {
+  std::string oid_der = std::string(1, kDerOIDTag) + missing_tag_oid_der;
+  const unsigned char* data_ptr =
+      reinterpret_cast<const unsigned char*>(oid_der.data());
+
+  ASN1_OBJECT *oid = d2i_ASN1_OBJECT(NULL, &data_ptr, oid_der.size());
+
+  if (oid == nullptr) {
+    return Status(util::error::INVALID_ARGUMENT,
+                  std::string("Bad DER in OID: ") +
+                  util::DumpOpenSSLErrorStack());
+  }
+  return std::move(OID(oid));
+}
+
+}  // namespace rfc6962_bis

--- a/cpp/proto/serializer_v2.h
+++ b/cpp/proto/serializer_v2.h
@@ -1,0 +1,34 @@
+/* -*- mode: c++; indent-tabs-mode: nil -*- */
+#ifndef SERIALIZER_V2_H
+#define SERIALIZER_V2_H
+
+#include <string>
+
+#include <openssl/objects.h>
+
+#include "util/statusor.h"
+
+// RFC6962-bis (V2) stuff.
+namespace rfc6962_bis {
+class OID {
+ public:
+  static util::StatusOr<OID> FromString(const std::string& oid_string);
+  static util::StatusOr<OID> FromTagMissingDER(const std::string& der_oid);
+
+  OID();
+  OID(const OID& other);
+  ~OID();
+
+  util::StatusOr<std::string> ToTagMissingDER() const;
+  std::string ToString() const;
+
+ private:
+  // Takes ownership
+  OID(ASN1_OBJECT* oid);
+
+  ASN1_OBJECT *oid_;
+};
+
+}  // namespace rfc6962_bis
+
+#endif

--- a/cpp/proto/serializer_v2_test.cc
+++ b/cpp/proto/serializer_v2_test.cc
@@ -1,0 +1,60 @@
+/* -*- indent-tabs-mode: nil -*- */
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <google/protobuf/repeated_field.h>
+#include <gtest/gtest.h>
+#include <string>
+
+#include "proto/cert_serializer.h"
+#include "proto/ct.pb.h"
+#include "proto/serializer_v2.h"
+#include "util/testing.h"
+#include "util/util.h"
+
+namespace {
+
+const char kOID[] = "1.2.3.4.5";
+const char kOIDTagMissingDERHex[] = "042a030405";
+
+using rfc6962_bis::OID;
+using std::string;
+
+class SerializerV2Test : public ::testing::Test {
+ public:
+  SerializerV2Test() {
+    oid_text_ = std::string(kOID);
+    oid_der_missing_tag_ = util::BinaryString(kOIDTagMissingDERHex);
+  }
+ protected:
+  string oid_text_;
+  string oid_der_missing_tag_;
+};
+
+TEST_F(SerializerV2Test, SerializesSimpleOID) {
+  util::StatusOr<OID> res = OID::FromString(oid_text_);
+  ASSERT_TRUE(res.ok());
+
+  string encoded_der = res.ValueOrDie().ToTagMissingDER().ValueOrDie();
+  EXPECT_EQ(oid_der_missing_tag_, encoded_der);
+}
+
+TEST_F(SerializerV2Test, FailsOnInvalidOID) {
+  string bad_oid("3.7.-12.b");
+
+  util::StatusOr<OID> res = OID::FromString(bad_oid);
+  ASSERT_FALSE(res.ok());
+}
+
+TEST_F(SerializerV2Test, CreatesFromTagMissingDER) {
+  util::StatusOr<OID> res = OID::FromTagMissingDER(oid_der_missing_tag_);
+
+  ASSERT_TRUE(res.ok());
+  EXPECT_EQ(oid_text_, res.ValueOrDie().ToString());
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  cert_trans::test::InitTesting(argv[0], &argc, &argv, true);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
For implementing 6962-bis we'll need a way to decode DER-encoded OIDs and encode them (for later TLS serialization).

I had some hand-rolled code to do this, but using OpenSSL is probably safer. I hope.