### PR TITLE
Golang: Initialize http.Client if passed nil in client.New

### DIFF
--- a/go/client/logclient.go
+++ b/go/client/logclient.go
@@ -110,6 +110,9 @@ type getEntryAndProofResponse struct {
 // http://ct.googleapis.com/pilot
 // |hc| is the underlying client to be used for HTTP requests to the CT log.
 func New(uri string, hc *http.Client) *LogClient {
+	if hc == nil {
+		hc = new(http.Client)
+	}
 	return &LogClient{uri: uri, httpClient: hc}
 }
 


### PR DESCRIPTION
If the `http.Client` passed to `go/client.New` is nil initialize it before passing `client.LogClient` back to the user (general Golang stdlib behavior as far as I can tell).