### PR TITLE
Parallelize Google cloud scripts

### DIFF
--- a/cloud/google/create_new_cluster.sh
+++ b/cloud/google/create_new_cluster.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-GCLOUD="gcloud"
 if [ "$1" == "" ]; then
   echo "Usage: $0 <config-file>"
   exit 1
@@ -9,6 +8,7 @@ fi
 CONFIG_FILE="$1"
 
 . ${DIR}/config.sh ${CONFIG_FILE}
+GCLOUD="gcloud --project ${PROJECT}"
 
 if [ ! -x ${DIR}/../../cpp/tools/ct-clustertool ]; then
   echo "Please ensure that cpp/tools/ct-clustertool is built."
@@ -18,7 +18,7 @@ fi
 function WaitForEtcd() {
   echo "Waiting for etcd @ ${ETCD_MACHINES[1]}"
   while true; do
-    gcloud compute ssh ${ETCD_MACHINES[1]} \
+    ${GCLOUD} compute ssh ${ETCD_MACHINES[1]} \
         --zone ${ETCD_ZONES[1]} \
         --command "\
      until curl -s -L -m 10 localhost:4001/v2/keys/ > /dev/null; do \
@@ -33,7 +33,7 @@ function WaitForEtcd() {
 function PopulateEtcdForLog() {
   export PUT="curl -s -L -X PUT --retry 10"
   export ETCD="${ETCD_MACHINES[1]}:4001"
-  gcloud compute ssh ${ETCD_MACHINES[1]} \
+  ${GCLOUD} compute ssh ${ETCD_MACHINES[1]} \
       --zone ${ETCD_ZONES[1]} \
       --command "\
     ${PUT} ${ETCD}/v2/keys/root/serving_sth && \
@@ -42,7 +42,7 @@ function PopulateEtcdForLog() {
     ${PUT} ${ETCD}/v2/keys/root/entries/ -d dir=true && \
     ${PUT} ${ETCD}/v2/keys/root/nodes/ -d dir=true"
 
-  gcloud compute ssh ${ETCD_MACHINES[1]} \
+  ${GCLOUD} compute ssh ${ETCD_MACHINES[1]} \
       --zone ${ETCD_ZONES[1]} \
       --command "\
     sudo docker run gcr.io/${PROJECT}/ct-log:test \
@@ -55,7 +55,7 @@ function PopulateEtcdForLog() {
 function PopulateEtcdForMirror() {
   export PUT="curl -s -L -X PUT --retry 10"
   export ETCD="${ETCD_MACHINES[1]}:4001"
-  gcloud compute ssh ${ETCD_MACHINES[1]} \
+  ${GCLOUD} compute ssh ${ETCD_MACHINES[1]} \
       --zone ${ETCD_ZONES[1]} \
       --command "\
     ${PUT} ${ETCD}/v2/keys/root/serving_sth && \
@@ -67,9 +67,6 @@ function PopulateEtcdForMirror() {
 echo "============================================================="
 echo "Creating new GCE-based ${INSTANCE_TYPE} cluster."
 echo "============================================================="
-
-# Set gcloud defaults:
-${GCLOUD} config set project ${PROJECT}
 
 echo "============================================================="
 echo "Creating etcd instances..."

--- a/cloud/google/node_init.sh
+++ b/cloud/google/node_init.sh
@@ -42,7 +42,7 @@ fi
 # TODO(robpercival): For CT mirrors, the path below should be "/data/ctmirror/",
 # not "/data/ctlog/".
 sudo bash ./${AGENT_INSTALL_SCRIPT}
-cat > /tmp/ct-info.conf <<EOF
+sudo cat > /etc/google-fluentd/config.d/ct-info.conf <<EOF
 <source>
   type tail
   format none
@@ -76,7 +76,6 @@ cat > /tmp/ct-info.conf <<EOF
   tag ct-error
 </source>
 EOF
-sudo cp /tmp/ct-info.conf /etc/google-fluentd/config.d/ct-info.conf
 sudo service google-fluentd restart
 # End google-fluentd stuff
 

--- a/cloud/google/start_etcd.sh
+++ b/cloud/google/start_etcd.sh
@@ -8,7 +8,7 @@ source ${DIR}/config.sh $1
 source ${DIR}/util.sh
 
 set -e
-GCLOUD="gcloud"
+GCLOUD="gcloud --project ${PROJECT}"
 
 Header "Creating etcd persistent disks..."
 for i in `seq 0 $((${ETCD_NUM_REPLICAS} - 1))`; do

--- a/cloud/google/start_log.sh
+++ b/cloud/google/start_log.sh
@@ -25,22 +25,28 @@ for i in `seq 0 $((${LOG_NUM_REPLICAS} - 1))`; do
 done
 wait
 
-MANIFEST=/tmp/log_container.yaml
+function create_instance()
+{
+  echo "Creating instance ${LOG_MACHINES[$1]}"
+
+  MANIFEST=$(mktemp)
+  echo "${LOG_META[$1]}" > ${MANIFEST}
+
+  ${GCLOUD} compute instances create -q ${LOG_MACHINES[$1]} \
+      --zone=${LOG_ZONES[$1]} \
+      --machine-type ${LOG_MACHINE_TYPE} \
+      --image container-vm \
+      --disk name=${LOG_DISKS[$1]},mode=rw,boot=no,auto-delete=yes \
+      --tags log-node \
+      --scopes "monitoring,storage-ro,compute-ro,logging-write" \
+      --metadata-from-file startup-script=${DIR}/node_init.sh,google-container-manifest=${MANIFEST}
+
+  rm "${MANIFEST}"
+}
 
 Header "Creating log instances..."
 for i in `seq 0 $((${LOG_NUM_REPLICAS} - 1))`; do
-  echo "Creating instance ${LOG_MACHINES[$i]}"
-
-  echo "${LOG_META[${i}]}" > ${MANIFEST}.${i}
-
-  ${GCLOUD} compute instances create -q ${LOG_MACHINES[${i}]} \
-      --zone=${LOG_ZONES[${i}]} \
-      --machine-type ${LOG_MACHINE_TYPE} \
-      --image container-vm \
-      --disk name=${LOG_DISKS[${i}]},mode=rw,boot=no,auto-delete=yes \
-      --tags log-node \
-      --scopes "monitoring,storage-ro,compute-ro,logging-write" \
-      --metadata-from-file startup-script=${DIR}/node_init.sh,google-container-manifest=${MANIFEST}.${i} &
+  create_instance $i &
 done
 wait
 
@@ -49,5 +55,4 @@ for i in `seq 0 $((${LOG_NUM_REPLICAS} - 1))`; do
   WaitForStatus instances ${LOG_MACHINES[${i}]} ${LOG_ZONES[${i}]} RUNNING &
 done
 wait
-
 

--- a/cloud/google/start_log.sh
+++ b/cloud/google/start_log.sh
@@ -8,7 +8,7 @@ source ${DIR}/util.sh
 source ${DIR}/config.sh $1
 
 set -e
-GCLOUD="gcloud"
+GCLOUD="gcloud --project ${PROJECT}"
 
 Header "Creating log persistent disks..."
 for i in `seq 0 $((${LOG_NUM_REPLICAS} - 1))`; do

--- a/cloud/google/start_mirror.sh
+++ b/cloud/google/start_mirror.sh
@@ -8,7 +8,7 @@ source ${DIR}/config.sh $1
 source ${DIR}/util.sh
 
 set -e
-GCLOUD="gcloud"
+GCLOUD="gcloud --project ${PROJECT}"
 
 Header "Creating mirror persistent disks..."
 for i in `seq 0 $((${MIRROR_NUM_REPLICAS} - 1))`; do

--- a/cloud/google/start_prometheus.sh
+++ b/cloud/google/start_prometheus.sh
@@ -8,7 +8,7 @@ source ${DIR}/config.sh $1
 source ${DIR}/util.sh
 
 set -e
-GCLOUD="gcloud"
+GCLOUD="gcloud --project ${PROJECT}"
 
 Header "Creating prometheus persistent disks..."
 for i in `seq 0 $((${PROMETHEUS_NUM_REPLICAS} - 1))`; do

--- a/cloud/google/start_prometheus.sh
+++ b/cloud/google/start_prometheus.sh
@@ -25,23 +25,29 @@ for i in `seq 0 $((${PROMETHEUS_NUM_REPLICAS} - 1))`; do
 done
 wait
 
-MANIFEST=/tmp/prometheus_container.yaml
+function create_instance()
+{
+  echo "Creating instance ${PROMETHEUS_MACHINES[$1]}"
+
+  MANIFEST=$(mktemp)
+  sed --e "s^@@PROJECT@@^${PROJECT}^
+           s^@@CONTAINER_HOST@@^${PROMETHEUS_MACHINES[$1]}^" \
+      < ${DIR}/prometheus_container.yaml > ${MANIFEST}
+
+  ${GCLOUD} compute instances create -q ${PROMETHEUS_MACHINES[$1]} \
+      --zone ${PROMETHEUS_ZONES[$1]} \
+      --machine-type ${PROMETHEUS_MACHINE_TYPE} \
+      --image container-vm \
+      --disk name=${PROMETHEUS_DISKS[$1]},mode=rw,boot=no,auto-delete=yes \
+      --tags prometheus-node \
+      --metadata-from-file startup-script=${DIR}/node_init.sh,google-container-manifest=${MANIFEST}
+
+  rm "${MANIFEST}"
+}
 
 Header "Creating prometheus instances..."
 for i in `seq 0 $((${PROMETHEUS_NUM_REPLICAS} - 1))`; do
-  echo "Creating instance ${PROMETHEUS_MACHINES[$i]}"
-
-  sed --e "s^@@PROJECT@@^${PROJECT}^
-           s^@@CONTAINER_HOST@@^${PROMETHEUS_MACHINES[$i]}^" \
-      < ${DIR}/prometheus_container.yaml > ${MANIFEST}.${i}
-
-  ${GCLOUD} compute instances create -q ${PROMETHEUS_MACHINES[${i}]} \
-      --zone ${PROMETHEUS_ZONES[${i}]} \
-      --machine-type ${PROMETHEUS_MACHINE_TYPE} \
-      --image container-vm \
-      --disk name=${PROMETHEUS_DISKS[${i}]},mode=rw,boot=no,auto-delete=yes \
-      --tags prometheus-node \
-      --metadata-from-file startup-script=${DIR}/node_init.sh,google-container-manifest=${MANIFEST}.${i} &
+  create_instance $i &
 done
 wait
 

--- a/cloud/google/stop_etcd.sh
+++ b/cloud/google/stop_etcd.sh
@@ -7,7 +7,7 @@ fi
 source ${DIR}/config.sh $1
 source ${DIR}/util.sh
 
-GCLOUD="gcloud"
+GCLOUD="gcloud --project ${PROJECT}"
 
 Header "Deleting etcd instances..."
 for i in `seq 0 $((${ETCD_NUM_REPLICAS} - 1))`; do

--- a/cloud/google/stop_log.sh
+++ b/cloud/google/stop_log.sh
@@ -7,7 +7,7 @@ fi
 source ${DIR}/config.sh $1
 source ${DIR}/util.sh
 
-GCLOUD="gcloud"
+GCLOUD="gcloud --project ${PROJECT}"
 
 Header "Deleting log instances..."
 for i in `seq 0 $((${LOG_NUM_REPLICAS} - 1))`; do

--- a/cloud/google/stop_mirror.sh
+++ b/cloud/google/stop_mirror.sh
@@ -7,7 +7,7 @@ fi
 source ${DIR}/config.sh $1
 source ${DIR}/util.sh
 
-GCLOUD="gcloud"
+GCLOUD="gcloud --project ${PROJECT}"
 
 Header "Deleting mirror instances..."
 for i in `seq 0 $((${MIRROR_NUM_REPLICAS} - 1))`; do

--- a/cloud/google/stop_prometheus.sh
+++ b/cloud/google/stop_prometheus.sh
@@ -7,7 +7,7 @@ fi
 source ${DIR}/config.sh $1
 source ${DIR}/util.sh
 
-GCLOUD="gcloud"
+GCLOUD="gcloud --project ${PROJECT}"
 
 Header "Deleting prometheus instances..."
 for i in `seq 0 $((${PROMETHEUS_NUM_REPLICAS} - 1))`; do

--- a/cloud/google/update_log.sh
+++ b/cloud/google/update_log.sh
@@ -8,7 +8,7 @@ source ${DIR}/util.sh
 source ${DIR}/config.sh $1
 
 set -e
-GCLOUD="gcloud"
+GCLOUD="gcloud --project ${PROJECT}"
 
 Header "Updating log instances..."
 i=0

--- a/cloud/google/update_log.sh
+++ b/cloud/google/update_log.sh
@@ -14,12 +14,14 @@ Header "Updating log instances..."
 i=0
 while [ $i -lt ${LOG_NUM_REPLICAS} ]; do
   echo "Updating ${LOG_MACHINES[${i}]}"
-  echo "${LOG_META[${i}]}" > /tmp/metadata.${i}
+
+  METADATA=$(mktemp)
+  echo "${LOG_META[${i}]}" > ${METADATA}
 
   if ! gcloud compute instances add-metadata \
       ${LOG_MACHINES[${i}]} \
       --zone ${LOG_ZONES[${i}]} \
-      --metadata-from-file google-container-manifest=/tmp/metadata.${i}; then
+      --metadata-from-file google-container-manifest=${METADATA}; then
     echo "Retrying"
     continue
   fi
@@ -35,6 +37,8 @@ while [ $i -lt ${LOG_NUM_REPLICAS} ]; do
 
   WaitHttpStatus ${LOG_MACHINES[${i}]} ${LOG_ZONES[${i}]} /ct/v1/get-sth 200
   i=$(($i + 1))
+
+  rm "${METADATA}"
 done;
 
 

--- a/cloud/google/update_log_vm_image.sh
+++ b/cloud/google/update_log_vm_image.sh
@@ -13,8 +13,6 @@ GCLOUD="gcloud"
 
 ${GCLOUD} config set project ${PROJECT}
 
-MANIFEST=/tmp/log_container.yaml
-
 Header "Recreating log instances..."
 for i in `seq 0 $((${LOG_NUM_REPLICAS} - 1))`; do
   echo "Deleting instance ${LOG_MACHINES[$i]}"
@@ -24,7 +22,8 @@ for i in `seq 0 $((${LOG_NUM_REPLICAS} - 1))`; do
       --keep-disks data
   set -e
 
-  echo "${LOG_META[${i}]}" > ${MANIFEST}.${i}
+  MANIFEST=$(mktemp)
+  echo "${LOG_META[${i}]}" > ${MANIFEST}
 
   echo "Recreating instance ${LOG_MACHINES[$i]}"
   ${GCLOUD} compute instances create -q ${LOG_MACHINES[${i}]} \
@@ -34,7 +33,7 @@ for i in `seq 0 $((${LOG_NUM_REPLICAS} - 1))`; do
       --disk name=${LOG_DISKS[${i}]},mode=rw,boot=no,auto-delete=no \
       --tags log-node \
       --scopes "monitoring,storage-ro,compute-ro,logging-write" \
-      --metadata-from-file startup-script=${DIR}/node_init.sh,google-container-manifest=${MANIFEST}.${i}
+      --metadata-from-file startup-script=${DIR}/node_init.sh,google-container-manifest=${MANIFEST}
 
   gcloud compute instance-groups unmanaged add-instances \
       "log-group-${LOG_ZONES[${i}]}" \
@@ -47,4 +46,5 @@ for i in `seq 0 $((${LOG_NUM_REPLICAS} - 1))`; do
   echo "Waiting for log service on ${LOG_MACHINES[${i}]}..."
   WaitHttpStatus ${LOG_MACHINES[${i}]} ${LOG_ZONES[${i}]} /ct/v1/get-sth 200
   set -e
+  rm "${MANIFEST}"
 done

--- a/cloud/google/update_log_vm_image.sh
+++ b/cloud/google/update_log_vm_image.sh
@@ -11,8 +11,6 @@ source ${DIR}/util.sh
 set -e
 GCLOUD="gcloud --project ${PROJECT}"
 
-${GCLOUD} config set project ${PROJECT}
-
 Header "Recreating log instances..."
 for i in `seq 0 $((${LOG_NUM_REPLICAS} - 1))`; do
   echo "Deleting instance ${LOG_MACHINES[$i]}"

--- a/cloud/google/update_log_vm_image.sh
+++ b/cloud/google/update_log_vm_image.sh
@@ -9,7 +9,7 @@ source ${DIR}/config.sh $1
 source ${DIR}/util.sh
 
 set -e
-GCLOUD="gcloud"
+GCLOUD="gcloud --project ${PROJECT}"
 
 ${GCLOUD} config set project ${PROJECT}
 
@@ -35,7 +35,7 @@ for i in `seq 0 $((${LOG_NUM_REPLICAS} - 1))`; do
       --scopes "monitoring,storage-ro,compute-ro,logging-write" \
       --metadata-from-file startup-script=${DIR}/node_init.sh,google-container-manifest=${MANIFEST}
 
-  gcloud compute instance-groups unmanaged add-instances \
+  ${GCLOUD} compute instance-groups unmanaged add-instances \
       "log-group-${LOG_ZONES[${i}]}" \
       --zone ${LOG_ZONES[${i}]} \
       --instances ${LOG_MACHINES[${i}]} &

--- a/cloud/google/update_mirror.sh
+++ b/cloud/google/update_mirror.sh
@@ -7,7 +7,7 @@ fi
 source ${DIR}/util.sh
 source ${DIR}/config.sh $1
 
-GCLOUD="gcloud"
+GCLOUD="gcloud --project ${PROJECT}"
 
 Header "Updating mirror instances..."
 i=0
@@ -17,7 +17,7 @@ while [ $i -lt ${MIRROR_NUM_REPLICAS} ]; do
   MANIFEST=$(mktemp)
   echo "${MIRROR_META[${i}]}" > ${MANIFEST}
 
-  if ! gcloud compute instances add-metadata \
+  if ! ${GCLOUD} compute instances add-metadata \
       ${MIRROR_MACHINES[${i}]} \
       --zone ${MIRROR_ZONES[${i}]} \
       --metadata-from-file google-container-manifest=${MANIFEST}; then
@@ -25,7 +25,7 @@ while [ $i -lt ${MIRROR_NUM_REPLICAS} ]; do
     continue
   fi
 
-  if ! gcloud compute ssh ${MIRROR_MACHINES[${i}]} \
+  if ! ${GCLOUD} compute ssh ${MIRROR_MACHINES[${i}]} \
       --zone ${MIRROR_ZONES[${i}]} \
       --command \
           'sudo docker pull gcr.io/'${PROJECT}'/ct-mirror:test &&

--- a/cloud/google/update_mirror.sh
+++ b/cloud/google/update_mirror.sh
@@ -13,16 +13,17 @@ Header "Updating mirror instances..."
 i=0
 while [ $i -lt ${MIRROR_NUM_REPLICAS} ]; do
   echo "Updating ${MIRROR_MACHINES[${i}]}"
-  echo "${MIRROR_META[${i}]}" > /tmp/metadata.${i}
+
+  MANIFEST=$(mktemp)
+  echo "${MIRROR_META[${i}]}" > ${MANIFEST}
 
   if ! gcloud compute instances add-metadata \
       ${MIRROR_MACHINES[${i}]} \
       --zone ${MIRROR_ZONES[${i}]} \
-      --metadata-from-file google-container-manifest=/tmp/metadata.${i}; then
+      --metadata-from-file google-container-manifest=${MANIFEST}; then
     echo "Retrying"
     continue
   fi
-  
 
   if ! gcloud compute ssh ${MIRROR_MACHINES[${i}]} \
       --zone ${MIRROR_ZONES[${i}]} \
@@ -35,6 +36,7 @@ while [ $i -lt ${MIRROR_NUM_REPLICAS} ]; do
 
   WaitHttpStatus ${MIRROR_MACHINES[${i}]} ${MIRROR_ZONES[${i}]} /ct/v1/get-sth 200
   i=$(($i + 1))
+  rm "${MANIFEST}"
 done;
 
 

--- a/cloud/google/update_mirror_vm_image.sh
+++ b/cloud/google/update_mirror_vm_image.sh
@@ -12,33 +12,39 @@ GCLOUD="gcloud"
 
 ${GCLOUD} config set project ${PROJECT}
 
-MANIFEST=/tmp/mirror_container.yaml
-
-Header "Recreating mirror instances..."
-for i in `seq 0 $((${MIRROR_NUM_REPLICAS} - 1))`; do
-  echo "Deleting instance ${MIRROR_MACHINES[$i]}"
+function recreate_instance()
+{
+  echo "Deleting instance ${MIRROR_MACHINES[$1]}"
   set +e
-   ${GCLOUD} compute instances delete -q ${MIRROR_MACHINES[${i}]} \
-      --zone ${MIRROR_ZONES[${i}]} \
+   ${GCLOUD} compute instances delete -q ${MIRROR_MACHINES[$1]} \
+      --zone ${MIRROR_ZONES[$1]} \
       --keep-disks data
   set -e
 
-  echo "${MIRROR_META[${i}]}" > ${MANIFEST}.${i}
+  MANIFEST=$(mktemp)
+  echo "${MIRROR_META[$1]}" > ${MANIFEST}
 
-  echo "Recreating instance ${MIRROR_MACHINES[$i]}"
-  ${GCLOUD} compute instances create -q ${MIRROR_MACHINES[${i}]} \
-      --zone ${MIRROR_ZONES[${i}]} \
+  echo "Recreating instance ${MIRROR_MACHINES[$1]}"
+  ${GCLOUD} compute instances create -q ${MIRROR_MACHINES[$1]} \
+      --zone ${MIRROR_ZONES[$1]} \
       --machine-type ${MIRROR_MACHINE_TYPE} \
       --image container-vm \
-      --disk name=${MIRROR_DISKS[${i}]},mode=rw,boot=no,auto-delete=no \
+      --disk name=${MIRROR_DISKS[$1]},mode=rw,boot=no,auto-delete=no \
       --tags mirror-node \
       --scopes "monitoring,storage-ro,compute-ro,logging-write" \
-      --metadata-from-file startup-script=${DIR}/node_init.sh,google-container-manifest=${MANIFEST}.${i}
+      --metadata-from-file startup-script=${DIR}/node_init.sh,google-container-manifest=${MANIFEST}
+
+  rm "${MANIFEST}"
 
   gcloud compute instance-groups unmanaged add-instances \
-      "mirror-group-${MIRROR_ZONES[${i}]}" \
-      --zone ${MIRROR_ZONES[${i}]} \
-      --instances ${MIRROR_MACHINES[${i}]} &
+      "mirror-group-${MIRROR_ZONES[$1]}" \
+      --zone ${MIRROR_ZONES[$1]} \
+      --instances ${MIRROR_MACHINES[$1]} &
+}
+
+Header "Recreating mirror instances..."
+for i in `seq 0 $((${MIRROR_NUM_REPLICAS} - 1))`; do
+  recreate_instance $i
 
   set +e
   echo "Waiting for instance ${MIRROR_MACHINES[${i}]}..."

--- a/cloud/google/update_mirror_vm_image.sh
+++ b/cloud/google/update_mirror_vm_image.sh
@@ -8,7 +8,7 @@ source ${DIR}/config.sh $1
 source ${DIR}/util.sh
 
 set -e
-GCLOUD="gcloud"
+GCLOUD="gcloud --project ${PROJECT}"
 
 ${GCLOUD} config set project ${PROJECT}
 
@@ -36,7 +36,7 @@ function recreate_instance()
 
   rm "${MANIFEST}"
 
-  gcloud compute instance-groups unmanaged add-instances \
+  ${GCLOUD} compute instance-groups unmanaged add-instances \
       "mirror-group-${MIRROR_ZONES[$1]}" \
       --zone ${MIRROR_ZONES[$1]} \
       --instances ${MIRROR_MACHINES[$1]} &

--- a/cloud/google/update_mirror_vm_image.sh
+++ b/cloud/google/update_mirror_vm_image.sh
@@ -26,7 +26,8 @@ function recreate_instance()
   ${GCLOUD} compute instances create -q ${MIRROR_MACHINES[$1]} \
       --zone ${MIRROR_ZONES[$1]} \
       --machine-type ${MIRROR_MACHINE_TYPE} \
-      --image container-vm \
+      --image-family=container-vm \
+      --image-project=google-containers \
       --disk name=${MIRROR_DISKS[$1]},mode=rw,boot=no,auto-delete=no \
       --tags mirror-node \
       --scopes "monitoring,storage-ro,compute-ro,logging-write" \

--- a/cloud/google/update_mirror_vm_image.sh
+++ b/cloud/google/update_mirror_vm_image.sh
@@ -10,8 +10,6 @@ source ${DIR}/util.sh
 set -e
 GCLOUD="gcloud --project ${PROJECT}"
 
-${GCLOUD} config set project ${PROJECT}
-
 function recreate_instance()
 {
   echo "Deleting instance ${MIRROR_MACHINES[$1]}"

--- a/cloud/google/update_prometheus_config.sh
+++ b/cloud/google/update_prometheus_config.sh
@@ -25,7 +25,7 @@ ETCD_HOSTS=$(
     echo -n "    - ${i}.c.${PROJECT}.internal:8080\n";
   done)
 
-export TMP_CONFIG=/tmp/prometheus.conf
+export TMP_CONFIG=$(mktemp)
 sed -- "s%@@LOG_TARGETS@@%${LOG_HOSTS}%g
         s%@@MIRROR_TARGETS@@%${MIRROR_HOSTS}%g
         s%@@ETCD_TARGETS@@%${ETCD_HOSTS}%g" < ${DIR}/../prometheus/prometheus.conf > ${TMP_CONFIG}
@@ -61,3 +61,5 @@ for i in `seq 0 $((${PROMETHEUS_NUM_REPLICAS} - 1))`; do
       echo "Prometheus container not yet running."
     fi'
 done
+
+rm ${TMP_CONFIG}

--- a/cloud/google/update_prometheus_config.sh
+++ b/cloud/google/update_prometheus_config.sh
@@ -8,7 +8,7 @@ source ${DIR}/config.sh $1
 source ${DIR}/util.sh
 
 set -e
-GCLOUD="gcloud"
+GCLOUD="gcloud --project ${PROJECT}"
 
 LOG_HOSTS=$(
   for i in ${LOG_MACHINES[@]}; do
@@ -37,12 +37,12 @@ for i in `seq 0 $((${PROMETHEUS_NUM_REPLICAS} - 1))`; do
   WaitMachineUp ${INSTANCE} ${ZONE}
 
   # Workaround copy-files ignoring the --zone flag:
-  gcloud config set compute/zone ${ETCD_ZONES[1]}
+  ${GCLOUD} config set compute/zone ${ETCD_ZONES[1]}
   ${GCLOUD} compute copy-files \
       --zone ${ZONE} \
       ${TMP_CONFIG} ${INSTANCE}:.
   # Remove workaround
-  gcloud config unset compute/zone
+  ${GCLOUD} config unset compute/zone
 
   ${GCLOUD} compute ssh ${INSTANCE} \
       --zone ${ZONE} \


### PR DESCRIPTION
Key changes:
- No longer relies on the gcloud default project being set.
- No longer uses hard-coded tmp file paths.

These changes allow the scripts to be run in parallel without conflicting.