### PR TITLE
Log status when we fail to init leveldb

### DIFF
--- a/cpp/log/leveldb_db.cc
+++ b/cpp/log/leveldb_db.cc
@@ -333,8 +333,8 @@ void LevelDB::InitializeNode(const string& node_id) {
                                   string(kMetaPrefix) + kMetaNodeIdKey,
                                   &existing_id));
   if (!status.IsNotFound()) {
-    LOG(FATAL) << "Attempting to initialize DB beloging to node with node_id: "
-               << existing_id;
+    LOG(FATAL) << "Attempting to init DB belonging to node with node_id: "
+               << existing_id << " got status: " << status.ToString();
   }
   status = db_->Put(leveldb::WriteOptions(),
                     string(kMetaPrefix) + kMetaNodeIdKey, node_id);


### PR DESCRIPTION
Mirrors are crashing at this point, collecting more info.