### PR TITLE
Add JSON Serialization functions

### DIFF
--- a/go/serialization.go
+++ b/go/serialization.go
@@ -6,9 +6,11 @@ import (
 	"crypto"
 	"encoding/asn1"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 )
 
 // Variable size structure prefix-header byte lengths
@@ -18,6 +20,7 @@ const (
 	ExtensionsLengthBytes       = 2
 	CertificateChainLengthBytes = 3
 	SignatureLengthBytes        = 2
+	JSONLengthBytes             = 3
 )
 
 // Max lengths
@@ -169,6 +172,13 @@ func SerializeTimestampedEntry(w io.Writer, t *TimestampedEntry) error {
 			return err
 		}
 		if err := writeVarBytes(w, t.PrecertEntry.TBSCertificate, PreCertificateLengthBytes); err != nil {
+			return err
+		}
+	case XJSONLogEntryType:
+		// TODO: Pending google/certificate-transparency#1243, replace
+		// with ObjectHash once supported by CT server.
+		//jsonhash := objecthash.CommonJSONHash(string(t.JSONData))
+		if err := writeVarBytes(w, []byte(t.JSONData), JSONLengthBytes); err != nil {
 			return err
 		}
 	default:
@@ -610,7 +620,7 @@ func SerializeMerkleTreeLeaf(w io.Writer, m *MerkleTreeLeaf) error {
 	return nil
 }
 
-// Create X509 MerkleTreeLeaf generates a MerkleTreeLeaf for an X509 cert
+// CreateX509MerkleTreeLeaf generates a MerkleTreeLeaf for an X509 cert
 func CreateX509MerkleTreeLeaf(cert ASN1Cert, timestamp uint64) *MerkleTreeLeaf {
 	return &MerkleTreeLeaf{
 		Version:  V1,
@@ -619,6 +629,32 @@ func CreateX509MerkleTreeLeaf(cert ASN1Cert, timestamp uint64) *MerkleTreeLeaf {
 			Timestamp: timestamp,
 			EntryType: X509LogEntryType,
 			X509Entry: cert,
+		},
+	}
+}
+
+// CreateJSONMerkleTreeLeaf creates the merkle tree leaf for json data.
+func CreateJSONMerkleTreeLeaf(data interface{}, timestamp uint64) *MerkleTreeLeaf {
+	jsonData, err := json.Marshal(AddJSONRequest{Data: data})
+	if err != nil {
+		return nil
+	}
+	// Match the JSON serialization implemented by json-c
+	jsonStr := strings.Replace(string(jsonData), ":", ": ", -1)
+	jsonStr = strings.Replace(jsonStr, ",", ", ", -1)
+	jsonStr = strings.Replace(jsonStr, "{", "{ ", -1)
+	jsonStr = strings.Replace(jsonStr, "}", " }", -1)
+	jsonStr = strings.Replace(jsonStr, "/", `\/`, -1)
+	// TODO: Pending google/certificate-transparency#1243, replace with
+	// ObjectHash once supported by CT server.
+
+	return &MerkleTreeLeaf{
+		Version:  V1,
+		LeafType: TimestampedEntryLeafType,
+		TimestampedEntry: TimestampedEntry{
+			Timestamp: timestamp,
+			EntryType: XJSONLogEntryType,
+			JSONData:  []byte(jsonStr),
 		},
 	}
 }

--- a/go/serialization_test.go
+++ b/go/serialization_test.go
@@ -518,3 +518,18 @@ func TestX509MerkleTreeLeafHash(t *testing.T) {
 	}
 
 }
+
+func TestJSONMerkleTreeLeaf(t *testing.T) {
+	data := `CioaINV25GV8X4a6M6Q10avSLP9PYd5N8MwWxQvWU7E2CzZ8IgYI0KnavAUSWAoIZDc1NjMzMzMSTAgEEAMaRjBEAiBQlnp6Q3di86g8M3l5gz+9qls/Cz1+KJ+tK/jpaBtUCgIgXaJ94uLsnChA1NY7ocGwKrQwPU688hwaZ5L/DboV4mQ=2`
+	timestamp := uint64(1469664866615)
+	leaf := CreateJSONMerkleTreeLeaf(data, timestamp)
+	b := new(bytes.Buffer)
+	if err := SerializeMerkleTreeLeaf(b, leaf); err != nil {
+		t.Fatalf("Failed to Serialize x509 leaf: %v", err)
+	}
+	leafBytes := dh("0000000001562eda313780000000c67b202264617461223a202243696f61494e563235475638583461364d365131306176534c5039505964354e384d77577851765755374532437a5a3849675949304b6e617641555357416f495a4463314e6a4d7a4d7a4d535441674545414d61526a4245416942516c6e703651336469383667384d336c35677a2b39716c735c2f437a312b4b4a2b744b5c2f6a70614274554367496758614a3934754c736e436841314e59376f6347774b72517750553638386877615a354c5c2f44626f56346d513d3222207d0000")
+
+	if !bytes.Equal(b.Bytes(), leafBytes) {
+		t.Errorf("CreateJSONMerkleTreeLeaf(): got\n%x, want\n%x", b.Bytes(), leafBytes)
+	}
+}

--- a/go/types.go
+++ b/go/types.go
@@ -28,6 +28,8 @@ func (e LogEntryType) String() string {
 		return "X509LogEntryType"
 	case PrecertLogEntryType:
 		return "PrecertLogEntryType"
+	case XJSONLogEntryType:
+		return "XJSONLogEntryType"
 	}
 	panic(fmt.Sprintf("No string defined for LogEntryType constant value %d", e))
 }
@@ -36,6 +38,7 @@ func (e LogEntryType) String() string {
 const (
 	X509LogEntryType    LogEntryType = 0
 	PrecertLogEntryType LogEntryType = 1
+	XJSONLogEntryType   LogEntryType = 0x8000 // Experimental.  Don't rely on this!
 )
 
 // MerkleLeafType represents the MerkleLeafType enum from section 3.4 of the
@@ -238,6 +241,7 @@ type LogEntry struct {
 	Leaf     MerkleTreeLeaf
 	X509Cert *x509.Certificate
 	Precert  *Precertificate
+	JSONData []byte
 	Chain    []ASN1Cert
 }
 
@@ -313,6 +317,7 @@ type TimestampedEntry struct {
 	Timestamp    uint64
 	EntryType    LogEntryType
 	X509Entry    ASN1Cert
+	JSONData     []byte
 	PrecertEntry PreCert
 	Extensions   CTExtensions
 }
@@ -360,4 +365,10 @@ func (e sctError) Error() string {
 	default:
 		return "unknown error"
 	}
+}
+
+// AddJSONRequest represents the JSON request body sent ot the add-json CT
+// method.
+type AddJSONRequest struct {
+	Data interface{} `json:"data"`
 }


### PR DESCRIPTION
Serialize XJSON Merkel Tree Leaf mimics the same encoding style as the json-c library.  This is a temporary implementation until either ObjectHash is used by the XJSON server or Trillian is finished.