### PR TITLE
Have the caller supply the RoundTripper used in logclient.go.

### DIFF
--- a/go/client/logclient.go
+++ b/go/client/logclient.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/google/certificate-transparency/go"
-	"github.com/mreiferson/go-httpclient"
 	"golang.org/x/net/context"
 )
 
@@ -109,18 +108,9 @@ type getEntryAndProofResponse struct {
 // New constructs a new LogClient instance.
 // |uri| is the base URI of the CT log instance to interact with, e.g.
 // http://ct.googleapis.com/pilot
-func New(uri string) *LogClient {
-	var c LogClient
-	c.uri = uri
-	transport := &httpclient.Transport{
-		ConnectTimeout:        10 * time.Second,
-		RequestTimeout:        30 * time.Second,
-		ResponseHeaderTimeout: 30 * time.Second,
-		MaxIdleConnsPerHost:   10,
-		DisableKeepAlives:     false,
-	}
-	c.httpClient = &http.Client{Transport: transport}
-	return &c
+// |hc| is the underlying client to be used for HTTP requests to the CT log.
+func New(uri string, hc *http.Client) *LogClient {
+	return &LogClient{uri: uri, httpClient: hc}
 }
 
 // Makes a HTTP call to |uri|, and attempts to parse the response as a JSON

--- a/go/client/logclient_test.go
+++ b/go/client/logclient_test.go
@@ -57,7 +57,7 @@ func TestGetEntriesWorks(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client := New(ts.URL)
+	client := New(ts.URL, &http.Client{})
 	leaves, err := client.GetEntries(0, 1)
 	if err != nil {
 		t.Fatal(err)
@@ -78,7 +78,7 @@ func TestGetSTHWorks(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client := New(ts.URL)
+	client := New(ts.URL, &http.Client{})
 	sth, err := client.GetSTH()
 	if err != nil {
 		t.Fatal(err)
@@ -139,7 +139,7 @@ func TestAddChainWithContext(t *testing.T) {
 	}
 	chain := []ct.ASN1Cert{certBytes}
 
-	c := New(hs.URL)
+	c := New(hs.URL, &http.Client{})
 	leeway := time.Millisecond * 100
 	instant := time.Millisecond
 	fiveSeconds := time.Second * 5
@@ -193,7 +193,7 @@ func TestAddJSON(t *testing.T) {
 	}))
 	defer hs.Close()
 
-	c := New(hs.URL)
+	c := New(hs.URL, &http.Client{})
 
 	tests := []struct {
 		success bool

--- a/go/scanner/main/scanner.go
+++ b/go/scanner/main/scanner.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 	"log"
 	"math/big"
+	"net/http"
 	"regexp"
+	"time"
 
 	"encoding/base64"
 	"github.com/google/certificate-transparency/go"
 	"github.com/google/certificate-transparency/go/client"
 	"github.com/google/certificate-transparency/go/scanner"
+	"github.com/mreiferson/go-httpclient"
 )
 
 const (
@@ -96,7 +99,15 @@ func createMatcherFromFlags() (scanner.Matcher, error) {
 
 func main() {
 	flag.Parse()
-	logClient := client.New(*logUri)
+	logClient := client.New(*logUri, &http.Client{
+		Transport: &httpclient.Transport{
+			ConnectTimeout:        10 * time.Second,
+			RequestTimeout:        30 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
+			MaxIdleConnsPerHost:   10,
+			DisableKeepAlives:     false,
+			},
+		})
 	matcher, err := createMatcherFromFlags()
 	if err != nil {
 		log.Fatal(err)

--- a/go/scanner/scanner_test.go
+++ b/go/scanner/scanner_test.go
@@ -171,7 +171,7 @@ func TestScannerEndToEnd(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	logClient := client.New(ts.URL)
+	logClient := client.New(ts.URL, &http.Client{})
 	opts := ScannerOptions{
 		Matcher:       &MatchSubjectRegex{regexp.MustCompile(".*\\.google\\.com"), nil},
 		BatchSize:     10,


### PR DESCRIPTION
This permits callers to use a RoundTripper implementation different
to github.com/mreiferson/go-httpclient if they want to, and removes
the import dependency on that library.