### PR TITLE
Have CertChecker::CheckIssuerChain log better.

### DIFF
--- a/cpp/log/cert_checker.cc
+++ b/cpp/log/cert_checker.cc
@@ -152,7 +152,7 @@ Status CertChecker::CheckIssuerChain(CertChain* chain) const {
   // because we will later check that it is trusted.
   Status status = chain->IsValidCaIssuerChainMaybeLegacyRoot();
   if (!status.ok()) {
-    LOG(ERROR) << "Failed to check issuer chain";
+    LOG(ERROR) << "Failed to check issuer chain: " << status;
     return Status(status.CanonicalCode(), "invalid certificate chain");
   }
 


### PR DESCRIPTION
If we have a non-OK status and we're logging a message, it should have the status in it!
