### PR TITLE
travis: On OSX add user's pip dir to PATH

### DIFF
--- a/build/travis.osx.before_install.sh
+++ b/build/travis.osx.before_install.sh
@@ -15,3 +15,6 @@ brew upgrade go
 for i in homebrew/dupes/tcl-tk ant; do
 	brew install $i
 done
+
+# Python tests rely on Twisted's trial script being in the path
+export PATH=$PATH:${HOME}/Library/Python/2.7/bin


### PR DESCRIPTION
Some of the Python unit tests rely on executing trial, which
is a script provided by Twisted.  The pip --user install puts
this into a local directory, so make sure that directory is in
the path