### PR TITLE
Extract interface LogClient and rename existing struct logClientImpl.

### DIFF
--- a/go/preload/main/preload.go
+++ b/go/preload/main/preload.go
@@ -91,7 +91,7 @@ func sctWriterJob(addedCerts <-chan *preload.AddedCert, sctWriter io.Writer, wg 
 	wg.Done()
 }
 
-func certSubmitterJob(addedCerts chan<- *preload.AddedCert, log_client *client.LogClient, certs <-chan *ct.LogEntry,
+func certSubmitterJob(addedCerts chan<- *preload.AddedCert, log_client client.LogClient, certs <-chan *ct.LogEntry,
 	wg *sync.WaitGroup) {
 	for c := range certs {
 		chain := make([]ct.ASN1Cert, len(c.Chain)+1)
@@ -111,7 +111,7 @@ func certSubmitterJob(addedCerts chan<- *preload.AddedCert, log_client *client.L
 	wg.Done()
 }
 
-func precertSubmitterJob(addedCerts chan<- *preload.AddedCert, log_client *client.LogClient,
+func precertSubmitterJob(addedCerts chan<- *preload.AddedCert, log_client client.LogClient,
 	precerts <-chan *ct.LogEntry,
 	wg *sync.WaitGroup) {
 	for c := range precerts {

--- a/go/scanner/scanner.go
+++ b/go/scanner/scanner.go
@@ -150,7 +150,7 @@ func DefaultScannerOptions() *ScannerOptions {
 // Scanner is a tool to scan all the entries in a CT Log.
 type Scanner struct {
 	// Client used to talk to the CT log instance
-	logClient *client.LogClient
+	logClient client.LogClient
 
 	// Configuration options for this Scanner instance
 	opts ScannerOptions
@@ -401,7 +401,7 @@ func (s *Scanner) Scan(foundCert func(*ct.LogEntry),
 
 // Creates a new Scanner instance using |client| to talk to the log, and taking
 // configuration options from |opts|.
-func NewScanner(client *client.LogClient, opts ScannerOptions) *Scanner {
+func NewScanner(client client.LogClient, opts ScannerOptions) *Scanner {
 	var scanner Scanner
 	scanner.logClient = client
 	// Set a default match-everything regex if none was provided:


### PR DESCRIPTION
Using an interface makes it easier to write a mock LogClient for unit
tests.