### PR TITLE
Bump etcd to v2.1.3 and stop using IPs in client/peer listen URLs

### DIFF
--- a/cloud/etcd/Dockerfile
+++ b/cloud/etcd/Dockerfile
@@ -5,16 +5,14 @@ RUN \
  env DEBIAN_FRONTEND=noninteractive apt-get install -y curl
 RUN \
  cd /tmp && \
- (curl -L  https://github.com/coreos/etcd/releases/download/v2.0.9/etcd-v2.0.9-linux-amd64.tar.gz | tar -xz) && \
+ (curl -L  https://github.com/coreos/etcd/releases/download/v2.1.3/etcd-v2.1.3-linux-amd64.tar.gz | tar -xz) && \
  mkdir -p /opt/etcd/bin && \
- cp -v /tmp/etcd-v2.0.9-linux-amd64/etcd /opt/etcd/bin && \
- cp -v /tmp/etcd-v2.0.9-linux-amd64/etcdctl /opt/etcd/bin && \
- rm -rf /tmp/etcd-v2.0.9-linux-amd64
+ cp -v /tmp/etcd-v2.1.3-linux-amd64/etcd /opt/etcd/bin && \
+ cp -v /tmp/etcd-v2.1.3-linux-amd64/etcdctl /opt/etcd/bin && \
+ rm -rf /tmp/etcd-v2.1.3-linux-amd64
 WORKDIR /opt/etcd
 VOLUME ["/opt/etcd/data"]
-CMD MY_IP=$(awk "/${HOSTNAME}/ {print \$1}" < /etc/hosts) && \
-    export HEARTBEAT_INTERVAL=${HEARTBEAT_INTERVAL:-100} && \
-    echo "My IP: ${MY_IP}" && \
+CMD export HEARTBEAT_INTERVAL=${HEARTBEAT_INTERVAL:-100} && \
     echo "Container host: ${CONTAINER_HOST}" && \
     echo "My Discovery: ${DISCOVERY}" && \
     echo "Heartbeat interval: ${HEARTBEAT_INTERVAL}" && \
@@ -22,8 +20,8 @@ CMD MY_IP=$(awk "/${HOSTNAME}/ {print \$1}" < /etc/hosts) && \
           --name=${ETCD_NAME} \
           --advertise-client-urls=http://${CONTAINER_HOST}:4001 \
           --initial-advertise-peer-urls=http://${CONTAINER_HOST}:7001 \
-          --listen-client-urls=http://${MY_IP}:4001 \
-          --listen-peer-urls=http://${MY_IP}:7001 \
+          --listen-client-urls=http://:4001 \
+          --listen-peer-urls=http://:7001 \
           --data-dir=/opt/etcd/data \
           --heartbeat-interval=${HEARTBEAT_INTERVAL} \
           --election-timeout=6000


### PR DESCRIPTION
etcd v2.1.3 can read and upgrade v2.0.9's DB format on the fly.