### PR TITLE
Simplify TLS deserialization.

### DIFF
--- a/cpp/proto/cert_serializer.cc
+++ b/cpp/proto/cert_serializer.cc
@@ -265,7 +265,7 @@ DeserializeResult DeserializeV1SCTMerkleTreeLeaf(TLSDeserializer* des,
         return DeserializeResult::INPUT_TOO_SHORT;
       }
       entry->mutable_signed_entry()->set_x509(x509);
-      return des->ReadExtensions(entry);
+      return ReadExtensionsV1(des, entry);
     }
 
     case ct::PRECERT_ENTRY: {
@@ -281,7 +281,7 @@ DeserializeResult DeserializeV1SCTMerkleTreeLeaf(TLSDeserializer* des,
       }
       entry->mutable_signed_entry()->mutable_precert()->set_tbs_certificate(
           tbs_certificate);
-      return des->ReadExtensions(entry);
+      return ReadExtensionsV1(des, entry);
     }
   }
 
@@ -530,7 +530,9 @@ DeserializeResult DeserializeV2SCTMerkleTreeLeaf(TLSDeserializer* des,
       }
       entry->mutable_signed_entry()->mutable_cert_info()->set_tbs_certificate(
           tbs_certificate);
-      return des->ReadExtensions(entry);
+      // TODO(eranm): This is wrong, V2 Extensions should be read using
+      // ReadSctExtensions
+      return ReadExtensionsV1(des, entry);
     }
 
     case ct::UNKNOWN_ENTRY_TYPE: {

--- a/cpp/proto/serializer_test.cc
+++ b/cpp/proto/serializer_test.cc
@@ -1129,7 +1129,7 @@ TEST_F(SerializerTestV1, DeserializeSCTTooLong) {
 
   // We can still read from the beginning of a longer string...
   TLSDeserializer deserializer(token);
-  EXPECT_EQ(DeserializeResult::OK, deserializer.ReadSCT(&sct));
+  EXPECT_EQ(DeserializeResult::OK, ReadSCT(&deserializer, &sct));
   EXPECT_FALSE(deserializer.ReachedEnd());
   CompareSCT(DefaultSCT(), sct);
 

--- a/cpp/proto/xjson_serializer.cc
+++ b/cpp/proto/xjson_serializer.cc
@@ -156,7 +156,7 @@ DeserializeResult DeserializeV1SCTMerkleTreeLeaf(TLSDeserializer* des,
         return DeserializeResult::INPUT_TOO_SHORT;
       }
       entry->mutable_signed_entry()->set_json(json);
-      return des->ReadExtensions(entry);
+      return ReadExtensionsV1(des, entry);
     }
 
     case ct::UNKNOWN_ENTRY_TYPE: {


### PR DESCRIPTION
The TLSDeserializer class contained a mix of low-level TLS deserializing
and deserialization of application-specific data (SCTs, etc).

The TLSDeserializer was moved to tls_encoding.h/cc and was left only with
the basic TLS deserialization abilities.

De-serialization of application-specific structures remains in serializer.h
as stand-alone functions (rather than member functions).