### PR TITLE
Get rid of the TLSSerializer class.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -191,6 +191,7 @@ cpp_libcore_a_SOURCES = \
 	cpp/proto/cert_serializer.cc \
 	cpp/proto/serializer.cc \
 	cpp/proto/serializer_v2.cc \
+	cpp/proto/tls_encoding.cc \
 	cpp/server/metrics.cc \
 	cpp/server/proxy.cc \
 	cpp/server/server.cc \

--- a/cpp/client/async_log_client.cc
+++ b/cpp/client/async_log_client.cc
@@ -17,6 +17,7 @@ using cert_trans::CertChain;
 using cert_trans::PreCertChain;
 using cert_trans::URL;
 using cert_trans::UrlFetcher;
+using cert_trans::serialization::DeserializeResult;
 using ct::DigitallySigned;
 using ct::MerkleAuditProof;
 using ct::SignedCertificateTimestamp;

--- a/cpp/client/ct.cc
+++ b/cpp/client/ct.cc
@@ -127,6 +127,8 @@ using cert_trans::ScopedRSA;
 using cert_trans::ScopedX509;
 using cert_trans::ScopedX509_NAME;
 using cert_trans::TbsCertificate;
+using cert_trans::serialization::SerializeResult;
+using cert_trans::serialization::DeserializeResult;
 using ct::LogEntry;
 using ct::MerkleAuditProof;
 using ct::SSLClientCTData;

--- a/cpp/client/ssl_client.cc
+++ b/cpp/client/ssl_client.cc
@@ -13,6 +13,7 @@
 #include "merkletree/serial_hasher.h"
 #include "proto/serializer.h"
 
+using cert_trans::serialization::DeserializeResult;
 using ct::LogEntry;
 using ct::SSLClientCTData;
 using ct::SignedCertificateTimestamp;

--- a/cpp/log/file_db.cc
+++ b/cpp/log/file_db.cc
@@ -14,6 +14,7 @@
 #include "proto/serializer.h"
 #include "util/util.h"
 
+using cert_trans::serialization::DeserializeResult;
 using std::chrono::milliseconds;
 using std::lock_guard;
 using std::make_pair;

--- a/cpp/log/leveldb_db.cc
+++ b/cpp/log/leveldb_db.cc
@@ -12,6 +12,7 @@
 #include "proto/serializer.h"
 #include "util/util.h"
 
+using cert_trans::serialization::DeserializeResult;
 using std::chrono::milliseconds;
 using std::lock_guard;
 using std::make_pair;

--- a/cpp/log/log_signer.cc
+++ b/cpp/log/log_signer.cc
@@ -12,6 +12,8 @@
 #include "util/util.h"
 
 using cert_trans::Verifier;
+using cert_trans::serialization::SerializeResult;
+using cert_trans::serialization::DeserializeResult;
 using ct::DigitallySigned;
 using ct::LogEntry;
 using ct::LogEntryType;

--- a/cpp/log/log_signer.h
+++ b/cpp/log/log_signer.h
@@ -53,7 +53,8 @@ class LogSigner : public cert_trans::Signer {
   SignResult SignTreeHead(ct::SignedTreeHead* sth) const;
 
  private:
-  static SignResult GetSerializeError(SerializeResult result);
+  static SignResult GetSerializeError(
+      cert_trans::serialization::SerializeResult result);
 };
 
 class LogSigVerifier : public cert_trans::Verifier {
@@ -103,9 +104,11 @@ class LogSigVerifier : public cert_trans::Verifier {
   VerifyResult VerifySTHSignature(const ct::SignedTreeHead& sth) const;
 
  private:
-  static VerifyResult GetSerializeError(SerializeResult result);
+  static VerifyResult GetSerializeError(
+      cert_trans::serialization::SerializeResult result);
 
-  static VerifyResult GetDeserializeSignatureError(DeserializeResult result);
+  static VerifyResult GetDeserializeSignatureError(
+      cert_trans::serialization::DeserializeResult result);
 };
 
 #endif  // CERT_TRANS_LOG_LOG_SIGNER_H_

--- a/cpp/log/log_signer_test.cc
+++ b/cpp/log/log_signer_test.cc
@@ -14,6 +14,8 @@
 
 namespace {
 
+using cert_trans::serialization::SerializeResult;
+using cert_trans::serialization::DeserializeResult;
 using ct::LogEntry;
 using ct::SignedCertificateTimestamp;
 using ct::DigitallySigned;

--- a/cpp/log/log_verifier.cc
+++ b/cpp/log/log_verifier.cc
@@ -10,6 +10,7 @@
 #include "proto/serializer.h"
 #include "util/util.h"
 
+using cert_trans::serialization::SerializeResult;
 using ct::LogEntry;
 using ct::MerkleAuditProof;
 using ct::SignedCertificateTimestamp;

--- a/cpp/log/logged_entry.cc
+++ b/cpp/log/logged_entry.cc
@@ -4,6 +4,7 @@
 #include "proto/serializer.h"
 #include "util/util.h"
 
+using cert_trans::serialization::SerializeResult;
 using ct::CertInfo;
 using ct::LogEntry;
 using ct::PreCert;

--- a/cpp/log/signer_verifier_test.cc
+++ b/cpp/log/signer_verifier_test.cc
@@ -39,7 +39,7 @@ class SignerVerifierTest : public ::testing::Test {
 
   static string SerializedSignature(const DigitallySigned& signature) {
     string serialized_sig;
-    CHECK_EQ(SerializeResult::OK,
+    CHECK_EQ(cert_trans::serialization::SerializeResult::OK,
              Serializer::SerializeDigitallySigned(signature, &serialized_sig));
     return serialized_sig;
   }

--- a/cpp/log/test_signer.cc
+++ b/cpp/log/test_signer.cc
@@ -470,7 +470,7 @@ void TestSigner::FillData(LoggedEntry* logged_cert) {
            Sha256Hasher::Sha256Digest(
                Serializer::LeafData(logged_cert->entry())));
   string serialized_leaf;
-  CHECK_EQ(SerializeResult::OK,
+  CHECK_EQ(cert_trans::serialization::SerializeResult::OK,
            Serializer::SerializeSCTMerkleTreeLeaf(logged_cert->sct(),
                                                   logged_cert->entry(),
                                                   &serialized_leaf));

--- a/cpp/proto/cert_serializer.cc
+++ b/cpp/proto/cert_serializer.cc
@@ -8,6 +8,12 @@
 #include "proto/ct.pb.h"
 #include "proto/serializer.h"
 
+using cert_trans::serialization::SerializeResult;
+using cert_trans::serialization::DeserializeResult;
+using cert_trans::serialization::WriteFixedBytes;
+using cert_trans::serialization::WriteList;
+using cert_trans::serialization::WriteUint;
+using cert_trans::serialization::WriteVarBytes;
 using ct::DigitallySigned;
 using ct::LogEntry;
 using ct::LogEntryType_IsValid;
@@ -74,15 +80,13 @@ SerializeResult SerializeV1CertSCTSignatureInput(uint64_t timestamp,
   if (res != SerializeResult::OK) {
     return res;
   }
-  TLSSerializer serializer;
-  serializer.WriteUint(ct::V1, Serializer::kVersionLengthInBytes);
-  serializer.WriteUint(ct::CERTIFICATE_TIMESTAMP,
-                       Serializer::kSignatureTypeLengthInBytes);
-  serializer.WriteUint(timestamp, Serializer::kTimestampLengthInBytes);
-  serializer.WriteUint(ct::X509_ENTRY, Serializer::kLogEntryTypeLengthInBytes);
-  serializer.WriteVarBytes(certificate, kMaxCertificateLength);
-  serializer.WriteVarBytes(extensions, Serializer::kMaxExtensionsLength);
-  result->assign(serializer.SerializedString());
+  WriteUint(ct::V1, Serializer::kVersionLengthInBytes, result);
+  WriteUint(ct::CERTIFICATE_TIMESTAMP, Serializer::kSignatureTypeLengthInBytes,
+            result);
+  WriteUint(timestamp, Serializer::kTimestampLengthInBytes, result);
+  WriteUint(ct::X509_ENTRY, Serializer::kLogEntryTypeLengthInBytes, result);
+  WriteVarBytes(certificate, kMaxCertificateLength, result);
+  WriteVarBytes(extensions, Serializer::kMaxExtensionsLength, result);
   return SerializeResult::OK;
 }
 
@@ -102,17 +106,15 @@ SerializeResult SerializeV1PrecertSCTSignatureInput(
   if (res != SerializeResult::OK) {
     return res;
   }
-  TLSSerializer serializer;
-  serializer.WriteUint(ct::V1, Serializer::kVersionLengthInBytes);
-  serializer.WriteUint(ct::CERTIFICATE_TIMESTAMP,
-                       Serializer::kSignatureTypeLengthInBytes);
-  serializer.WriteUint(timestamp, Serializer::kTimestampLengthInBytes);
-  serializer.WriteUint(ct::PRECERT_ENTRY,
-                       Serializer::kLogEntryTypeLengthInBytes);
-  serializer.WriteFixedBytes(issuer_key_hash);
-  serializer.WriteVarBytes(tbs_certificate, kMaxCertificateLength);
-  serializer.WriteVarBytes(extensions, Serializer::kMaxExtensionsLength);
-  result->assign(serializer.SerializedString());
+  result->clear();
+  WriteUint(ct::V1, Serializer::kVersionLengthInBytes, result);
+  WriteUint(ct::CERTIFICATE_TIMESTAMP, Serializer::kSignatureTypeLengthInBytes,
+            result);
+  WriteUint(timestamp, Serializer::kTimestampLengthInBytes, result);
+  WriteUint(ct::PRECERT_ENTRY, Serializer::kLogEntryTypeLengthInBytes, result);
+  WriteFixedBytes(issuer_key_hash, result);
+  WriteVarBytes(tbs_certificate, kMaxCertificateLength, result);
+  WriteVarBytes(extensions, Serializer::kMaxExtensionsLength, result);
   return SerializeResult::OK;
 }
 
@@ -123,6 +125,7 @@ SerializeResult SerializeV1SCTSignatureInput(
   if (sct.version() != ct::V1) {
     return SerializeResult::UNSUPPORTED_VERSION;
   }
+  result->clear();
   switch (entry.type()) {
     case ct::X509_ENTRY:
       return SerializeV1CertSCTSignatureInput(
@@ -151,15 +154,14 @@ SerializeResult SerializeV1CertSCTMerkleTreeLeaf(uint64_t timestamp,
   if (res != SerializeResult::OK) {
     return res;
   }
-  TLSSerializer serializer;
-  serializer.WriteUint(ct::V1, Serializer::kVersionLengthInBytes);
-  serializer.WriteUint(ct::TIMESTAMPED_ENTRY,
-                       Serializer::kMerkleLeafTypeLengthInBytes);
-  serializer.WriteUint(timestamp, Serializer::kTimestampLengthInBytes);
-  serializer.WriteUint(ct::X509_ENTRY, Serializer::kLogEntryTypeLengthInBytes);
-  serializer.WriteVarBytes(certificate, kMaxCertificateLength);
-  serializer.WriteVarBytes(extensions, Serializer::kMaxExtensionsLength);
-  result->assign(serializer.SerializedString());
+  result->clear();
+  WriteUint(ct::V1, Serializer::kVersionLengthInBytes, result);
+  WriteUint(ct::TIMESTAMPED_ENTRY, Serializer::kMerkleLeafTypeLengthInBytes,
+            result);
+  WriteUint(timestamp, Serializer::kTimestampLengthInBytes, result);
+  WriteUint(ct::X509_ENTRY, Serializer::kLogEntryTypeLengthInBytes, result);
+  WriteVarBytes(certificate, kMaxCertificateLength, result);
+  WriteVarBytes(extensions, Serializer::kMaxExtensionsLength, result);
   return SerializeResult::OK;
 }
 
@@ -179,17 +181,15 @@ SerializeResult SerializeV1PrecertSCTMerkleTreeLeaf(
   if (res != SerializeResult::OK) {
     return res;
   }
-  TLSSerializer serializer;
-  serializer.WriteUint(ct::V1, Serializer::kVersionLengthInBytes);
-  serializer.WriteUint(ct::TIMESTAMPED_ENTRY,
-                       Serializer::kMerkleLeafTypeLengthInBytes);
-  serializer.WriteUint(timestamp, Serializer::kTimestampLengthInBytes);
-  serializer.WriteUint(ct::PRECERT_ENTRY,
-                       Serializer::kLogEntryTypeLengthInBytes);
-  serializer.WriteFixedBytes(issuer_key_hash);
-  serializer.WriteVarBytes(tbs_certificate, kMaxCertificateLength);
-  serializer.WriteVarBytes(extensions, Serializer::kMaxExtensionsLength);
-  result->assign(serializer.SerializedString());
+  result->clear();
+  WriteUint(ct::V1, Serializer::kVersionLengthInBytes, result);
+  WriteUint(ct::TIMESTAMPED_ENTRY, Serializer::kMerkleLeafTypeLengthInBytes,
+            result);
+  WriteUint(timestamp, Serializer::kTimestampLengthInBytes, result);
+  WriteUint(ct::PRECERT_ENTRY, Serializer::kLogEntryTypeLengthInBytes, result);
+  WriteFixedBytes(issuer_key_hash, result);
+  WriteVarBytes(tbs_certificate, kMaxCertificateLength, result);
+  WriteVarBytes(extensions, Serializer::kMaxExtensionsLength, result);
   return SerializeResult::OK;
 }
 
@@ -200,6 +200,7 @@ SerializeResult SerializeV1SCTMerkleTreeLeaf(
   if (sct.version() != ct::V1) {
     return SerializeResult::UNSUPPORTED_VERSION;
   }
+  result->clear();
   switch (entry.type()) {
     case ct::X509_ENTRY:
       return SerializeV1CertSCTMerkleTreeLeaf(
@@ -329,16 +330,15 @@ SerializeResult SerializeV2CertSCTSignatureInput(
   if (res != SerializeResult::OK) {
     return res;
   }
-  TLSSerializer serializer;
-  serializer.WriteUint(ct::V2, Serializer::kVersionLengthInBytes);
-  serializer.WriteUint(ct::CERTIFICATE_TIMESTAMP,
-                       Serializer::kSignatureTypeLengthInBytes);
-  serializer.WriteUint(timestamp, Serializer::kTimestampLengthInBytes);
-  serializer.WriteUint(ct::X509_ENTRY, Serializer::kLogEntryTypeLengthInBytes);
-  serializer.WriteFixedBytes(issuer_key_hash);
-  serializer.WriteVarBytes(tbs_certificate, kMaxCertificateLength);
-  serializer.WriteSctExtension(sct_extension);
-  result->assign(serializer.SerializedString());
+  result->clear();
+  WriteUint(ct::V2, Serializer::kVersionLengthInBytes, result);
+  WriteUint(ct::CERTIFICATE_TIMESTAMP, Serializer::kSignatureTypeLengthInBytes,
+            result);
+  WriteUint(timestamp, Serializer::kTimestampLengthInBytes, result);
+  WriteUint(ct::X509_ENTRY, Serializer::kLogEntryTypeLengthInBytes, result);
+  WriteFixedBytes(issuer_key_hash, result);
+  WriteVarBytes(tbs_certificate, kMaxCertificateLength, result);
+  WriteSctExtension(sct_extension, result);
   return SerializeResult::OK;
 }
 
@@ -356,17 +356,16 @@ SerializeResult SerializeV2PrecertSCTSignatureInput(
   if (res != SerializeResult::OK) {
     return res;
   }
-  TLSSerializer serializer;
-  serializer.WriteUint(ct::V2, Serializer::kVersionLengthInBytes);
-  serializer.WriteUint(ct::CERTIFICATE_TIMESTAMP,
-                       Serializer::kSignatureTypeLengthInBytes);
-  serializer.WriteUint(timestamp, Serializer::kTimestampLengthInBytes);
-  serializer.WriteUint(ct::PRECERT_ENTRY_V2,
-                       Serializer::kLogEntryTypeLengthInBytes);
-  serializer.WriteFixedBytes(issuer_key_hash);
-  serializer.WriteVarBytes(tbs_certificate, kMaxCertificateLength);
-  serializer.WriteSctExtension(sct_extension);
-  result->assign(serializer.SerializedString());
+  result->clear();
+  WriteUint(ct::V2, Serializer::kVersionLengthInBytes, result);
+  WriteUint(ct::CERTIFICATE_TIMESTAMP, Serializer::kSignatureTypeLengthInBytes,
+            result);
+  WriteUint(timestamp, Serializer::kTimestampLengthInBytes, result);
+  WriteUint(ct::PRECERT_ENTRY_V2, Serializer::kLogEntryTypeLengthInBytes,
+            result);
+  WriteFixedBytes(issuer_key_hash, result);
+  WriteVarBytes(tbs_certificate, kMaxCertificateLength, result);
+  WriteSctExtension(sct_extension, result);
   return SerializeResult::OK;
 }
 
@@ -377,6 +376,7 @@ SerializeResult SerializeV2SCTSignatureInput(
   if (sct.version() != ct::V2) {
     return SerializeResult::UNSUPPORTED_VERSION;
   }
+  result->clear();
   switch (entry.type()) {
     case ct::X509_ENTRY:
       return SerializeV2CertSCTSignatureInput(
@@ -407,16 +407,15 @@ SerializeResult SerializeV2CertSCTMerkleTreeLeaf(
   if (res != SerializeResult::OK) {
     return res;
   }
-  TLSSerializer serializer;
-  serializer.WriteUint(ct::V2, Serializer::kVersionLengthInBytes);
-  serializer.WriteUint(ct::TIMESTAMPED_ENTRY,
-                       Serializer::kMerkleLeafTypeLengthInBytes);
-  serializer.WriteUint(timestamp, Serializer::kTimestampLengthInBytes);
-  serializer.WriteUint(ct::X509_ENTRY, Serializer::kLogEntryTypeLengthInBytes);
-  serializer.WriteFixedBytes(issuer_key_hash);
-  serializer.WriteVarBytes(tbs_certificate, kMaxCertificateLength);
-  serializer.WriteSctExtension(sct_extension);
-  result->assign(serializer.SerializedString());
+  result->clear();
+  WriteUint(ct::V2, Serializer::kVersionLengthInBytes, result);
+  WriteUint(ct::TIMESTAMPED_ENTRY, Serializer::kMerkleLeafTypeLengthInBytes,
+            result);
+  WriteUint(timestamp, Serializer::kTimestampLengthInBytes, result);
+  WriteUint(ct::X509_ENTRY, Serializer::kLogEntryTypeLengthInBytes, result);
+  WriteFixedBytes(issuer_key_hash, result);
+  WriteVarBytes(tbs_certificate, kMaxCertificateLength, result);
+  WriteSctExtension(sct_extension, result);
   return SerializeResult::OK;
 }
 
@@ -438,17 +437,16 @@ SerializeResult SerializeV2PrecertSCTMerkleTreeLeaf(
   if (res != SerializeResult::OK) {
     return res;
   }
-  TLSSerializer serializer;
-  serializer.WriteUint(ct::V2, Serializer::kVersionLengthInBytes);
-  serializer.WriteUint(ct::TIMESTAMPED_ENTRY,
-                       Serializer::kMerkleLeafTypeLengthInBytes);
-  serializer.WriteUint(timestamp, Serializer::kTimestampLengthInBytes);
-  serializer.WriteUint(ct::PRECERT_ENTRY_V2,
-                       Serializer::kLogEntryTypeLengthInBytes);
-  serializer.WriteFixedBytes(issuer_key_hash);
-  serializer.WriteVarBytes(tbs_certificate, kMaxCertificateLength);
-  serializer.WriteSctExtension(sct_extension);
-  result->assign(serializer.SerializedString());
+  result->clear();
+  WriteUint(ct::V2, Serializer::kVersionLengthInBytes, result);
+  WriteUint(ct::TIMESTAMPED_ENTRY, Serializer::kMerkleLeafTypeLengthInBytes,
+            result);
+  WriteUint(timestamp, Serializer::kTimestampLengthInBytes, result);
+  WriteUint(ct::PRECERT_ENTRY_V2, Serializer::kLogEntryTypeLengthInBytes,
+            result);
+  WriteFixedBytes(issuer_key_hash, result);
+  WriteVarBytes(tbs_certificate, kMaxCertificateLength, result);
+  WriteSctExtension(sct_extension, result);
   return SerializeResult::OK;
 }
 
@@ -457,6 +455,7 @@ SerializeResult SerializeV2SCTMerkleTreeLeaf(
     const ct::SignedCertificateTimestamp& sct, const ct::LogEntry& entry,
     string* result) {
   CHECK_EQ(ct::V2, sct.version());
+  result->clear();
   switch (entry.type()) {
     case ct::X509_ENTRY:
       return SerializeV2CertSCTMerkleTreeLeaf(
@@ -581,7 +580,6 @@ SerializeResult SerializePrecertChainEntry(const ct::PrecertChainEntry& entry,
 SerializeResult SerializePrecertChainEntry(
     const std::string& pre_certificate,
     const repeated_string& precertificate_chain, std::string* result) {
-  TLSSerializer serializer;
   if (pre_certificate.size() > kMaxCertificateLength) {
     return SerializeResult::CERTIFICATE_TOO_LONG;
   }
@@ -589,15 +587,15 @@ SerializeResult SerializePrecertChainEntry(
     return SerializeResult::EMPTY_CERTIFICATE;
   }
 
-  serializer.WriteVarBytes(pre_certificate, kMaxCertificateLength);
+  result->clear();
+  WriteVarBytes(pre_certificate, kMaxCertificateLength, result);
 
-  SerializeResult res =
-      serializer.WriteList(precertificate_chain, kMaxCertificateLength,
-                           kMaxCertificateChainLength);
+  SerializeResult res = WriteList(precertificate_chain, kMaxCertificateLength,
+                                  kMaxCertificateChainLength, result);
   if (res != SerializeResult::OK) {
+    result->clear();
     return res;
   }
-  result->assign(serializer.SerializedString());
   return SerializeResult::OK;
 }
 
@@ -608,10 +606,9 @@ SerializeResult SerializeV1SignedCertEntryWithType(
   if (res != SerializeResult::OK) {
     return res;
   }
-  TLSSerializer serializer;
-  serializer.WriteUint(ct::X509_ENTRY, Serializer::kLogEntryTypeLengthInBytes);
-  serializer.WriteVarBytes(leaf_certificate, kMaxCertificateLength);
-  result->assign(serializer.SerializedString());
+  result->clear();
+  WriteUint(ct::X509_ENTRY, Serializer::kLogEntryTypeLengthInBytes, result);
+  WriteVarBytes(leaf_certificate, kMaxCertificateLength, result);
   return SerializeResult::OK;
 }
 
@@ -627,12 +624,10 @@ SerializeResult SerializeV1SignedPrecertEntryWithType(
   if (res != SerializeResult::OK) {
     return res;
   }
-  TLSSerializer serializer;
-  serializer.WriteUint(ct::PRECERT_ENTRY,
-                       Serializer::kLogEntryTypeLengthInBytes);
-  serializer.WriteFixedBytes(issuer_key_hash);
-  serializer.WriteVarBytes(tbs_certificate, kMaxCertificateLength);
-  result->assign(serializer.SerializedString());
+  result->clear();
+  WriteUint(ct::PRECERT_ENTRY, Serializer::kLogEntryTypeLengthInBytes, result);
+  WriteFixedBytes(issuer_key_hash, result);
+  WriteVarBytes(tbs_certificate, kMaxCertificateLength, result);
   return SerializeResult::OK;
 }
 

--- a/cpp/proto/cert_serializer.h
+++ b/cpp/proto/cert_serializer.h
@@ -17,72 +17,73 @@ void ConfigureSerializerForV2CT();
 
 // NB This serializes the certificate_chain component of the X509 chain only.
 // Needed for the GetEntries flow.
-SerializeResult SerializeX509Chain(const ct::X509ChainEntry& entry,
-                                   std::string* result);
+cert_trans::serialization::SerializeResult SerializeX509Chain(
+    const ct::X509ChainEntry& entry, std::string* result);
 
-SerializeResult SerializeX509ChainV1(const repeated_string& certificate_chain,
-                                     std::string* result);
+cert_trans::serialization::SerializeResult SerializeX509ChainV1(
+    const repeated_string& certificate_chain, std::string* result);
 
-SerializeResult SerializePrecertChainEntry(const ct::PrecertChainEntry& entry,
-                                           std::string* result);
+cert_trans::serialization::SerializeResult SerializePrecertChainEntry(
+    const ct::PrecertChainEntry& entry, std::string* result);
 
-SerializeResult SerializePrecertChainEntry(
+cert_trans::serialization::SerializeResult SerializePrecertChainEntry(
     const std::string& pre_certificate,
     const repeated_string& precertificate_chain, std::string* result);
 
 // These two functions are depended on externally.
-SerializeResult SerializeV1SignedCertEntryWithType(
+cert_trans::serialization::SerializeResult SerializeV1SignedCertEntryWithType(
     const std::string& leaf_certificate, std::string* result);
 
-SerializeResult SerializeV1SignedPrecertEntryWithType(
-    const std::string& issuer_key_hash, const std::string& tbs_certificate,
-    std::string* result);
+cert_trans::serialization::SerializeResult
+SerializeV1SignedPrecertEntryWithType(const std::string& issuer_key_hash,
+                                      const std::string& tbs_certificate,
+                                      std::string* result);
 
-DeserializeResult DeserializeX509Chain(const std::string& in,
-                                       ct::X509ChainEntry* x509_chain_entry);
+cert_trans::serialization::DeserializeResult DeserializeX509Chain(
+    const std::string& in, ct::X509ChainEntry* x509_chain_entry);
 
-DeserializeResult DeserializePrecertChainEntry(
+cert_trans::serialization::DeserializeResult DeserializePrecertChainEntry(
     const std::string& in, ct::PrecertChainEntry* precert_chain_entry);
 
 // Test helpers
 //
-SerializeResult SerializeV1CertSCTMerkleTreeLeaf(
+cert_trans::serialization::SerializeResult SerializeV1CertSCTMerkleTreeLeaf(
     uint64_t timestamp, const std::string& certificate,
     const std::string& extensions, std::string* result);
 
-SerializeResult SerializeV1PrecertSCTMerkleTreeLeaf(
+cert_trans::serialization::SerializeResult SerializeV1PrecertSCTMerkleTreeLeaf(
     uint64_t timestamp, const std::string& issuer_key_hash,
     const std::string& tbs_certificate, const std::string& extensions,
     std::string* result);
 
-SerializeResult SerializeV2CertSCTMerkleTreeLeaf(
+cert_trans::serialization::SerializeResult SerializeV2CertSCTMerkleTreeLeaf(
     uint64_t timestamp, const std::string& issuer_key_hash,
     const std::string& tbs_certificate,
     const google::protobuf::RepeatedPtrField<ct::SctExtension>& sct_extension,
     std::string* result);
 
-SerializeResult SerializeV2PrecertSCTMerkleTreeLeaf(
+cert_trans::serialization::SerializeResult SerializeV2PrecertSCTMerkleTreeLeaf(
     uint64_t timestamp, const std::string& issuer_key_hash,
     const std::string& tbs_certificate,
     const google::protobuf::RepeatedPtrField<ct::SctExtension>& sct_extension,
     std::string* result);
 
-SerializeResult SerializeV2CertSCTSignatureInput(
+cert_trans::serialization::SerializeResult SerializeV2CertSCTSignatureInput(
     uint64_t timestamp, const std::string& issuer_key_hash,
     const std::string& tbs_certificate,
     const google::protobuf::RepeatedPtrField<ct::SctExtension>& sct_extension,
     std::string* result);
 
-SerializeResult SerializeV1CertSCTSignatureInput(
+cert_trans::serialization::SerializeResult SerializeV1CertSCTSignatureInput(
     uint64_t timestamp, const std::string& certificate,
     const std::string& extensions, std::string* result);
 
-SerializeResult SerializeV1PrecertSCTSignatureInput(
+cert_trans::serialization::SerializeResult SerializeV1PrecertSCTSignatureInput(
     uint64_t timestamp, const std::string& issuer_key_hash,
     const std::string& tbs_certificate, const std::string& extensions,
     std::string* result);
 
-SerializeResult SerializeV2PrecertSCTSignatureInput(
+cert_trans::serialization::SerializeResult SerializeV2PrecertSCTSignatureInput(
     uint64_t timestamp, const std::string& issuer_key_hash,
     const std::string& tbs_certificate,
     const google::protobuf::RepeatedPtrField<ct::SctExtension>& sct_extension,

--- a/cpp/proto/serializer.h
+++ b/cpp/proto/serializer.h
@@ -9,105 +9,22 @@
 
 #include "base/macros.h"
 #include "proto/ct.pb.h"
+#include "proto/tls_encoding.h"
 
-
-// Serialization methods return OK on success,
-// or the first encountered error on failure.
-enum class SerializeResult {
-  OK,
-  INVALID_ENTRY_TYPE,
-  EMPTY_CERTIFICATE,
-  // TODO(alcutter): rename these to LEAFDATA_TOO_LONG or similar?
-  CERTIFICATE_TOO_LONG,
-  CERTIFICATE_CHAIN_TOO_LONG,
-  INVALID_HASH_ALGORITHM,
-  INVALID_SIGNATURE_ALGORITHM,
-  SIGNATURE_TOO_LONG,
-  INVALID_HASH_LENGTH,
-  EMPTY_PRECERTIFICATE_CHAIN,
-  UNSUPPORTED_VERSION,
-  EXTENSIONS_TOO_LONG,
-  INVALID_KEYID_LENGTH,
-  EMPTY_LIST,
-  EMPTY_ELEM_IN_LIST,
-  LIST_ELEM_TOO_LONG,
-  LIST_TOO_LONG,
-  EXTENSIONS_NOT_ORDERED,
-};
-
-std::ostream& operator<<(std::ostream& stream, const SerializeResult& r);
-
-
-enum class DeserializeResult {
-  OK,
-  INPUT_TOO_SHORT,
-  INVALID_HASH_ALGORITHM,
-  INVALID_SIGNATURE_ALGORITHM,
-  INPUT_TOO_LONG,
-  UNSUPPORTED_VERSION,
-  INVALID_LIST_ENCODING,
-  EMPTY_LIST,
-  EMPTY_ELEM_IN_LIST,
-  UNKNOWN_LEAF_TYPE,
-  UNKNOWN_LOGENTRY_TYPE,
-  EXTENSIONS_TOO_LONG,
-  EXTENSIONS_NOT_ORDERED,
-};
-
-std::ostream& operator<<(std::ostream& stream, const DeserializeResult& r);
-
-typedef google::protobuf::RepeatedPtrField<std::string> repeated_string;
 typedef google::protobuf::RepeatedPtrField<ct::SthExtension>
     repeated_sth_extension;
 typedef google::protobuf::RepeatedPtrField<ct::SctExtension>
     repeated_sct_extension;
 
-SerializeResult CheckExtensionsFormat(const std::string& extensions);
-SerializeResult CheckKeyHashFormat(const std::string& key_hash);
-SerializeResult CheckSctExtensionsFormat(
+cert_trans::serialization::SerializeResult CheckExtensionsFormat(
+    const std::string& extensions);
+cert_trans::serialization::SerializeResult CheckKeyHashFormat(
+    const std::string& key_hash);
+cert_trans::serialization::SerializeResult CheckSctExtensionsFormat(
     const repeated_sct_extension& extension);
 
-// TODO(pphaneuf): Make this into normal functions in a namespace.
-class TLSSerializer {
- public:
-  // returns binary data
-  std::string SerializedString() const {
-    return output_;
-  }
-
-  SerializeResult WriteSCTV1(const ct::SignedCertificateTimestamp& sct);
-
-  SerializeResult WriteSCTV2(const ct::SignedCertificateTimestamp& sct);
-
-  SerializeResult WriteList(const repeated_string& in, size_t max_elem_length,
-                            size_t max_total_length);
-
-  SerializeResult WriteDigitallySigned(const ct::DigitallySigned& sig);
-
-
-  template <class T>
-  void WriteUint(T in, size_t bytes) {
-    CHECK_LE(bytes, sizeof(in));
-    CHECK(bytes == sizeof(in) || in >> (bytes * 8) == 0);
-    for (; bytes > 0; --bytes)
-      output_.push_back(((in & (static_cast<T>(0xff) << ((bytes - 1) * 8))) >>
-                         ((bytes - 1) * 8)));
-  }
-
-  // Fixed-length byte array.
-  void WriteFixedBytes(const std::string& in);
-
-  // Variable-length byte array.
-  // Caller is responsible for checking |in| <= max_length
-  // TODO(ekasper): could return a bool instead.
-  void WriteVarBytes(const std::string& in, size_t max_length);
-
-  void WriteSctExtension(const repeated_sct_extension& extension);
-
- private:
-  std::string output_;
-};
-
+void WriteSctExtension(const repeated_sct_extension& extension,
+                       std::string* output);
 
 class TLSDeserializer {
  public:
@@ -121,14 +38,17 @@ class TLSDeserializer {
     return bytes_remaining_ == 0;
   }
 
-  DeserializeResult ReadSCT(ct::SignedCertificateTimestamp* sct);
+  cert_trans::serialization::DeserializeResult ReadSCT(
+      ct::SignedCertificateTimestamp* sct);
 
-  DeserializeResult ReadList(size_t max_total_length, size_t max_elem_length,
-                             repeated_string* out);
+  cert_trans::serialization::DeserializeResult ReadList(
+      size_t max_total_length, size_t max_elem_length, repeated_string* out);
 
-  DeserializeResult ReadDigitallySigned(ct::DigitallySigned* sig);
+  cert_trans::serialization::DeserializeResult ReadDigitallySigned(
+      ct::DigitallySigned* sig);
 
-  DeserializeResult ReadMerkleTreeLeaf(ct::MerkleTreeLeaf* leaf);
+  cert_trans::serialization::DeserializeResult ReadMerkleTreeLeaf(
+      ct::MerkleTreeLeaf* leaf);
   bool ReadVarBytes(size_t max_length, std::string* result);
 
   template <class T>
@@ -146,18 +66,24 @@ class TLSDeserializer {
     return true;
   }
 
-  DeserializeResult ReadExtensions(ct::TimestampedEntry* entry);
+  cert_trans::serialization::DeserializeResult ReadExtensions(
+      ct::TimestampedEntry* entry);
   bool ReadFixedBytes(size_t bytes, std::string* result);
 
  private:
   static const size_t kV2ExtensionCountLengthInBytes;
   static const size_t kV2ExtensionTypeLengthInBytes;
 
-  DeserializeResult ReadSctExtension(repeated_sct_extension* extension);
-  DeserializeResult ReadMerkleTreeLeafV1(ct::MerkleTreeLeaf* leaf);
-  DeserializeResult ReadMerkleTreeLeafV2(ct::MerkleTreeLeaf* leaf);
-  DeserializeResult ReadSCTV1(ct::SignedCertificateTimestamp* sct);
-  DeserializeResult ReadSCTV2(ct::SignedCertificateTimestamp* sct);
+  cert_trans::serialization::DeserializeResult ReadSctExtension(
+      repeated_sct_extension* extension);
+  cert_trans::serialization::DeserializeResult ReadMerkleTreeLeafV1(
+      ct::MerkleTreeLeaf* leaf);
+  cert_trans::serialization::DeserializeResult ReadMerkleTreeLeafV2(
+      ct::MerkleTreeLeaf* leaf);
+  cert_trans::serialization::DeserializeResult ReadSCTV1(
+      ct::SignedCertificateTimestamp* sct);
+  cert_trans::serialization::DeserializeResult ReadSCTV2(
+      ct::SignedCertificateTimestamp* sct);
   bool ReadLengthPrefix(size_t max_length, size_t* result);
 
   const char* current_pos_;
@@ -169,7 +95,6 @@ class TLSDeserializer {
 // A utility class for writing protocol buffer fields in canonical TLS style.
 class Serializer {
  public:
-  static const size_t kMaxSignatureLength;
   static const size_t kMaxV2ExtensionType;
   static const size_t kMaxV2ExtensionsCount;
   static const size_t kMaxExtensionsLength;
@@ -178,8 +103,6 @@ class Serializer {
 
   static const size_t kLogEntryTypeLengthInBytes;
   static const size_t kSignatureTypeLengthInBytes;
-  static const size_t kHashAlgorithmLengthInBytes;
-  static const size_t kSigAlgorithmLengthInBytes;
   static const size_t kVersionLengthInBytes;
   // Log Key ID
   static const size_t kKeyIDLengthInBytes;
@@ -192,66 +115,67 @@ class Serializer {
   // TODO(alcutter): typedef these function<> bits
   static void ConfigureV1(
       const std::function<std::string(const ct::LogEntry&)>& leaf_data,
-      const std::function<SerializeResult(
+      const std::function<cert_trans::serialization::SerializeResult(
           const ct::SignedCertificateTimestamp& sct, const ct::LogEntry& entry,
           std::string* result)>& serialize_sct_sig_input,
-      const std::function<SerializeResult(
+      const std::function<cert_trans::serialization::SerializeResult(
           const ct::SignedCertificateTimestamp& sct, const ct::LogEntry& entry,
           std::string* result)>& serialize_sct_merkle_leaf);
 
   static void ConfigureV2(
       const std::function<std::string(const ct::LogEntry&)>& leaf_data,
-      const std::function<SerializeResult(
+      const std::function<cert_trans::serialization::SerializeResult(
           const ct::SignedCertificateTimestamp& sct, const ct::LogEntry& entry,
           std::string* result)>& serialize_sct_sig_input,
-      const std::function<SerializeResult(
+      const std::function<cert_trans::serialization::SerializeResult(
           const ct::SignedCertificateTimestamp& sct, const ct::LogEntry& entry,
           std::string* result)>& serialize_sct_merkle_leaf);
 
   static std::string LeafData(const ct::LogEntry& entry);
 
-  static SerializeResult SerializeSTHSignatureInput(
+  static cert_trans::serialization::SerializeResult SerializeSTHSignatureInput(
       const ct::SignedTreeHead& sth, std::string* result);
 
-  static SerializeResult SerializeSCTMerkleTreeLeaf(
+  static cert_trans::serialization::SerializeResult SerializeSCTMerkleTreeLeaf(
       const ct::SignedCertificateTimestamp& sct, const ct::LogEntry& entry,
       std::string* result);
 
-  static SerializeResult SerializeSCTSignatureInput(
+  static cert_trans::serialization::SerializeResult SerializeSCTSignatureInput(
       const ct::SignedCertificateTimestamp& sct, const ct::LogEntry& entry,
       std::string* result);
 
-  static SerializeResult SerializeV1STHSignatureInput(
-      uint64_t timestamp, int64_t tree_size, const std::string& root_hash,
-      std::string* result);
+  static cert_trans::serialization::SerializeResult
+  SerializeV1STHSignatureInput(uint64_t timestamp, int64_t tree_size,
+                               const std::string& root_hash,
+                               std::string* result);
 
-  static SerializeResult SerializeV2STHSignatureInput(
-      uint64_t timestamp, int64_t tree_size, const std::string& root_hash,
-      const repeated_sth_extension& sth_extension, const std::string& log_id,
-      std::string* result);
+  static cert_trans::serialization::SerializeResult
+  SerializeV2STHSignatureInput(uint64_t timestamp, int64_t tree_size,
+                               const std::string& root_hash,
+                               const repeated_sth_extension& sth_extension,
+                               const std::string& log_id, std::string* result);
 
 
   // Random utils
-  static SerializeResult SerializeList(const repeated_string& in,
-                                       size_t max_elem_length,
-                                       size_t max_total_length,
-                                       std::string* result);
+  static cert_trans::serialization::SerializeResult SerializeList(
+      const repeated_string& in, size_t max_elem_length,
+      size_t max_total_length, std::string* result);
 
-  static SerializeResult SerializeSCT(
+  static cert_trans::serialization::SerializeResult SerializeSCT(
       const ct::SignedCertificateTimestamp& sct, std::string* result);
 
-  static SerializeResult SerializeSCTList(
+  static cert_trans::serialization::SerializeResult SerializeSCTList(
       const ct::SignedCertificateTimestampList& sct_list, std::string* result);
 
-  static SerializeResult SerializeDigitallySigned(
+  static cert_trans::serialization::SerializeResult SerializeDigitallySigned(
       const ct::DigitallySigned& sig, std::string* result);
 
   // TODO(ekasper): tests for these!
   template <class T>
   static std::string SerializeUint(T in, size_t bytes = sizeof(T)) {
-    TLSSerializer serializer;
-    serializer.WriteUint(in, bytes);
-    return serializer.SerializedString();
+    std::string out;
+    cert_trans::serialization::WriteUint(in, bytes, &out);
+    return out;
   }
 
  private:
@@ -263,42 +187,42 @@ class Serializer {
 
 class Deserializer {
  public:
-  static void Configure(const std::function<DeserializeResult(
-                            TLSDeserializer* d, ct::MerkleTreeLeaf* leaf)>&
-                            read_merkle_tree_leaf_body);
+  static void Configure(
+      const std::function<cert_trans::serialization::DeserializeResult(
+          TLSDeserializer* d, ct::MerkleTreeLeaf* leaf)>&
+          read_merkle_tree_leaf_body);
 
-  static DeserializeResult DeserializeSCT(const std::string& in,
-                                          ct::SignedCertificateTimestamp* sct);
+  static cert_trans::serialization::DeserializeResult DeserializeSCT(
+      const std::string& in, ct::SignedCertificateTimestamp* sct);
 
-  static DeserializeResult DeserializeSCTList(
+  static cert_trans::serialization::DeserializeResult DeserializeSCTList(
       const std::string& in, ct::SignedCertificateTimestampList* sct_list);
 
-  static DeserializeResult DeserializeDigitallySigned(
-      const std::string& in, ct::DigitallySigned* sig);
+  static cert_trans::serialization::DeserializeResult
+  DeserializeDigitallySigned(const std::string& in, ct::DigitallySigned* sig);
 
   // FIXME(ekasper): for simplicity these reject if the list has empty
   // elements (all our use cases are like this) but they should take in
   // an arbitrary min bound instead.
-  static DeserializeResult DeserializeList(const std::string& in,
-                                           size_t max_total_length,
-                                           size_t max_elem_length,
-                                           repeated_string* out);
+  static cert_trans::serialization::DeserializeResult DeserializeList(
+      const std::string& in, size_t max_total_length, size_t max_elem_length,
+      repeated_string* out);
 
-  static DeserializeResult DeserializeMerkleTreeLeaf(const std::string& in,
-                                                     ct::MerkleTreeLeaf* leaf);
+  static cert_trans::serialization::DeserializeResult
+  DeserializeMerkleTreeLeaf(const std::string& in, ct::MerkleTreeLeaf* leaf);
 
   // TODO(pphaneuf): Maybe the users of this should just use
   // TLSDeserializer directly?
   template <class T>
-  static DeserializeResult DeserializeUint(const std::string& in, size_t bytes,
-                                           T* result) {
+  static cert_trans::serialization::DeserializeResult DeserializeUint(
+      const std::string& in, size_t bytes, T* result) {
     TLSDeserializer deserializer(in);
     bool res = deserializer.ReadUint(bytes, result);
     if (!res)
-      return DeserializeResult::INPUT_TOO_SHORT;
+      return cert_trans::serialization::DeserializeResult::INPUT_TOO_SHORT;
     if (!deserializer.ReachedEnd())
-      return DeserializeResult::INPUT_TOO_LONG;
-    return DeserializeResult::OK;
+      return cert_trans::serialization::DeserializeResult::INPUT_TOO_LONG;
+    return cert_trans::serialization::DeserializeResult::OK;
   }
 
  private:

--- a/cpp/proto/serializer_test.cc
+++ b/cpp/proto/serializer_test.cc
@@ -15,6 +15,8 @@ DECLARE_bool(allow_reconfigure_serializer_test_only);
 
 namespace {
 
+using cert_trans::serialization::SerializeResult;
+using cert_trans::serialization::DeserializeResult;
 using ct::DigitallySigned;
 using ct::LogEntry;
 using ct::LogEntryType;

--- a/cpp/proto/tls_encoding.cc
+++ b/cpp/proto/tls_encoding.cc
@@ -1,0 +1,179 @@
+/* -*- indent-tabs-mode: nil -*- */
+#include "proto/tls_encoding.h"
+
+#include <math.h>
+#include <ostream>
+#include <string>
+
+using ct::DigitallySigned;
+
+namespace cert_trans {
+
+namespace serialization {
+
+namespace {
+
+SerializeResult CheckSignatureFormat(const DigitallySigned& sig) {
+  // This is just DCHECKED upon setting, so check again.
+  if (!DigitallySigned_HashAlgorithm_IsValid(sig.hash_algorithm()))
+    return SerializeResult::INVALID_HASH_ALGORITHM;
+  if (!DigitallySigned_SignatureAlgorithm_IsValid(sig.sig_algorithm()))
+    return SerializeResult::INVALID_SIGNATURE_ALGORITHM;
+  if (sig.signature().size() > constants::kMaxSignatureLength)
+    return SerializeResult::SIGNATURE_TOO_LONG;
+  return SerializeResult::OK;
+}
+
+size_t SerializedListLength(const repeated_string& in, size_t max_elem_length,
+                            size_t max_total_length) {
+  size_t elem_prefix_length = internal::PrefixLength(max_elem_length);
+  size_t total_length = 0;
+
+  for (int i = 0; i < in.size(); ++i) {
+    if (in.Get(i).size() > max_elem_length ||
+        max_total_length - total_length < elem_prefix_length ||
+        max_total_length - total_length - elem_prefix_length <
+            in.Get(i).size())
+      return 0;
+
+    total_length += elem_prefix_length + in.Get(i).size();
+  }
+
+  return total_length + internal::PrefixLength(max_total_length);
+}
+
+}  // namespace
+
+std::ostream& operator<<(std::ostream& stream, const SerializeResult& r) {
+  switch (r) {
+    case SerializeResult::OK:
+      return stream << "OK";
+    case SerializeResult::INVALID_ENTRY_TYPE:
+      return stream << "INVALID_ENTRY_TYPE";
+    case SerializeResult::EMPTY_CERTIFICATE:
+      return stream << "EMPTY_CERTIFICATE";
+    case SerializeResult::CERTIFICATE_TOO_LONG:
+      return stream << "CERTIFICATE_TOO_LONG";
+    case SerializeResult::CERTIFICATE_CHAIN_TOO_LONG:
+      return stream << "CERTIFICATE_CHAIN_TOO_LONG";
+    case SerializeResult::INVALID_HASH_ALGORITHM:
+      return stream << "INVALID_HASH_ALGORITHM";
+    case SerializeResult::INVALID_SIGNATURE_ALGORITHM:
+      return stream << "INVALID_SIGNATURE_ALGORITHM";
+    case SerializeResult::SIGNATURE_TOO_LONG:
+      return stream << "SIGNATURE_TOO_LONG";
+    case SerializeResult::INVALID_HASH_LENGTH:
+      return stream << "INVALID_HASH_LENGTH";
+    case SerializeResult::EMPTY_PRECERTIFICATE_CHAIN:
+      return stream << "EMPTY_PRECERTIFICATE_CHAIN";
+    case SerializeResult::UNSUPPORTED_VERSION:
+      return stream << "UNSUPPORTED_VERSION";
+    case SerializeResult::EXTENSIONS_TOO_LONG:
+      return stream << "EXTENSIONS_TOO_LONG";
+    case SerializeResult::INVALID_KEYID_LENGTH:
+      return stream << "INVALID_KEYID_LENGTH";
+    case SerializeResult::EMPTY_LIST:
+      return stream << "EMPTY_LIST";
+    case SerializeResult::EMPTY_ELEM_IN_LIST:
+      return stream << "EMPTY_ELEM_IN_LIST";
+    case SerializeResult::LIST_ELEM_TOO_LONG:
+      return stream << "LIST_ELEM_TOO_LONG";
+    case SerializeResult::LIST_TOO_LONG:
+      return stream << "LIST_TOO_LONG";
+    case SerializeResult::EXTENSIONS_NOT_ORDERED:
+      return stream << "EXTENSIONS_NOT_ORDERED";
+  }
+  return stream << "<unknown>";
+}
+
+std::ostream& operator<<(std::ostream& stream, const DeserializeResult& r) {
+  switch (r) {
+    case DeserializeResult::OK:
+      return stream << "OK";
+    case DeserializeResult::INPUT_TOO_SHORT:
+      return stream << "INPUT_TOO_SHORT";
+    case DeserializeResult::INVALID_HASH_ALGORITHM:
+      return stream << "INVALID_HASH_ALGORITHM";
+    case DeserializeResult::INVALID_SIGNATURE_ALGORITHM:
+      return stream << "INVALID_SIGNATURE_ALGORITHM";
+    case DeserializeResult::INPUT_TOO_LONG:
+      return stream << "INPUT_TOO_LONG";
+    case DeserializeResult::UNSUPPORTED_VERSION:
+      return stream << "UNSUPPORTED_VERSION";
+    case DeserializeResult::INVALID_LIST_ENCODING:
+      return stream << "INVALID_LIST_ENCODING";
+    case DeserializeResult::EMPTY_LIST:
+      return stream << "EMPTY_LIST";
+    case DeserializeResult::EMPTY_ELEM_IN_LIST:
+      return stream << "EMPTY_ELEM_IN_LIST";
+    case DeserializeResult::UNKNOWN_LEAF_TYPE:
+      return stream << "UNKNOWN_LEAF_TYPE";
+    case DeserializeResult::UNKNOWN_LOGENTRY_TYPE:
+      return stream << "UNKNOWN_LOGENTRY_TYPE";
+    case DeserializeResult::EXTENSIONS_TOO_LONG:
+      return stream << "EXTENSIONS_TOO_LONG";
+    case DeserializeResult::EXTENSIONS_NOT_ORDERED:
+      return stream << "EXTENSIONS_NOT_ORDERED";
+  }
+  return stream << "<unknown>";
+}
+
+void WriteFixedBytes(const std::string& in, std::string* output) {
+  output->append(in);
+}
+
+void WriteVarBytes(const std::string& in, size_t max_length,
+                   std::string* output) {
+  CHECK_LE(in.size(), max_length);
+
+  size_t prefix_length = internal::PrefixLength(max_length);
+  WriteUint(in.size(), prefix_length, output);
+  WriteFixedBytes(in, output);
+}
+
+SerializeResult WriteList(const repeated_string& in, size_t max_elem_length,
+                          size_t max_total_length, std::string* output) {
+  for (int i = 0; i < in.size(); ++i) {
+    if (in.Get(i).empty())
+      return SerializeResult::EMPTY_ELEM_IN_LIST;
+    if (in.Get(i).size() > max_elem_length)
+      return SerializeResult::LIST_ELEM_TOO_LONG;
+  }
+  size_t length = SerializedListLength(in, max_elem_length, max_total_length);
+  if (length == 0)
+    return SerializeResult::LIST_TOO_LONG;
+  size_t prefix_length = internal::PrefixLength(max_total_length);
+  CHECK_GE(length, prefix_length);
+
+  WriteUint(length - prefix_length, prefix_length, output);
+
+  for (int i = 0; i < in.size(); ++i)
+    WriteVarBytes(in.Get(i), max_elem_length, output);
+  return SerializeResult::OK;
+}
+
+SerializeResult WriteDigitallySigned(const DigitallySigned& sig,
+                                     std::string* output) {
+  SerializeResult res = CheckSignatureFormat(sig);
+  if (res != SerializeResult::OK)
+    return res;
+  WriteUint(sig.hash_algorithm(), constants::kHashAlgorithmLengthInBytes,
+            output);
+  WriteUint(sig.sig_algorithm(), constants::kSigAlgorithmLengthInBytes,
+            output);
+  WriteVarBytes(sig.signature(), constants::kMaxSignatureLength, output);
+  return SerializeResult::OK;
+}
+
+namespace internal {
+
+size_t PrefixLength(size_t max_length) {
+  CHECK_GT(max_length, 0U);
+  return ceil(log2(max_length) / float(8));
+}
+
+}  // namespace internal
+
+}  // namespace serialization
+
+}  // namespace cert_trans

--- a/cpp/proto/tls_encoding.h
+++ b/cpp/proto/tls_encoding.h
@@ -1,0 +1,103 @@
+#ifndef CERT_TRANS_PROTO_TLS_ENCODING_H_
+#define CERT_TRANS_PROTO_TLS_ENCODING_H_
+
+#include <glog/logging.h>
+#include <string>
+
+#include "proto/ct.pb.h"
+
+typedef google::protobuf::RepeatedPtrField<std::string> repeated_string;
+
+namespace cert_trans {
+
+namespace serialization {
+
+// Serialization methods return OK on success,
+// or the first encountered error on failure.
+enum class SerializeResult {
+  OK,
+  INVALID_ENTRY_TYPE,
+  EMPTY_CERTIFICATE,
+  // TODO(alcutter): rename these to LEAFDATA_TOO_LONG or similar?
+  CERTIFICATE_TOO_LONG,
+  CERTIFICATE_CHAIN_TOO_LONG,
+  INVALID_HASH_ALGORITHM,
+  INVALID_SIGNATURE_ALGORITHM,
+  SIGNATURE_TOO_LONG,
+  INVALID_HASH_LENGTH,
+  EMPTY_PRECERTIFICATE_CHAIN,
+  UNSUPPORTED_VERSION,
+  EXTENSIONS_TOO_LONG,
+  INVALID_KEYID_LENGTH,
+  EMPTY_LIST,
+  EMPTY_ELEM_IN_LIST,
+  LIST_ELEM_TOO_LONG,
+  LIST_TOO_LONG,
+  EXTENSIONS_NOT_ORDERED,
+};
+
+std::ostream& operator<<(std::ostream& stream, const SerializeResult& r);
+
+enum class DeserializeResult {
+  OK,
+  INPUT_TOO_SHORT,
+  INVALID_HASH_ALGORITHM,
+  INVALID_SIGNATURE_ALGORITHM,
+  INPUT_TOO_LONG,
+  UNSUPPORTED_VERSION,
+  INVALID_LIST_ENCODING,
+  EMPTY_LIST,
+  EMPTY_ELEM_IN_LIST,
+  UNKNOWN_LEAF_TYPE,
+  UNKNOWN_LOGENTRY_TYPE,
+  EXTENSIONS_TOO_LONG,
+  EXTENSIONS_NOT_ORDERED,
+};
+
+std::ostream& operator<<(std::ostream& stream, const DeserializeResult& r);
+
+///////////////////////////////////////////////////////////////////////////////
+// Basic serialization functions.                                            //
+///////////////////////////////////////////////////////////////////////////////
+template <class T>
+void WriteUint(T in, size_t bytes, std::string* output) {
+  CHECK_LE(bytes, sizeof(in));
+  CHECK(bytes == sizeof(in) || in >> (bytes * 8) == 0);
+  for (; bytes > 0; --bytes)
+    output->push_back(((in & (static_cast<T>(0xff) << ((bytes - 1) * 8))) >>
+                       ((bytes - 1) * 8)));
+}
+
+// Fixed-length byte array.
+void WriteFixedBytes(const std::string& in, std::string* output);
+
+// Variable-length byte array.
+// Caller is responsible for checking |in| <= max_length
+// TODO(ekasper): could return a bool instead.
+void WriteVarBytes(const std::string& in, size_t max_length,
+                   std::string* output);
+
+SerializeResult WriteList(const repeated_string& in, size_t max_elem_length,
+                          size_t max_total_length, std::string* output);
+
+SerializeResult WriteDigitallySigned(const ct::DigitallySigned& sig,
+                                     std::string* output);
+
+namespace constants {
+static const size_t kMaxSignatureLength = (1 << 16) - 1;
+static const size_t kHashAlgorithmLengthInBytes = 1;
+static const size_t kSigAlgorithmLengthInBytes = 1;
+}  // namespace constants
+
+namespace internal {
+
+// Returns the number of bytes needed to store a value up to max_length.
+size_t PrefixLength(size_t max_length);
+
+}  // namespace internal
+
+}  // namespace serializer
+
+}  // namespace cert_trans
+
+#endif

--- a/cpp/proto/xjson_serializer.cc
+++ b/cpp/proto/xjson_serializer.cc
@@ -9,6 +9,12 @@
 #include "proto/ct.pb.h"
 #include "proto/serializer.h"
 
+using cert_trans::serialization::SerializeResult;
+using cert_trans::serialization::DeserializeResult;
+using cert_trans::serialization::WriteDigitallySigned;
+using cert_trans::serialization::WriteFixedBytes;
+using cert_trans::serialization::WriteUint;
+using cert_trans::serialization::WriteVarBytes;
 using ct::DigitallySigned;
 using ct::DigitallySigned_HashAlgorithm_IsValid;
 using ct::DigitallySigned_SignatureAlgorithm_IsValid;
@@ -62,16 +68,14 @@ SerializeResult SerializeV1SCTSignatureInput(
   if (res != SerializeResult::OK) {
     return res;
   }
-  TLSSerializer serializer;
-  serializer.WriteUint(ct::V1, Serializer::kVersionLengthInBytes);
-  serializer.WriteUint(ct::CERTIFICATE_TIMESTAMP,
-                       Serializer::kSignatureTypeLengthInBytes);
-  serializer.WriteUint(sct.timestamp(), Serializer::kTimestampLengthInBytes);
-  serializer.WriteUint(ct::X_JSON_ENTRY,
-                       Serializer::kLogEntryTypeLengthInBytes);
-  serializer.WriteVarBytes(json, kMaxJsonLength);
-  serializer.WriteVarBytes(extensions, Serializer::kMaxExtensionsLength);
-  result->assign(serializer.SerializedString());
+  result->clear();
+  WriteUint(ct::V1, Serializer::kVersionLengthInBytes, result);
+  WriteUint(ct::CERTIFICATE_TIMESTAMP, Serializer::kSignatureTypeLengthInBytes,
+            result);
+  WriteUint(sct.timestamp(), Serializer::kTimestampLengthInBytes, result);
+  WriteUint(ct::X_JSON_ENTRY, Serializer::kLogEntryTypeLengthInBytes, result);
+  WriteVarBytes(json, kMaxJsonLength, result);
+  WriteVarBytes(extensions, Serializer::kMaxExtensionsLength, result);
   return SerializeResult::OK;
 }
 
@@ -93,16 +97,14 @@ SerializeResult SerializeV1SCTMerkleTreeLeaf(
   if (res != SerializeResult::OK) {
     return res;
   }
-  TLSSerializer serializer;
-  serializer.WriteUint(ct::V1, Serializer::kVersionLengthInBytes);
-  serializer.WriteUint(ct::TIMESTAMPED_ENTRY,
-                       Serializer::kMerkleLeafTypeLengthInBytes);
-  serializer.WriteUint(sct.timestamp(), Serializer::kTimestampLengthInBytes);
-  serializer.WriteUint(ct::X_JSON_ENTRY,
-                       Serializer::kLogEntryTypeLengthInBytes);
-  serializer.WriteVarBytes(json, kMaxJsonLength);
-  serializer.WriteVarBytes(extensions, Serializer::kMaxExtensionsLength);
-  result->assign(serializer.SerializedString());
+  result->clear();
+  WriteUint(ct::V1, Serializer::kVersionLengthInBytes, result);
+  WriteUint(ct::TIMESTAMPED_ENTRY, Serializer::kMerkleLeafTypeLengthInBytes,
+            result);
+  WriteUint(sct.timestamp(), Serializer::kTimestampLengthInBytes, result);
+  WriteUint(ct::X_JSON_ENTRY, Serializer::kLogEntryTypeLengthInBytes, result);
+  WriteVarBytes(json, kMaxJsonLength, result);
+  WriteVarBytes(extensions, Serializer::kMaxExtensionsLength, result);
   return SerializeResult::OK;
 }
 

--- a/cpp/server/ct-dns-server.cc
+++ b/cpp/server/ct-dns-server.cc
@@ -222,7 +222,7 @@ class CTUDPDNSServer : public UDPServer {
 
     std::string signature;
     CHECK_EQ(Serializer::SerializeDigitallySigned(sth.signature(), &signature),
-             SerializeResult::OK);
+             cert_trans::serialization::SerializeResult::OK);
 
     stringstream ss;
     ss << sth.tree_size() << '.' << sth.timestamp() << '.'

--- a/cpp/server/handler.cc
+++ b/cpp/server/handler.cc
@@ -320,7 +320,7 @@ void HttpHandler::BlockingGetEntries(evhttp_request* req, int64_t start,
         !entry.SerializeExtraData(&extra_data) ||
         (include_scts &&
          Serializer::SerializeSCT(entry.sct(), &sct_data) !=
-             SerializeResult::OK)) {
+             cert_trans::serialization::SerializeResult::OK)) {
       LOG(WARNING) << "Failed to serialize entry @ " << i << ":\n"
                    << entry.DebugString();
       return SendJsonError(event_base_, req, HTTP_INTERNAL,

--- a/cpp/tools/db_tool.cc
+++ b/cpp/tools/db_tool.cc
@@ -39,6 +39,7 @@ using cert_trans::LevelDB;
 using cert_trans::LoggedEntry;
 using cert_trans::ReadOnlyDatabase;
 using cert_trans::SQLiteDB;
+using cert_trans::serialization::SerializeResult;
 using std::cerr;
 using std::cout;
 using std::function;

--- a/cpp/util/json_wrapper.h
+++ b/cpp/util/json_wrapper.h
@@ -92,7 +92,7 @@ class JsonObject {
   void Add(const char* name, const ct::DigitallySigned& ds) {
     std::string signature;
     CHECK_EQ(Serializer::SerializeDigitallySigned(ds, &signature),
-             SerializeResult::OK);
+             cert_trans::serialization::SerializeResult::OK);
     AddBase64(name, signature);
   }
 


### PR DESCRIPTION
Make the low-level serialization functions stand-alone ones in a namespace rather than members of a class.

Using the TLSSerializer class required encoding the knowledge of all things that could be serialized in this class, preventing separation of serialization of different types of objects.

In order to use the low-level serialization code for 6962-bis, I had to move these functions out.