### PR TITLE
	Fix RootFromInclusionProof

### DIFF
--- a/go/merkletree/merkle_verifier.go
+++ b/go/merkletree/merkle_verifier.go
@@ -47,15 +47,16 @@ func (m MerkleVerifier) VerifyInclusionProof(leafIndex, treeSize int64, proof []
 }
 
 // RootFromInclusionProof calculates the expected tree root given the proof and leaf.
+// leafIndex starts at 0. treeSize starts at 1.
 func (m MerkleVerifier) RootFromInclusionProof(leafIndex, treeSize int64, proof [][]byte, leaf []byte) ([]byte, error) {
-	if leafIndex > treeSize {
+	if leafIndex >= treeSize {
 		return nil, fmt.Errorf("leafIndex %d > treeSize %d", leafIndex, treeSize)
 	}
-	if leafIndex == 0 {
-		return nil, errors.New("leafIndex is zero")
+	if leafIndex < 0 || treeSize < 1 {
+		return nil, errors.New("leafIndex < 0 or treeSize < 1")
 	}
 
-	node := leafIndex - 1
+	nodeIndex := leafIndex
 	lastNode := treeSize - 1
 	nodeHash := m.treeHasher.HashLeaf(leaf)
 	proofIndex := 0
@@ -64,16 +65,16 @@ func (m MerkleVerifier) RootFromInclusionProof(leafIndex, treeSize int64, proof 
 		if proofIndex == len(proof) {
 			return nil, fmt.Errorf("insuficient number of proof components (%d) for treeSize %d", len(proof), treeSize)
 		}
-		if isRightChild(node) {
+		if isRightChild(nodeIndex) {
 			nodeHash = m.treeHasher.HashChildren(proof[proofIndex], nodeHash)
 			proofIndex++
-		} else if node < lastNode {
+		} else if nodeIndex < lastNode {
 			nodeHash = m.treeHasher.HashChildren(nodeHash, proof[proofIndex])
 			proofIndex++
 		} else {
 			// the sibling does not exist and the parent is a dummy copy; do nothing.
 		}
-		node = parent(node)
+		nodeIndex = parent(nodeIndex)
 		lastNode = parent(lastNode)
 	}
 	if proofIndex != len(proof) {

--- a/go/merkletree/merkle_verifier_test.go
+++ b/go/merkletree/merkle_verifier_test.go
@@ -3,8 +3,11 @@ package merkletree
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/pem"
 	"errors"
 	"fmt"
+	ct "github.com/google/certificate-transparency/go"
+	"io/ioutil"
 	"testing"
 )
 
@@ -19,7 +22,7 @@ func verifierCheck(v *MerkleVerifier, leafIndex, treeSize int64, proof [][]byte,
 		return err
 	}
 	if want := root; !bytes.Equal(got, want) {
-		return fmt.Errorf("got root:\n%v\nexpected:\n%v", got, want)
+		return fmt.Errorf("got root:\n%x\nexpected:\n%x", got, want)
 	}
 	if err := v.VerifyInclusionProof(leafIndex, treeSize, proof, root, leaf); err != nil {
 		return err
@@ -299,9 +302,39 @@ func getConsistencyProofs() []consistencyTestVector {
 	}
 }
 
+func TestVerifyInclusionProofTreeSizeOne(t *testing.T) {
+	v := getVerifier()
+	// Serialized MerkleTreeLeaf from test-cert.pem and test-cert.proof
+	certFile := "../../test/testdata/test-cert.pem"
+	sctFile := "../../test/testdata/test-cert.proof"
+	certB, err := ioutil.ReadFile(certFile)
+	if err != nil {
+		t.Fatalf("Failed to read file %s: %v", certFile, err)
+	}
+	certDER, _ := pem.Decode(certB)
+
+	sctB, err := ioutil.ReadFile(sctFile)
+	if err != nil {
+		t.Fatalf("Failed to read file %s: %v", sctFile, err)
+	}
+	sct, err := ct.DeserializeSCT(bytes.NewBuffer(sctB))
+	if err != nil {
+		t.Fatalf("Failed to deserialize sct: %v", err)
+	}
+
+	b := new(bytes.Buffer)
+	leaf := ct.CreateX509MerkleTreeLeaf(certDER.Bytes, sct.Timestamp)
+	if err := ct.SerializeMerkleTreeLeaf(b, leaf); err != nil {
+		t.Fatalf("Failed to Serialize x509 leaf: %v", err)
+	}
+	// Test output from a real CT instance.
+	if err := verifierCheck(&v, 0, 1, [][]byte{}, dh("04a64b64631b0270d6d204168cd24d0b24b6220c1e5a7efa616ded165bb702e6"), b.Bytes()); err != nil {
+		t.Fatalf("i=%s: %s", "test-cert", err)
+	}
+}
+
 func TestVerifyInclusionProof(t *testing.T) {
 	v := getVerifier()
-
 	path := [][]byte{}
 	// Various invalid paths
 	if err := v.VerifyInclusionProof(0, 0, path, []byte{}, []byte{}); err == nil {
@@ -342,7 +375,7 @@ func TestVerifyInclusionProof(t *testing.T) {
 		for j := int64(0); j < inclusionProofs[i].proofLength; j++ {
 			proof = append(proof, inclusionProofs[i].proof[j].h)
 		}
-		err := verifierCheck(&v, inclusionProofs[i].leaf, inclusionProofs[i].snapshot, proof,
+		err := verifierCheck(&v, inclusionProofs[i].leaf-1, inclusionProofs[i].snapshot, proof,
 			roots[inclusionProofs[i].snapshot-1].h,
 			inputs[inclusionProofs[i].leaf-1].h)
 		if err != nil {


### PR DESCRIPTION
Merge PR #1281 first 

RootFromInclusionProof make the assumption that leafs are indexed from
1. However, upon observation from real output from CT server, leafs
appear to be indexed from 0. After inserting a single entry into an
empty tree, the tree size is 1, and the leaf index is 0.

This CL adds a test to the Go Merkle Tree Verifier for this case and
adjusts the verification algorithm to more closely match the python
implementation.

Fixes #1278