### PR TITLE
Fix Golint errors

### DIFF
--- a/go/client/getentries.go
+++ b/go/client/getentries.go
@@ -13,20 +13,19 @@ import (
 	"golang.org/x/net/context"
 )
 
-// LeafEntry respresents a JSON leaf entry
+// LeafEntry respresents a JSON leaf entry.
 type LeafEntry struct {
 	LeafInput []byte `json:"leaf_input"`
 	ExtraData []byte `json:"extra_data"`
 }
 
-// getEntriesReponse respresents the JSON response to the CT get-entries method
-type getEntriesResponse struct {
+// GetEntriesResponse respresents the JSON response to the CT get-entries method.
+type GetEntriesResponse struct {
 	Entries []LeafEntry `json:"entries"` // the list of returned entries
 }
 
-// GetRawEntries exposes the /ct/v1/get-entries result with only the
-// JSON parsing done.
-func GetRawEntries(ctx context.Context, httpClient *http.Client, logURL string, start, end int64) (*getEntriesResponse, error) {
+// GetRawEntries exposes the /ct/v1/get-entries result with only the JSON parsing done.
+func GetRawEntries(ctx context.Context, httpClient *http.Client, logURL string, start, end int64) (*GetEntriesResponse, error) {
 	if end < 0 {
 		return nil, errors.New("end should be >= 0")
 	}
@@ -44,7 +43,7 @@ func GetRawEntries(ctx context.Context, httpClient *http.Client, logURL string, 
 		"end":   []string{strconv.FormatInt(end, 10)},
 	}.Encode()
 
-	var resp getEntriesResponse
+	var resp GetEntriesResponse
 	err = fetchAndParse(context.TODO(), httpClient, baseURL.String(), &resp)
 	if err != nil {
 		return nil, err

--- a/go/client/logclient.go
+++ b/go/client/logclient.go
@@ -259,6 +259,7 @@ func (c *LogClient) AddChainWithContext(ctx context.Context, chain []ct.ASN1Cert
 	return c.addChainWithRetry(ctx, AddChainPath, chain)
 }
 
+// AddJSON submits arbitrary data to to XJSON server.
 func (c *LogClient) AddJSON(data interface{}) (*ct.SignedCertificateTimestamp, error) {
 	req := addJSONRequest{
 		Data: data,

--- a/go/merkletree/merkle_tree.go
+++ b/go/merkletree/merkle_tree.go
@@ -25,22 +25,30 @@ type CPPMerkleTree struct {
 	nodeSize C.size_t
 }
 
+// LeafCount is the number of leafs in the tree.
 func (m *CPPMerkleTree) LeafCount() uint64 {
 	return uint64(C.LeafCount(m.peer))
 }
 
+// LevelCount is the number of levels in the tree.
 func (m *CPPMerkleTree) LevelCount() uint64 {
 	return uint64(C.LevelCount(m.peer))
 }
 
+// AddLeaf ads a new leaf to the hash tree. Stores the hash of the leaf data in
+// the tree structure, does not store the data itself.
+// Returns the position of the leaf in the tree.
 func (m *CPPMerkleTree) AddLeaf(leaf []byte) uint64 {
 	return uint64(C.AddLeaf(m.peer, C.BYTE_SLICE(&leaf)))
 }
 
+// AddLeafHash adds a leaf hash directly to the tree. Returns the position of
+// the leaf in the tree.
 func (m *CPPMerkleTree) AddLeafHash(hash []byte) uint64 {
 	return uint64(C.AddLeafHash(m.peer, C.BYTE_SLICE(&hash)))
 }
 
+// LeafHash returns the leaf hash for the leaf at the requested index.
 func (m *CPPMerkleTree) LeafHash(leaf uint64) ([]byte, error) {
 	hash := make([]byte, m.nodeSize)
 	success := C.LeafHash(m.peer, C.BYTE_SLICE(&hash), C.size_t(leaf))
@@ -50,6 +58,7 @@ func (m *CPPMerkleTree) LeafHash(leaf uint64) ([]byte, error) {
 	return hash, nil
 }
 
+// CurrentRoot returns the current root of the tree.
 func (m *CPPMerkleTree) CurrentRoot() ([]byte, error) {
 	hash := make([]byte, m.nodeSize)
 	success := C.CurrentRoot(m.peer, C.BYTE_SLICE(&hash))
@@ -59,6 +68,7 @@ func (m *CPPMerkleTree) CurrentRoot() ([]byte, error) {
 	return hash, nil
 }
 
+// RootAtSnapshot returns the root at a given index.
 func (m *CPPMerkleTree) RootAtSnapshot(snapshot uint64) ([]byte, error) {
 	hash := make([]byte, m.nodeSize)
 	success := C.RootAtSnapshot(m.peer, C.BYTE_SLICE(&hash), C.size_t(snapshot))
@@ -82,6 +92,7 @@ func splitSlice(slice []byte, chunkSize int) ([][]byte, error) {
 	return ret, nil
 }
 
+// PathToCurrentRoot returns an audit path to the current root for a given leaf.
 func (m *CPPMerkleTree) PathToCurrentRoot(leaf uint64) ([][]byte, error) {
 	var numEntries C.size_t
 	entryBuffer := make([]byte, C.size_t(m.LevelCount())*m.nodeSize)
@@ -92,20 +103,22 @@ func (m *CPPMerkleTree) PathToCurrentRoot(leaf uint64) ([][]byte, error) {
 	return splitSlice(entryBuffer, int(m.nodeSize))
 }
 
+// PathToRootAtSnapshot returns an audit path to a given root for a given leaf.
 func (m *CPPMerkleTree) PathToRootAtSnapshot(leaf, snapshot uint64) ([][]byte, error) {
-	var num_entries C.size_t
+	var numEntries C.size_t
 	entryBuffer := make([]byte, C.size_t(m.LevelCount())*m.nodeSize)
-	success := C.PathToRootAtSnapshot(m.peer, C.BYTE_SLICE(&entryBuffer), &num_entries, C.size_t(leaf), C.size_t(snapshot))
+	success := C.PathToRootAtSnapshot(m.peer, C.BYTE_SLICE(&entryBuffer), &numEntries, C.size_t(leaf), C.size_t(snapshot))
 	if !success {
 		return nil, fmt.Errorf("failed to get path to root at snapshot %d from leaf %d", snapshot, leaf)
 	}
 	return splitSlice(entryBuffer, int(m.nodeSize))
 }
 
+// SnapshotConsistency returns a consistency proof between two given snapshots.
 func (m *CPPMerkleTree) SnapshotConsistency(snapshot1, snapshot2 uint64) ([][]byte, error) {
-	var num_entries C.size_t
+	var numEntries C.size_t
 	entryBuffer := make([]byte, C.size_t(m.LevelCount())*m.nodeSize)
-	success := C.SnapshotConsistency(m.peer, C.BYTE_SLICE(&entryBuffer), &num_entries, C.size_t(snapshot1), C.size_t(snapshot2))
+	success := C.SnapshotConsistency(m.peer, C.BYTE_SLICE(&entryBuffer), &numEntries, C.size_t(snapshot1), C.size_t(snapshot2))
 	if !success {
 		return nil, fmt.Errorf("failed to get path to snapshot consistency from %d to %d", snapshot1, snapshot2)
 	}

--- a/go/merkletree/merkle_verifier.go
+++ b/go/merkletree/merkle_verifier.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 )
 
+// RootMismatchError occurs when an inclusion proof fails.
 type RootMismatchError struct {
 	ExpectedRoot   []byte
 	CalculatedRoot []byte

--- a/go/serialization.go
+++ b/go/serialization.go
@@ -459,6 +459,7 @@ func deserializeSCTV1(r io.Reader, sct *SignedCertificateTimestamp) error {
 	return nil
 }
 
+// DeserializeSCT reads an SCT from Reader.
 func DeserializeSCT(r io.Reader) (*SignedCertificateTimestamp, error) {
 	var sct SignedCertificateTimestamp
 	if err := binary.Read(r, binary.BigEndian, &sct.SCTVersion); err != nil {


### PR DESCRIPTION
- Add comments to public functions.
- Use camel case for variable names.
- Export types that are returned by public functions. (`GetEntriesResponse`)