### PR TITLE
[RFC] Extract common code in preparation for RFC6962-bis

### DIFF
--- a/go/client/ctclient/ctclient.go
+++ b/go/client/ctclient/ctclient.go
@@ -26,7 +26,7 @@ func ctTimestampToTime(ts uint64) time.Time {
 }
 
 func signatureToString(signed *ct.DigitallySigned) string {
-	return fmt.Sprintf("Signature: Hash=%v Sign=%v Value=%x", signed.HashAlgorithm, signed.SignatureAlgorithm, signed.Signature)
+	return fmt.Sprintf("Signature: Hash=%v Sign=%v Value=%x", signed.Algorithm.Hash, signed.Algorithm.Signature, signed.Signature)
 }
 
 func getSTH(logClient *client.LogClient) {

--- a/go/client/logclient.go
+++ b/go/client/logclient.go
@@ -7,17 +7,14 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"strconv"
-	"time"
 
 	ct "github.com/google/certificate-transparency/go"
+	"github.com/google/certificate-transparency/go/jsonclient"
 	"golang.org/x/net/context"
 )
 
@@ -34,9 +31,7 @@ const (
 
 // LogClient represents a client for a given CT Log instance
 type LogClient struct {
-	uri        string                // the base URI of the log. e.g. http://ct.googleapis/pilot
-	httpClient *http.Client          // used to interact with the log via HTTP
-	verifier   *ct.SignatureVerifier // nil if no public key for log available
+	jsonclient.JSONClient
 }
 
 //////////////////////////////////////////////////////////////////////////////////
@@ -91,7 +86,7 @@ type getAcceptedRootsResponse struct {
 	Certificates []string `json:"certificates"`
 }
 
-// getEntryAndProodReponse represents the JSON response to the CT get-entry-and-proof method
+// getEntryAndProofReponse represents the JSON response to the CT get-entry-and-proof method
 type getEntryAndProofResponse struct {
 	LeafInput string   `json:"leaf_input"` // the entry itself
 	ExtraData string   `json:"extra_data"` // any chain provided when the entry was added to the log
@@ -109,168 +104,37 @@ type GetProofByHashResponse struct {
 // http://ct.googleapis.com/pilot
 // |hc| is the underlying client to be used for HTTP requests to the CT log.
 func New(uri string, hc *http.Client) *LogClient {
-	if hc == nil {
-		hc = new(http.Client)
+	logClient, err := jsonclient.NewWithoutVerification(uri, hc)
+	if err != nil {
+		panic(fmt.Sprintf("JSONClient creation failed: %v" + err.Error()))
 	}
-	return &LogClient{uri: uri, httpClient: hc}
+	return &LogClient{*logClient}
 }
 
 // NewWithPubKey constructs a new LogClient instance that includes public
 // key information for the log; this instance will check signatures on
 // responses from the log.
 func NewWithPubKey(uri string, hc *http.Client, pemEncodedKey string) (*LogClient, error) {
-	pubkey, _, rest, err := ct.PublicKeyFromPEM([]byte(pemEncodedKey))
-	if err != nil {
-		return nil, err
-	}
-	if len(rest) > 0 {
-		return nil, errors.New("extra data found after PEM key decoded")
-	}
-
-	verifier, err := ct.NewSignatureVerifier(pubkey)
-	if err != nil {
-		return nil, err
-	}
-
-	if hc == nil {
-		hc = new(http.Client)
-	}
-	return &LogClient{uri: uri, httpClient: hc, verifier: verifier}, nil
-}
-
-// Makes a HTTP call to |uri|, and attempts to parse the response as a
-// JSON representation of the structure in |res|. Uses |ctx| to
-// control the HTTP call (so it can have a timeout or be cancelled by
-// the caller), and |httpClient| to make the actual HTTP call.
-// Returns a non-nil |error| if there was a problem.
-func fetchAndParse(ctx context.Context, httpClient *http.Client, uri string, res interface{}) error {
-	req, err := http.NewRequest(http.MethodGet, uri, nil)
-	if err != nil {
-		return err
-	}
-	req.Cancel = ctx.Done()
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	// Make sure everything is read, so http.Client can reuse the connection.
-	defer ioutil.ReadAll(resp.Body)
-
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("got HTTP Status %s", resp.Status)
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(res); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// Makes a HTTP POST call to |uri|, and attempts to parse the response as a JSON
-// representation of the structure in |res|.
-// Returns a non-nil |error| if there was a problem.
-func (c *LogClient) postAndParse(uri string, req interface{}, res interface{}) (*http.Response, string, error) {
-	postBody, err := json.Marshal(req)
-	if err != nil {
-		return nil, "", err
-	}
-	httpReq, err := http.NewRequest(http.MethodPost, uri, bytes.NewReader(postBody))
-	if err != nil {
-		return nil, "", err
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	resp, err := c.httpClient.Do(httpReq)
-	// Read all of the body, if there is one, so that the http.Client can do
-	// Keep-Alive:
-	var body []byte
-	if resp != nil {
-		body, err = ioutil.ReadAll(resp.Body)
-		resp.Body.Close()
-	}
-	if err != nil {
-		return resp, string(body), err
-	}
-	if resp.StatusCode == 200 {
-		if err != nil {
-			return resp, string(body), err
-		}
-		if err = json.Unmarshal(body, &res); err != nil {
-			return resp, string(body), err
-		}
-	}
-	return resp, string(body), nil
-}
-
-func backoffForRetry(ctx context.Context, d time.Duration) error {
-	backoffTimer := time.NewTimer(d)
-	if ctx != nil {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-backoffTimer.C:
-		}
-	} else {
-		<-backoffTimer.C
-	}
-	return nil
+	logClient, err := jsonclient.New(uri, hc, pemEncodedKey)
+	return &LogClient{*logClient}, err
 }
 
 // Attempts to add |chain| to the log, using the api end-point specified by
 // |path|. If provided context expires before submission is complete an
 // error will be returned.
 func (c *LogClient) addChainWithRetry(ctx context.Context, ctype ct.LogEntryType, path string, chain []ct.ASN1Cert) (*ct.SignedCertificateTimestamp, error) {
+	if ctx == nil {
+		ctx = context.TODO()
+	}
 	var resp addChainResponse
 	var req addChainRequest
 	for _, link := range chain {
 		req.Chain = append(req.Chain, link)
 	}
-	httpStatus := "Unknown"
-	// Retry after 1s, 2s, 4s, 8s, 16s, 32s, 64s, 128s, 128s, ....
-	maxInterval := 128.0
-	backoffInterval := 1.0
-	backoffSeconds := 0
-loop:
-	for {
-		if backoffSeconds > 0 {
-			log.Printf("Got %s, backing-off %d seconds", httpStatus, backoffSeconds)
-		}
-		err := backoffForRetry(ctx, time.Second*time.Duration(backoffSeconds))
-		if err != nil {
-			return nil, err
-		}
-		if backoffSeconds > 0 {
-			backoffSeconds = 0
-		}
-		httpResp, _, err := c.postAndParse(c.uri+path, &req, &resp)
-		if err != nil {
-			backoffSeconds = int(backoffInterval)
-			if backoffInterval < maxInterval {
-				backoffInterval *= 2.0
-			}
-			continue
-		}
-		switch {
-		case httpResp.StatusCode == 200:
-			break loop
-		case httpResp.StatusCode == 408:
-			// request timeout, retry immediately
-		case httpResp.StatusCode == 503:
-			// Retry
-			backoffSeconds = int(backoffInterval)
-			if backoffInterval < maxInterval {
-				backoffInterval *= 2.0
-			}
-			if retryAfter := httpResp.Header.Get("Retry-After"); retryAfter != "" {
-				if seconds, err := strconv.Atoi(retryAfter); err == nil {
-					backoffSeconds = seconds
-				}
-			}
-		default:
-			return nil, fmt.Errorf("got HTTP Status %s", httpResp.Status)
-		}
-		httpStatus = httpResp.Status
+
+	_, err := c.PostAndParseWithRetry(ctx, path, &req, &resp)
+	if err != nil {
+		return nil, err
 	}
 
 	ds, err := ct.UnmarshalDigitallySigned(bytes.NewReader(resp.Signature))
@@ -315,7 +179,7 @@ func (c *LogClient) AddJSON(data interface{}) (*ct.SignedCertificateTimestamp, e
 		Data: data,
 	}
 	var resp addChainResponse
-	_, _, err := c.postAndParse(c.uri+AddJSONPath, &req, &resp)
+	_, err := c.PostAndParse(context.TODO(), AddJSONPath, &req, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -337,7 +201,8 @@ func (c *LogClient) AddJSON(data interface{}) (*ct.SignedCertificateTimestamp, e
 // Returns a populated SignedTreeHead, or a non-nil error.
 func (c *LogClient) GetSTH() (sth *ct.SignedTreeHead, err error) {
 	var resp getSTHResponse
-	if err = fetchAndParse(context.TODO(), c.httpClient, c.uri+GetSTHPath, &resp); err != nil {
+	_, err = c.GetAndParse(context.TODO(), GetSTHPath, nil, &resp)
+	if err != nil {
 		return
 	}
 	sth = &ct.SignedTreeHead{
@@ -365,16 +230,16 @@ func (c *LogClient) GetSTH() (sth *ct.SignedTreeHead, err error) {
 // VerifySTHSignature checks the signature in sth, returning any error encountered or nil if verification is
 // successful.
 func (c *LogClient) VerifySTHSignature(sth ct.SignedTreeHead) error {
-	if c.verifier == nil {
+	if c.Verifier == nil {
 		// Can't verify signatures without a verifier
 		return nil
 	}
-	return c.verifier.VerifySTHSignature(sth)
+	return c.Verifier.VerifySTHSignature(sth)
 }
 
 // VerifySCTSignature checks the signature in sct for the given LogEntryType, with associated certificate chain.
 func (c *LogClient) VerifySCTSignature(sct ct.SignedCertificateTimestamp, ctype ct.LogEntryType, certData []ct.ASN1Cert) error {
-	if c.verifier == nil {
+	if c.Verifier == nil {
 		// Can't verify signatures without a verifier
 		return nil
 	}
@@ -396,14 +261,19 @@ func (c *LogClient) VerifySCTSignature(sct ct.SignedCertificateTimestamp, ctype 
 			X509Entry:  certData[0],
 			Extensions: sct.Extensions}}
 	entry := ct.LogEntry{Leaf: leaf}
-	return c.verifier.VerifySCTSignature(sct, entry)
+	return c.Verifier.VerifySCTSignature(sct, entry)
 }
 
 // GetSTHConsistency retrieves the consistency proof between two snapshots.
 func (c *LogClient) GetSTHConsistency(ctx context.Context, first, second uint64) ([][]byte, error) {
-	u := fmt.Sprintf("%s%s?first=%d&second=%d", c.uri, GetSTHConsistencyPath, first, second)
+	base10 := 10
+	params := map[string]string{
+		"first":  strconv.FormatUint(first, base10),
+		"second": strconv.FormatUint(second, base10),
+	}
 	var resp getConsistencyProofResponse
-	if err := fetchAndParse(ctx, c.httpClient, u, &resp); err != nil {
+	_, err := c.GetAndParse(ctx, GetSTHConsistencyPath, params, &resp)
+	if err != nil {
 		return nil, err
 	}
 	return resp.Consistency, nil
@@ -412,9 +282,14 @@ func (c *LogClient) GetSTHConsistency(ctx context.Context, first, second uint64)
 // GetProofByHash returns an audit path for the hash of an SCT.
 func (c *LogClient) GetProofByHash(ctx context.Context, hash []byte, treeSize uint64) (*GetProofByHashResponse, error) {
 	b64Hash := url.QueryEscape(base64.StdEncoding.EncodeToString(hash))
-	u := fmt.Sprintf("%s%s?tree_size=%d&hash=%v", c.uri, GetProofByHashPath, treeSize, b64Hash)
+	base10 := 10
+	params := map[string]string{
+		"tree_size": strconv.FormatUint(treeSize, base10),
+		"hash":      b64Hash,
+	}
 	var resp GetProofByHashResponse
-	if err := fetchAndParse(ctx, c.httpClient, u, &resp); err != nil {
+	_, err := c.GetAndParse(ctx, GetProofByHashPath, params, &resp)
+	if err != nil {
 		return nil, err
 	}
 	return &resp, nil

--- a/go/client/logclient_test.go
+++ b/go/client/logclient_test.go
@@ -156,11 +156,11 @@ func TestGetSTHWorks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't unmarshal DigitallySigned: %v", err)
 	}
-	if sth.TreeHeadSignature.HashAlgorithm != expectedDS.HashAlgorithm {
-		t.Fatalf("Invalid TreeHeadSignature.HashAlgorithm: expected %v, got %v", sth.TreeHeadSignature.HashAlgorithm, expectedDS.HashAlgorithm)
+	if sth.TreeHeadSignature.Algorithm.Hash != expectedDS.Algorithm.Hash {
+		t.Fatalf("Invalid TreeHeadSignature.Algorithm.Hash: expected %v, got %v", sth.TreeHeadSignature.Algorithm.Hash, expectedDS.Algorithm.Hash)
 	}
-	if sth.TreeHeadSignature.SignatureAlgorithm != expectedDS.SignatureAlgorithm {
-		t.Fatalf("Invalid TreeHeadSignature.SignatureAlgorithm: expected %v, got %v", sth.TreeHeadSignature.SignatureAlgorithm, expectedDS.SignatureAlgorithm)
+	if sth.TreeHeadSignature.Algorithm.Signature != expectedDS.Algorithm.Signature {
+		t.Fatalf("Invalid TreeHeadSignature.Algorithm.Signature: expected %v, got %v", sth.TreeHeadSignature.Algorithm.Signature, expectedDS.Algorithm.Signature)
 	}
 	if bytes.Compare(sth.TreeHeadSignature.Signature, expectedDS.Signature) != 0 {
 		t.Fatalf("Invalid TreeHeadSignature.Signature: expected %v, got %v", sth.TreeHeadSignature.Signature, expectedDS.Signature)

--- a/go/jsonclient/client.go
+++ b/go/jsonclient/client.go
@@ -1,0 +1,204 @@
+package jsonclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	ct "github.com/google/certificate-transparency/go"
+	"golang.org/x/net/context"
+	"golang.org/x/net/context/ctxhttp"
+)
+
+// JSONClient provides common functionality for interacting with a JSON server
+// that uses cryptographic signatures.
+type JSONClient struct {
+	uri        string                // the base URI of the server. e.g. http://ct.googleapis/pilot
+	httpClient *http.Client          // used to interact with the server via HTTP
+	Verifier   *ct.SignatureVerifier // nil for no verification (e.g. no public key available)
+}
+
+// New constructs a new JSONClient instance, for the given base URI, using the
+// given http.Client object (if provided) and (PEM encoded) public key.
+func New(uri string, hc *http.Client, pemKey string) (*JSONClient, error) {
+	var verifier *ct.SignatureVerifier
+	pubkey, _ /* keyhash */, rest, err := ct.PublicKeyFromPEM([]byte(pemKey))
+	if err != nil {
+		return nil, err
+	}
+	if len(rest) > 0 {
+		return nil, errors.New("extra data found after PEM key decoded")
+	}
+
+	verifier, err = ct.NewSignatureVerifier(pubkey)
+	if err != nil {
+		return nil, err
+	}
+	if hc == nil {
+		hc = new(http.Client)
+	}
+	client := &JSONClient{
+		uri:        strings.TrimRight(uri, "/"),
+		httpClient: hc,
+		Verifier:   verifier}
+	return client, nil
+}
+
+// NewWithoutVerification constructs a new JSONClient instance, for the given
+// base URI, using the given http.Client object (if provided); however, this
+// client will not perform verification of signed responses from the server.
+func NewWithoutVerification(uri string, hc *http.Client) (*JSONClient, error) {
+	if hc == nil {
+		hc = new(http.Client)
+	}
+	return &JSONClient{uri: strings.TrimRight(uri, "/"), httpClient: hc}, nil
+}
+
+// GetAndParse makes a HTTP GET call to the given path, and attempt to parse
+// the response as a JSON representation of the rsp structure.  The provided
+// context is used to control the HTTP call.
+func (c *JSONClient) GetAndParse(ctx context.Context, path string, params map[string]string, rsp interface{}) (*http.Response, error) {
+	if ctx == nil {
+		return nil, errors.New("context.Context required")
+	}
+	// Build a GET request with URL-encoded parameters.
+	vals := url.Values{}
+	for k, v := range params {
+		vals.Add(k, v)
+	}
+	fullURI := fmt.Sprintf("%s%s?%s", c.uri, path, vals.Encode())
+	httpReq, err := http.NewRequest(http.MethodGet, fullURI, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	httpRsp, err := ctxhttp.Do(ctx, c.httpClient, httpReq)
+	if err != nil {
+		return nil, err
+	}
+	// Make sure everything is read, so http.Client can reuse the connection.
+	defer httpRsp.Body.Close()
+	defer ioutil.ReadAll(httpRsp.Body)
+
+	if httpRsp.StatusCode != http.StatusOK {
+		return httpRsp, fmt.Errorf("got HTTP Status %q", httpRsp.Status)
+	}
+
+	if err := json.NewDecoder(httpRsp.Body).Decode(rsp); err != nil {
+		return httpRsp, err
+	}
+
+	return httpRsp, nil
+}
+
+// PostAndParse makes a HTTP POST call to the given path, including the request
+// parameters, and attempt to parse the response as a JSON representation of
+// the rsp structure.  The provided context is used the control the HTTP call.
+func (c *JSONClient) PostAndParse(ctx context.Context, path string, req, rsp interface{}) (*http.Response, error) {
+	if ctx == nil {
+		return nil, errors.New("context.Context required")
+	}
+	// Build a POST request with JSON body.
+	postBody, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	fullURI := fmt.Sprintf("%s%s", c.uri, path)
+	httpReq, err := http.NewRequest(http.MethodPost, fullURI, bytes.NewReader(postBody))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpRsp, err := ctxhttp.Do(ctx, c.httpClient, httpReq)
+
+	// Read all of the body, if there is one, so that the http.Client can do Keep-Alive.
+	var body []byte
+	if httpRsp != nil {
+		body, err = ioutil.ReadAll(httpRsp.Body)
+		httpRsp.Body.Close()
+	}
+	if err != nil {
+		return httpRsp, err
+	}
+	if httpRsp.StatusCode == http.StatusOK {
+		if err = json.Unmarshal(body, &rsp); err != nil {
+			return httpRsp, err
+		}
+	}
+	return httpRsp, nil
+}
+
+// PostAndParseWithRetry makes a HTTP POST call, but retries (with backoff) on
+// retriable errors.
+func (c *JSONClient) PostAndParseWithRetry(ctx context.Context, path string, req, rsp interface{}) (*http.Response, error) {
+	if ctx == nil {
+		return nil, errors.New("context.Context required")
+	}
+	httpStatus := "Unknown"
+	// Retry after 1s, 2s, 4s, 8s, 16s, 32s, 64s, 128s, 128s, ....
+	maxInterval := 128 * time.Second
+	backoffInterval := 1 * time.Second
+	backoffSeconds := time.Duration(0)
+	for {
+		if backoffSeconds > 0 {
+			log.Printf("Got %q, backing-off %v", httpStatus, backoffSeconds)
+		}
+		err := backoffForRetry(ctx, backoffSeconds)
+		if err != nil {
+			return nil, err
+		}
+		if backoffSeconds > 0 {
+			backoffSeconds = time.Duration(0)
+		}
+		httpRsp, err := c.PostAndParse(ctx, path, req, rsp)
+		if err != nil {
+			backoffSeconds = backoffInterval
+			backoffInterval *= 2.0
+			if backoffInterval > maxInterval {
+				backoffInterval = maxInterval
+			}
+			continue
+		}
+		switch {
+		case httpRsp.StatusCode == http.StatusOK:
+			return httpRsp, nil
+		case httpRsp.StatusCode == http.StatusRequestTimeout:
+			// Request timeout, retry immediately
+		case httpRsp.StatusCode == http.StatusServiceUnavailable:
+			// Retry
+			backoffSeconds = backoffInterval
+			backoffInterval *= 2.0
+			if backoffInterval > maxInterval {
+				backoffInterval = maxInterval
+			}
+			if retryAfter := httpRsp.Header.Get("Retry-After"); retryAfter != "" {
+				// TODO(drysdale): cope with a retry-after timestamp (RFC 7231 s7.1.3)
+				if seconds, err := strconv.Atoi(retryAfter); err == nil {
+					backoffSeconds = time.Duration(seconds) * time.Second
+				}
+			}
+		default:
+			return nil, fmt.Errorf("got HTTP Status %q", httpRsp.Status)
+		}
+		httpStatus = httpRsp.Status
+	}
+}
+
+func backoffForRetry(ctx context.Context, d time.Duration) error {
+	backoffTimer := time.NewTimer(d)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-backoffTimer.C:
+	}
+	return nil
+}

--- a/go/jsonclient/client_test.go
+++ b/go/jsonclient/client_test.go
@@ -1,0 +1,308 @@
+package jsonclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/google/certificate-transparency/go/testdata"
+)
+
+func TestNewJSONClient(t *testing.T) {
+	tests := []struct {
+		pubKey string
+		errstr string
+	}{
+		{"", "no PEM block"},
+		{"bogus", "no PEM block"},
+		{testdata.RsaPublicKeyPEM, ""},
+		{testdata.EcdsaPublicKeyPEM, ""},
+		{testdata.DsaPublicKeyPEM, "Unsupported public key type"},
+		{testdata.RsaPublicKeyPEM + "bogus", "extra data found"},
+	}
+	for _, test := range tests {
+		client, err := New("http://127.0.0.1", nil, test.pubKey)
+		if test.errstr != "" {
+			if err == nil {
+				t.Errorf("New()=%p,nil; want error %q", client, test.errstr)
+			} else if !strings.Contains(err.Error(), test.errstr) {
+				t.Errorf("New()=nil,%q; want error %q", err.Error(), test.errstr)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("New()=nil,%q; want no error", err.Error())
+		} else if client == nil {
+			t.Errorf("New()=nil,nil; want client")
+		}
+	}
+}
+
+type TestStruct struct {
+	TreeSize  int    `json:"tree_size"`
+	Timestamp int    `json:"timestamp"`
+	Data      string `json:"data"`
+}
+
+type TestParams struct {
+	RespCode int `json:"rc"`
+}
+
+func MockServer(t *testing.T, failCount int, retryAfter int) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/struct/path":
+			fmt.Fprintf(w, `{"tree_size": 11, "timestamp": 99}`)
+		case "/struct/params":
+			var s TestStruct
+			if r.Method == http.MethodGet {
+				s.TreeSize, _ = strconv.Atoi(r.FormValue("tree_size"))
+				s.Timestamp, _ = strconv.Atoi(r.FormValue("timestamp"))
+				s.Data = r.FormValue("data")
+			} else {
+				decoder := json.NewDecoder(r.Body)
+				err := decoder.Decode(&s)
+				if err != nil {
+					panic("Failed to decode: " + err.Error())
+				}
+				defer r.Body.Close()
+			}
+			fmt.Fprintf(w, `{"tree_size": %d, "timestamp": %d, "data": "%s"}`, s.TreeSize, s.Timestamp, s.Data)
+		case "/error":
+			var params TestParams
+			if r.Method == http.MethodGet {
+				params.RespCode, _ = strconv.Atoi(r.FormValue("rc"))
+			} else {
+				decoder := json.NewDecoder(r.Body)
+				err := decoder.Decode(&params)
+				if err != nil {
+					panic("Failed to decode: " + err.Error())
+				}
+				defer r.Body.Close()
+			}
+			http.Error(w, "error page", params.RespCode)
+		case "/malformed":
+			fmt.Fprintf(w, `{"tree_size": 11, "timestamp": 99`) // no closing }
+		case "/retry":
+			if failCount > 0 {
+				failCount--
+				if retryAfter != 0 {
+					if retryAfter > 0 {
+						w.Header().Add("Retry-After", strconv.Itoa(retryAfter))
+					}
+					w.WriteHeader(http.StatusServiceUnavailable)
+				} else {
+					w.WriteHeader(http.StatusRequestTimeout)
+				}
+			} else {
+				fmt.Fprintf(w, `{"tree_size": 11, "timestamp": 99}`)
+			}
+		default:
+			t.Fatalf("Unhandled URL path: %s", r.URL.Path)
+		}
+	}))
+}
+
+func TestGetAndParse(t *testing.T) {
+	tests := []struct {
+		uri    string
+		params map[string]string
+		status int
+		result TestStruct
+		errstr string
+	}{
+		{uri: "[invalid-uri]", errstr: "too many colons"},
+		{uri: "/short%", errstr: "invalid URL escape"},
+		{uri: "/malformed", status: http.StatusOK, errstr: "unexpected EOF"},
+		{uri: "/error", params: map[string]string{"rc": "404"}, status: http.StatusNotFound},
+		{uri: "/error", params: map[string]string{"rc": "403"}, status: http.StatusForbidden},
+		{uri: "/struct/path", status: http.StatusOK, result: TestStruct{11, 99, ""}},
+		{
+			uri:    "/struct/params",
+			status: http.StatusOK,
+			params: map[string]string{"tree_size": "42", "timestamp": "88", "data": "abcd"},
+			result: TestStruct{42, 88, "abcd"},
+		},
+	}
+
+	ts := MockServer(t, -1, 0)
+	defer ts.Close()
+
+	logClient, err := NewWithoutVerification(ts.URL, &http.Client{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	for _, test := range tests {
+		var result TestStruct
+		httpRsp, err := logClient.GetAndParse(ctx, test.uri, test.params, &result)
+		if test.errstr != "" {
+			if err == nil {
+				t.Errorf("GetAndParse(%q)=%+v,nil; want error %q", test.uri, result, test.errstr)
+			} else if !strings.Contains(err.Error(), test.errstr) {
+				t.Errorf("GetAndParse(%q)=nil,%q; want error %q", test.uri, err.Error(), test.errstr)
+			}
+			continue
+		}
+		if httpRsp.StatusCode != test.status {
+			t.Errorf("GetAndParse('%s') got status %d; want %d", test.uri, httpRsp.StatusCode, test.status)
+		}
+		if test.status == http.StatusOK {
+			if err != nil {
+				t.Errorf("GetAndParse(%q)=nil,%q; want %+v", test.uri, err.Error(), result)
+			}
+			if !reflect.DeepEqual(result, test.result) {
+				t.Errorf("GetAndParse(%q)=%+v,nil; want %+v", test.uri, result, test.result)
+			}
+		}
+	}
+}
+
+func TestPostAndParse(t *testing.T) {
+	tests := []struct {
+		uri     string
+		request interface{}
+		status  int
+		result  TestStruct
+		errstr  string
+	}{
+		{uri: "[invalid-uri]", errstr: "too many colons"},
+		{uri: "/short%", errstr: "invalid URL escape"},
+		{uri: "/struct/params", request: json.Number(`invalid`), errstr: "invalid number literal"},
+		{uri: "/malformed", status: http.StatusOK, errstr: "unexpected end of JSON"},
+		{uri: "/error", request: TestParams{RespCode: 404}, status: http.StatusNotFound},
+		{uri: "/error", request: TestParams{RespCode: 403}, status: http.StatusForbidden},
+		{uri: "/struct/path", status: http.StatusOK, result: TestStruct{11, 99, ""}},
+		{
+			uri:     "/struct/params",
+			status:  http.StatusOK,
+			request: TestStruct{42, 88, "abcd"},
+			result:  TestStruct{42, 88, "abcd"},
+		},
+	}
+
+	ts := MockServer(t, -1, 0)
+	defer ts.Close()
+
+	logClient, err := NewWithoutVerification(ts.URL, &http.Client{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	for _, test := range tests {
+		var result TestStruct
+		httpRsp, err := logClient.PostAndParse(ctx, test.uri, test.request, &result)
+		if test.errstr != "" {
+			if err == nil {
+				t.Errorf("PostAndParse(%q)=%+v,nil; want %q", test.uri, result, test.errstr)
+			} else if !strings.Contains(err.Error(), test.errstr) {
+				t.Errorf("PostAndParse(%q)=nil,%q; want error %q", test.uri, err.Error(), test.errstr)
+			}
+			continue
+		}
+		if httpRsp.StatusCode != test.status {
+			t.Errorf("PostAndParse(%q) got status %d; want %d", test.uri, httpRsp.StatusCode, test.status)
+		}
+		if test.status == http.StatusOK {
+			if err != nil {
+				t.Errorf("PostAndParse(%q)=nil,%q; want %+v", test.uri, err.Error(), test.result)
+			}
+			if !reflect.DeepEqual(result, test.result) {
+				t.Errorf("PostAndParse(%q)=%+v,nil; want %+v", test.uri, result, test.result)
+			}
+		}
+	}
+}
+
+func TestPostAndParseWithRetry(t *testing.T) {
+	leeway := time.Millisecond * 100
+	jiffy := time.Millisecond
+
+	tests := []struct {
+		uri          string
+		request      interface{}
+		deadlineSecs int // -1 indicates no deadline
+		expected     time.Duration
+		retryAfter   int // -1 indicates generate 503 with no Retry-After
+		failCount    int
+		errstr       string
+	}{
+		{"/retry", nil, -1, jiffy, 0, 0, ""},
+		{"/error", TestParams{RespCode: 418}, 2, jiffy, 0, 0, "teapot"},
+		{"/short%", nil, 2, 2 * time.Second, 0, 0, "deadline exceeded"},
+		{"/retry", nil, -1, 7 * time.Second, -1, 3, ""},
+		{"/retry", nil, 6, 5 * time.Second, 5, 1, ""},
+		{"/retry", nil, 5, 5 * time.Second, 10, 1, "deadline exceeded"},
+		{"/retry", nil, 10, 5 * time.Second, 1, 5, ""},
+		{"/retry", nil, 1, 10 * jiffy, 0, 10, ""},
+	}
+	for _, test := range tests {
+		ts := MockServer(t, test.failCount, test.retryAfter)
+		defer ts.Close()
+
+		logClient, err := NewWithoutVerification(ts.URL, &http.Client{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx := context.Background()
+		if test.deadlineSecs >= 0 {
+			ctx, _ = context.WithDeadline(context.Background(), time.Now().Add(time.Duration(test.deadlineSecs)*time.Second))
+		}
+
+		var result TestStruct
+		started := time.Now()
+		httpRsp, err := logClient.PostAndParseWithRetry(ctx, test.uri, test.request, &result)
+		took := time.Since(started)
+
+		if math.Abs(float64(took-test.expected)) > float64(leeway) {
+			t.Errorf("PostAndParseWithRetry() took %s; want ~%s", took, test.expected)
+		}
+		if test.errstr != "" {
+			if err == nil {
+				t.Errorf("PostAndParseWithRetry()=%+v,nil; want error %q", result, test.errstr)
+			} else if !strings.Contains(err.Error(), test.errstr) {
+				t.Errorf("PostAndParseWithRetry()=nil,%q; want error %q", err.Error(), test.errstr)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("PostAndParseWithRetry()=nil,%q; want no error", err.Error())
+		} else if httpRsp.StatusCode != http.StatusOK {
+			t.Errorf("PostAndParseWithRetry() got status %d; want OK(404)", httpRsp.StatusCode)
+		}
+	}
+}
+
+func TestContextRequired(t *testing.T) {
+	ts := MockServer(t, -1, 0)
+	defer ts.Close()
+
+	logClient, err := NewWithoutVerification(ts.URL, &http.Client{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result TestStruct
+	_, err = logClient.GetAndParse(nil, "/struct/path", nil, &result)
+	if err == nil {
+		t.Errorf("GetAndParse() succeeded with empty Context")
+	}
+	_, err = logClient.PostAndParse(nil, "/struct/path", nil, &result)
+	if err == nil {
+		t.Errorf("PostAndParse() succeeded with empty Context")
+	}
+	_, err = logClient.PostAndParseWithRetry(nil, "/struct/path", nil, &result)
+	if err == nil {
+		t.Errorf("PostAndParseWithRetry() succeeded with empty Context")
+	}
+}

--- a/go/serialization.go
+++ b/go/serialization.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/google/certificate-transparency/go/tls"
 )
 
 // Variable size structure prefix-header byte lengths
@@ -265,9 +267,10 @@ func UnmarshalDigitallySigned(r io.Reader) (*DigitallySigned, error) {
 	}
 
 	return &DigitallySigned{
-		HashAlgorithm:      HashAlgorithm(h),
-		SignatureAlgorithm: SignatureAlgorithm(s),
-		Signature:          sig,
+		Algorithm: tls.SignatureAndHashAlgorithm{
+			Hash:      tls.HashAlgorithm(h),
+			Signature: tls.SignatureAlgorithm(s)},
+		Signature: sig,
 	}, nil
 }
 
@@ -282,8 +285,8 @@ func marshalDigitallySignedHere(ds DigitallySigned, here []byte) ([]byte, error)
 	}
 	here = here[0:dsOutLen]
 
-	here[0] = byte(ds.HashAlgorithm)
-	here[1] = byte(ds.SignatureAlgorithm)
+	here[0] = byte(ds.Algorithm.Hash)
+	here[1] = byte(ds.Algorithm.Signature)
 	binary.BigEndian.PutUint16(here[2:4], uint16(sigLen))
 	copy(here[4:], ds.Signature)
 

--- a/go/serialization_test.go
+++ b/go/serialization_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/certificate-transparency/go/tls"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -346,9 +347,10 @@ func defaultSTH() SignedTreeHead {
 		Timestamp:      2345,
 		SHA256RootHash: root,
 		TreeHeadSignature: DigitallySigned{
-			HashAlgorithm:      SHA256,
-			SignatureAlgorithm: ECDSA,
-			Signature:          []byte("tree_signature"),
+			Algorithm: tls.SignatureAndHashAlgorithm{
+				Hash:      tls.SHA256,
+				Signature: tls.ECDSA},
+			Signature: []byte("tree_signature"),
 		},
 	}
 }
@@ -418,17 +420,18 @@ func TestSerializeV1STHSignatureKAT(t *testing.T) {
 func TestMarshalDigitallySigned(t *testing.T) {
 	b, err := MarshalDigitallySigned(
 		DigitallySigned{
-			HashAlgorithm:      SHA512,
-			SignatureAlgorithm: ECDSA,
-			Signature:          []byte("signature")})
+			Algorithm: tls.SignatureAndHashAlgorithm{
+				Hash:      tls.SHA512,
+				Signature: tls.ECDSA},
+			Signature: []byte("signature")})
 	if err != nil {
 		t.Fatalf("Failed to marshal DigitallySigned struct: %v", err)
 	}
-	if b[0] != byte(SHA512) {
-		t.Fatalf("Expected b[0] == SHA512, but found %v", HashAlgorithm(b[0]))
+	if b[0] != byte(tls.SHA512) {
+		t.Fatalf("Expected b[0] == SHA512, but found %v", tls.HashAlgorithm(b[0]))
 	}
-	if b[1] != byte(ECDSA) {
-		t.Fatalf("Expected b[1] == ECDSA, but found %v", SignatureAlgorithm(b[1]))
+	if b[1] != byte(tls.ECDSA) {
+		t.Fatalf("Expected b[1] == ECDSA, but found %v", tls.SignatureAlgorithm(b[1]))
 	}
 	if b[2] != 0x00 || b[3] != 0x09 {
 		t.Fatalf("Found incorrect length bytes, expected (0x00, 0x09) found %v", b[2:3])
@@ -443,11 +446,11 @@ func TestUnmarshalDigitallySigned(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to unmarshal DigitallySigned: %v", err)
 	}
-	if ds.HashAlgorithm != MD5 {
-		t.Fatalf("Expected HashAlgorithm %v, but got %v", MD5, ds.HashAlgorithm)
+	if ds.Algorithm.Hash != tls.MD5 {
+		t.Fatalf("Expected HashAlgorithm %v, but got %v", tls.MD5, ds.Algorithm.Hash)
 	}
-	if ds.SignatureAlgorithm != DSA {
-		t.Fatalf("Expected SignatureAlgorithm %v, but got %v", DSA, ds.SignatureAlgorithm)
+	if ds.Algorithm.Signature != tls.DSA {
+		t.Fatalf("Expected SignatureAlgorithm %v, but got %v", tls.DSA, ds.Algorithm.Signature)
 	}
 	if string(ds.Signature) != "SiGnAtUrE!" {
 		t.Fatalf("Expected Signature %v, but got %v", []byte("SiGnAtUrE!"), ds.Signature)

--- a/go/testdata/keys.go
+++ b/go/testdata/keys.go
@@ -1,0 +1,198 @@
+// Package testdata holds data and utility functions needed for various Go tests.
+package testdata
+
+import "encoding/hex"
+
+// Hashes of text string 'abcd' with various algorithms; check with either "<alg>sum input" or "openssl dgst -<alg> input"
+const (
+	// AbcdMD5 is 'abcd' hashed with MD5
+	AbcdMD5 = "e2fc714c4727ee9395f324cd2e7f331f"
+	// AbcdSHA1 is 'abcd' hashed with SHA1
+	AbcdSHA1 = "81fe8bfe87576c3ecb22426f8e57847382917acf"
+	// AbcdSHA224 is 'abcd' hashed with SHA224
+	AbcdSHA224 = "a76654d8e3550e9a2d67a0eeb6c67b220e5885eddd3fde135806e601"
+	// AbcdSHA256 is 'abcd' hashed with SHA256
+	AbcdSHA256 = "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589"
+	// AbcdSHA384 is 'abcd' hashed with SHA384
+	AbcdSHA384 = "1165b3406ff0b52a3d24721f785462ca2276c9f454a116c2b2ba20171a7905ea5a026682eb659c4d5f115c363aa3c79b"
+	// AbcdSHA512 is 'abcd' hashed with SHA512
+	AbcdSHA512 = "d8022f2060ad6efd297ab73dcc5355c9b214054b0d1776a136a669d26a7d3b14f73aa0d0ebff19ee333368f0164b6419a96da49e3e481753e7e96b716bdccb6f"
+)
+
+const (
+	// RsaPrivateKeyPEM was generated with:
+	//    openssl genpkey -algorithm RSA -out rsa.privkey.pem -pkeyopt rsa_keygen_bits:2048
+	RsaPrivateKeyPEM = "-----BEGIN PRIVATE KEY-----\n" +
+		"MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDP8SJM5SBIbFpF\n" +
+		"dRAUEERo35E4iFXfT5SVAzBIqATkCpf3LfdFZgssPeliBdTtgdvT/CWC2m6aVXYZ\n" +
+		"eScAJOauTpGDyJ7OXj7Yhx1q6u28NuQleU3UQK5QYb7VOjeIse7oTh+THf5IK5T5\n" +
+		"esyh+ioybEYBXXMQetHc4YbXAq06crNT2BP+AxQ4z27xu4X5CKLwwVMa2xwMCFDC\n" +
+		"Y7mxQzEhFv8+HbOtM0IQMSSyh6+o0w4Yzt6i/TUOytZb1D7WHOEMpVTd1CMbXjN0\n" +
+		"tFZvoO0V+n0OV3oT1E5AvwujVguUJblQiapbL890/nZbBtP3xMoFLLhc7sX7N2vR\n" +
+		"1wLWsjOVAgMBAAECggEBAL+frUZDV86l20JqsFhs7T3f2MnKCahyg7AWciZif69O\n" +
+		"e+BTQa14bg9lNm8YhLIim1vs3vyJIqei3eR3mxMs7k/vI3XYKVBv1WZgjSF8QXzS\n" +
+		"8Mf/01MoD/sPOHby4T5dCpaVd89xMmV7lBubqHwUN1KkKJcVcPXc2Qy94C6/zrcu\n" +
+		"Vb7Q91ugTvvhyalWEN02M3tzHEn4cXrnMLWPmTgxb7YtTMRIbJFx2um7/W9G5D+1\n" +
+		"ZtKMjwt+P/yXynx3Sa555MjjJ1/LUyMSbQZoLE0SGOigz1VQnP8nFlpvXUHzktiA\n" +
+		"IBPBBQSsEoS8H3z6WThwY72O795/i2l5mf7EUUAa2/kCgYEA+W7tJPg69KWHKn6E\n" +
+		"gGZKIDTxvp3vRxjLedp7D7cu6bVPCBVIHrPQdmp/mneY6x7Air0a9gCVbh32iCrm\n" +
+		"UrSBCio4i6jtqtna2T1Gc0z63K3UrVQPR0Z6Swq1XDOI6/I23ibxPr12/XXWWYlA\n" +
+		"wkPwvewJVrjtMoP1dkAKVbyzImcCgYEA1WqS0xg7BL4iNGFPrrSme2blZOgga83x\n" +
+		"CtY9dnWAs0IvdxsuItCDaFVJm3oU18ohirEMzqZvbRlwMlUawpd75hCNWyVF4cRo\n" +
+		"+l1RvzOlC/7QXX/E+Kv7sTEUYH7hJyS46QhOtC1/ndAyObk9c2VNJmERfMwIHNm9\n" +
+		"BfSN8yrq1KMCgYEA94fCZPbGIvSFj4EgYv+fvhhscvrucsLDYniTuUPTlXAtLttX\n" +
+		"x8gwLuN/ID5hjarl7oi90bVAlZe8iOLx0M96YykFFmuc9/jcOsuZN2EEbq0/KocJ\n" +
+		"5nSldgT5d7dYwLWNB6bjr5x8Egm3nwEbN+4OYZt0pRA9q+zSUfg5iV4K8y8CgYA7\n" +
+		"S9YposTbJ3zXcuYx022iQc+gvsIrUdgUO7xuCm3M4KnRfRLPh4HLXk8KTNw3rKiv\n" +
+		"IUw+qo2xEW1T/sNlp7M8FANCfNOyy+CjF4ScDFxiPdVk9RgkQ5y1+b4ApaAnQRPD\n" +
+		"Y5SCiVW44lziHu7M/it2a2fxdbsXUQQtAGrkUltW4wKBgAPZyEGi4V2wryOswmkC\n" +
+		"I29TbC6ChnUOvqJfSfz536eIi41D1Ua2Y/VlAK1ud7K8ilr/M4VoRjHqbPivR1Uk\n" +
+		"RU7nO3cWRBuDBjgZWeAq5WFIMPbm9gRlaTECI6EFtAOI1GcHOsOBecd3PBiQNXvj\n" +
+		"YyGD1wSrHQwDcnxtP1rqEQDV\n" +
+		"-----END PRIVATE KEY-----\n"
+
+	// RsaPublicKeyPEM was generated from above with:
+	//    openssl rsa -pubout -in rsa.privkey.pem -out rsa.pubkey.pem
+	RsaPublicKeyPEM = "-----BEGIN PUBLIC KEY-----\n" +
+		"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAz/EiTOUgSGxaRXUQFBBE\n" +
+		"aN+ROIhV30+UlQMwSKgE5AqX9y33RWYLLD3pYgXU7YHb0/wlgtpumlV2GXknACTm\n" +
+		"rk6Rg8iezl4+2IcdaurtvDbkJXlN1ECuUGG+1To3iLHu6E4fkx3+SCuU+XrMofoq\n" +
+		"MmxGAV1zEHrR3OGG1wKtOnKzU9gT/gMUOM9u8buF+Qii8MFTGtscDAhQwmO5sUMx\n" +
+		"IRb/Ph2zrTNCEDEksoevqNMOGM7eov01DsrWW9Q+1hzhDKVU3dQjG14zdLRWb6Dt\n" +
+		"Ffp9Dld6E9ROQL8Lo1YLlCW5UImqWy/PdP52WwbT98TKBSy4XO7F+zdr0dcC1rIz\n" +
+		"lQIDAQAB\n" +
+		"-----END PUBLIC KEY-----\n"
+
+	// RsaSignedAbcdHex was generated with:
+	//    echo -n "abcd" > sign.input
+	//    openssl sha256 -sign rsa.privkey.pem -out sign.rsa sign.input
+	// Verify with:
+	//    openssl sha256 -verify rsa.pubkey.pem -signature sign.rsa sign.input
+	RsaSignedAbcdHex = "4692f17adad62324a38a786d9b05eb7facf95c277729bc23e8d4f4fe25c0ac0e" +
+		"9115f14ffd4dc6c00e6b2717677e96ed4da9e2226745db5c2d14ec8b4f96959e" +
+		"a43ca73e3ab801d4e76b0c0599c741b9701dd0c22b20cc7a294fccce97d2eda2" +
+		"72448830a19b0b1075f962d3bcf65922f81f4747dde1a2883ffce12941927af6" +
+		"25549ea7b4f745a95f5558822af434cc7471ea5a21cce656a7667d29bff3e6f2" +
+		"fb3d48bbee1a60116f0dd429d5691b008482e9ec42538bcf2692e1a685e836c8" +
+		"49316fb3c49b58bd5a0c33f0256b09d59af08a018fe64cd31051cb9e9a1d3fde" +
+		"e186bd80bfe304abbbec2ac18d3bee09465cb69f2638728aba4b9886a252768a"
+
+	// DsaPrivateKeyPEM was generated with:
+	//    openssl dsaparam -out dsa.param.pem 2048; openssl gendsa dsa.param.pem -out dsa.privkey.pem
+	DsaPrivateKeyPEM = "-----BEGIN DSA PRIVATE KEY-----\n" +
+		"MIIDVwIBAAKCAQEA3Q72qQc0ZM2eUjvZ/XOROQTbhmjzuZdzY7kd+82n54NPeqVz\n" +
+		"+FWmk26INd7pUNbn/TjniN5+pC2pK+p9alFLE19bOvsY4x7Ugwrpd9sQIea3W4Q7\n" +
+		"H9PaEW+BooFzT/feC9TmnU0ynwoNhZB33Cr3k3PFt/69lmyrkd91wTpXrstrQurU\n" +
+		"h4baL5l6t2/JT3TxpKx6xe19hWqqFsBLu/j+kE2o2Aw1TVLHg4/74TJLfqAkWnCI\n" +
+		"u9QL0uGQnW80kRfJnT+tUJXrXMpg1HxK7CsDEW5xsAWF370Is0UPaP7jRru6FiSN\n" +
+		"ObcVhSqCIs+QJIWie9cRtwniwhoi4z6AfGeEYQIhAOkSzAsWja1fwB486/LCW+zv\n" +
+		"DJKiCGLTalimfawzHQHFAoIBAQDJvCujEZ/WeQFLlP/0zS+2DjqdaxnKj1xuXfoL\n" +
+		"LOocvMw06dnrQNmDu/nBQiYSfzf7zjwpnx+AVjBQssK0jXs0l7gw52FyCIztDejT\n" +
+		"/ybMVudwKUGudxAEjOclOSQ7XVpPd4p3UMy+E6pkJ8VRiuNFDibYTD+O3XhFTj2l\n" +
+		"6LqV/KcB2fWV1fUqfxax2vpcwe4clTJbJXUgJC3mYmUXv1U6z0hliDz2WMhbOyea\n" +
+		"1fs31zYvIMyk2wJFJl7+EbXb8BgYcQt1FE4c14fuFnincAW0So+xBZ5DtiTja4lm\n" +
+		"DE0OAI2hhLslSQ7rGwWt2zIKSFLtsWf78CP1wigJvWcUVhazAoIBAFAhxgtOaV8G\n" +
+		"FJxs6A3TtXEmmrq3i5/w3/8l7skWamcHvcwrvw37g5KQY+N+85JZszHPjmUzEq/o\n" +
+		"NOLjF6zq7+oRtWbOR3Mvc2hHsHg86tE/HAkBIu2G73c9UuskzGSMec4F6TyWKHvC\n" +
+		"26F2cvu9aA42v/8q1d/QQs3+LrtARGhyFCqnBVNSZmZj5ngR0kLGUfs/LQklpGFe\n" +
+		"VciXK57RxHSPo15lnKiHW9kCte7tGEg9Eber8paMz67dQDuj1yRkS5H7JXqRZjIP\n" +
+		"UrICWGGk1vluQsuoyI/Nu8/tL7Im24xZH6XHBm4F+aijl9XlAJiKXfkCLIaxYSdc\n" +
+		"4PXquTwtRLICIQCijrpD+UhidGFLPZCCLzBC239PrP7PabSVurWXHh5iYw==\n" +
+		"-----END DSA PRIVATE KEY-----\n"
+
+	// DsaPrivateKeyPKCS8PEM is a copy of the private key above, encoded in PKCS#8 format.
+	// Generated from above with:
+	//    openssl pkcs8 -topk8 -nocrypt -in dsa.privkey.pem -out dsa.privkey.pkcs8.pem
+	DsaPrivateKeyPKCS8PEM = "-----BEGIN PRIVATE KEY-----\n" +
+		"MIICZgIBADCCAjoGByqGSM44BAEwggItAoIBAQDdDvapBzRkzZ5SO9n9c5E5BNuG\n" +
+		"aPO5l3NjuR37zafng096pXP4VaaTbog13ulQ1uf9OOeI3n6kLakr6n1qUUsTX1s6\n" +
+		"+xjjHtSDCul32xAh5rdbhDsf09oRb4GigXNP994L1OadTTKfCg2FkHfcKveTc8W3\n" +
+		"/r2WbKuR33XBOleuy2tC6tSHhtovmXq3b8lPdPGkrHrF7X2FaqoWwEu7+P6QTajY\n" +
+		"DDVNUseDj/vhMkt+oCRacIi71AvS4ZCdbzSRF8mdP61QletcymDUfErsKwMRbnGw\n" +
+		"BYXfvQizRQ9o/uNGu7oWJI05txWFKoIiz5AkhaJ71xG3CeLCGiLjPoB8Z4RhAiEA\n" +
+		"6RLMCxaNrV/AHjzr8sJb7O8MkqIIYtNqWKZ9rDMdAcUCggEBAMm8K6MRn9Z5AUuU\n" +
+		"//TNL7YOOp1rGcqPXG5d+gss6hy8zDTp2etA2YO7+cFCJhJ/N/vOPCmfH4BWMFCy\n" +
+		"wrSNezSXuDDnYXIIjO0N6NP/JsxW53ApQa53EASM5yU5JDtdWk93indQzL4TqmQn\n" +
+		"xVGK40UOJthMP47deEVOPaXoupX8pwHZ9ZXV9Sp/FrHa+lzB7hyVMlsldSAkLeZi\n" +
+		"ZRe/VTrPSGWIPPZYyFs7J5rV+zfXNi8gzKTbAkUmXv4RtdvwGBhxC3UUThzXh+4W\n" +
+		"eKdwBbRKj7EFnkO2JONriWYMTQ4AjaGEuyVJDusbBa3bMgpIUu2xZ/vwI/XCKAm9\n" +
+		"ZxRWFrMEIwIhAKKOukP5SGJ0YUs9kIIvMELbf0+s/s9ptJW6tZceHmJj\n" +
+		"-----END PRIVATE KEY-----\n"
+
+	// DsaPublicKeyPEM was generated from above with:
+	//    openssl dsa -in dsa.privkey.pem -pubout -out dsa.pubkey.pem
+	DsaPublicKeyPEM = "-----BEGIN PUBLIC KEY-----\n" +
+		"MIIDRzCCAjoGByqGSM44BAEwggItAoIBAQDdDvapBzRkzZ5SO9n9c5E5BNuGaPO5\n" +
+		"l3NjuR37zafng096pXP4VaaTbog13ulQ1uf9OOeI3n6kLakr6n1qUUsTX1s6+xjj\n" +
+		"HtSDCul32xAh5rdbhDsf09oRb4GigXNP994L1OadTTKfCg2FkHfcKveTc8W3/r2W\n" +
+		"bKuR33XBOleuy2tC6tSHhtovmXq3b8lPdPGkrHrF7X2FaqoWwEu7+P6QTajYDDVN\n" +
+		"UseDj/vhMkt+oCRacIi71AvS4ZCdbzSRF8mdP61QletcymDUfErsKwMRbnGwBYXf\n" +
+		"vQizRQ9o/uNGu7oWJI05txWFKoIiz5AkhaJ71xG3CeLCGiLjPoB8Z4RhAiEA6RLM\n" +
+		"CxaNrV/AHjzr8sJb7O8MkqIIYtNqWKZ9rDMdAcUCggEBAMm8K6MRn9Z5AUuU//TN\n" +
+		"L7YOOp1rGcqPXG5d+gss6hy8zDTp2etA2YO7+cFCJhJ/N/vOPCmfH4BWMFCywrSN\n" +
+		"ezSXuDDnYXIIjO0N6NP/JsxW53ApQa53EASM5yU5JDtdWk93indQzL4TqmQnxVGK\n" +
+		"40UOJthMP47deEVOPaXoupX8pwHZ9ZXV9Sp/FrHa+lzB7hyVMlsldSAkLeZiZRe/\n" +
+		"VTrPSGWIPPZYyFs7J5rV+zfXNi8gzKTbAkUmXv4RtdvwGBhxC3UUThzXh+4WeKdw\n" +
+		"BbRKj7EFnkO2JONriWYMTQ4AjaGEuyVJDusbBa3bMgpIUu2xZ/vwI/XCKAm9ZxRW\n" +
+		"FrMDggEFAAKCAQBQIcYLTmlfBhScbOgN07VxJpq6t4uf8N//Je7JFmpnB73MK78N\n" +
+		"+4OSkGPjfvOSWbMxz45lMxKv6DTi4xes6u/qEbVmzkdzL3NoR7B4POrRPxwJASLt\n" +
+		"hu93PVLrJMxkjHnOBek8lih7wtuhdnL7vWgONr//KtXf0ELN/i67QERochQqpwVT\n" +
+		"UmZmY+Z4EdJCxlH7Py0JJaRhXlXIlyue0cR0j6NeZZyoh1vZArXu7RhIPRG3q/KW\n" +
+		"jM+u3UA7o9ckZEuR+yV6kWYyD1KyAlhhpNb5bkLLqMiPzbvP7S+yJtuMWR+lxwZu\n" +
+		"Bfmoo5fV5QCYil35AiyGsWEnXOD16rk8LUSy\n" +
+		"-----END PUBLIC KEY-----\n"
+
+	// DsaSignedAbcdHex was generated with:
+	//    echo -n "abcd" > sign.input
+	//    openssl dgst -dss1 -sign dsa.privkey.pem -out sign.dsa sign.input
+	// Note that this includes randomization so will give different results each time.
+	// Verify with:
+	//    openssl dgst -dss1 -verify dsa.pubkey.pem -signature sign.dsa sign.input
+	DsaSignedAbcdHex = "3045022100c287211dec54eab597ed5264f6fdf57faf651909914c533d42f0e3" +
+		"2809e9141402205f34cc4b8ca12ebdf025bf36bbe1ff7d807d4cfe951ac1329a" +
+		"35a39f5e971f10"
+
+	// EcdsaPrivateKeyPEM was generated with:
+	//    openssl ecparam -genkey -name prime256v1 -noout -out ecdsa.privkey.pem
+	EcdsaPrivateKeyPEM = "-----BEGIN EC PRIVATE KEY-----\n" +
+		"MHcCAQEEIHg0hg3vLqLVI7wv2y0cCk+kmwuwoKsMZqzqbjqP1AtjoAoGCCqGSM49\n" +
+		"AwEHoUQDQgAEjHs6Rw7KFt8Wd2ZcioZi7eZY5nodUXMnCWUhZzsGVsPaexqUyPSr\n" +
+		"9cQgrCe7MPRLJ524AO6rREqfs7FKt85++A==\n" +
+		"-----END EC PRIVATE KEY-----\n"
+
+	// EcdsaPrivateKeyPKCS8PEM is a copy of the private key above, encoded in PKCS#8 format.
+	// Generated from above with:
+	//    openssl pkcs8 -topk8 -nocrypt -in ecdsa.privkey.pem -out ecdsa.privkey.pkcs8.pem
+	EcdsaPrivateKeyPKCS8PEM = "-----BEGIN PRIVATE KEY-----\n" +
+		"MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgeDSGDe8uotUjvC/b\n" +
+		"LRwKT6SbC7CgqwxmrOpuOo/UC2OhRANCAASMezpHDsoW3xZ3ZlyKhmLt5ljmeh1R\n" +
+		"cycJZSFnOwZWw9p7GpTI9Kv1xCCsJ7sw9EsnnbgA7qtESp+zsUq3zn74\n" +
+		"-----END PRIVATE KEY-----\n"
+
+	// EcdsaPublicKeyPEM was generated from above with:
+	//    openssl ec -in ecdsa.privkey.pem -pubout -out ecdsa.pubkey.pem
+	EcdsaPublicKeyPEM = "-----BEGIN PUBLIC KEY-----\n" +
+		"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjHs6Rw7KFt8Wd2ZcioZi7eZY5nod\n" +
+		"UXMnCWUhZzsGVsPaexqUyPSr9cQgrCe7MPRLJ524AO6rREqfs7FKt85++A==\n" +
+		"-----END PUBLIC KEY-----\n"
+
+	// EcdsaSignedAbcdHex was generated with:
+	//    echo -n "abcd" > sign.input
+	//    openssl dgst -sha256 -sign ecdsa.privkey.pem -out sign.ecdsa sign.input
+	// Note that this includes randomization so will give different results each time.
+	// Verify with:
+	//    openssl dgst -sha256 -verify ecdsa.pubkey.pem -signature sign.ecdsa sign.input
+	EcdsaSignedAbcdHex = "304502202e0204dadf2baa35e426b66ab8cd32a9ba33421187645a9110512e3e" +
+		"d1b8007b022100ae83f5f993ab3af6f46bb09b4f15d07cc582b03e1353879ada" +
+		"ce68796fe537e5"
+)
+
+// FromHex decodes a hex string to a byte array, and panics on error; only suitable for
+// use in test code.
+func FromHex(hexdata string) []byte {
+	data, err := hex.DecodeString(hexdata)
+	if err != nil {
+		panic("non hex data: " + err.Error())
+	}
+	return data
+}

--- a/go/tls/signature.go
+++ b/go/tls/signature.go
@@ -1,0 +1,138 @@
+package tls
+
+import (
+	"crypto"
+	"crypto/dsa"
+	"crypto/ecdsa"
+	_ "crypto/md5" // For registration side-effect
+	"crypto/rand"
+	"crypto/rsa"
+	_ "crypto/sha1"   // For registration side-effect
+	_ "crypto/sha256" // For registration side-effect
+	_ "crypto/sha512" // For registration side-effect
+	"errors"
+	"fmt"
+	"log"
+	"math/big"
+
+	"github.com/google/certificate-transparency/go/asn1"
+)
+
+type dsaSig struct {
+	R, S *big.Int
+}
+
+func generateHash(algo HashAlgorithm, data []byte) ([]byte, crypto.Hash, error) {
+	var hashType crypto.Hash
+	switch algo {
+	case MD5:
+		hashType = crypto.MD5
+	case SHA1:
+		hashType = crypto.SHA1
+	case SHA224:
+		hashType = crypto.SHA224
+	case SHA256:
+		hashType = crypto.SHA256
+	case SHA384:
+		hashType = crypto.SHA384
+	case SHA512:
+		hashType = crypto.SHA512
+	default:
+		return nil, hashType, fmt.Errorf("unsupported Algorithm.Hash in signature: %v", algo)
+	}
+
+	hasher := hashType.New()
+	if _, err := hasher.Write(data); err != nil {
+		return nil, hashType, fmt.Errorf("failed to write to hasher: %v", err)
+	}
+	return hasher.Sum([]byte{}), hashType, nil
+}
+
+// VerifySignature verifies that the passed in signature over data was created by the given PublicKey.
+func VerifySignature(pubKey crypto.PublicKey, data []byte, sig DigitallySigned) error {
+	hash, hashType, err := generateHash(sig.Algorithm.Hash, data)
+	if err != nil {
+		return err
+	}
+
+	switch sig.Algorithm.Signature {
+	case RSA:
+		rsaKey, ok := pubKey.(*rsa.PublicKey)
+		if !ok {
+			return fmt.Errorf("cannot verify RSA signature with %T key", pubKey)
+		}
+		if err := rsa.VerifyPKCS1v15(rsaKey, hashType, hash, sig.Signature); err != nil {
+			return fmt.Errorf("failed to verify rsa signature: %v", err)
+		}
+	case DSA:
+		dsaKey, ok := pubKey.(*dsa.PublicKey)
+		if !ok {
+			return fmt.Errorf("cannot verify DSA signature with %T key", pubKey)
+		}
+		var dsaSig dsaSig
+		rest, err := asn1.Unmarshal(sig.Signature, &dsaSig)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal DSA signature: %v", err)
+		}
+		if len(rest) != 0 {
+			log.Printf("Garbage following signature %v", rest)
+		}
+		if dsaSig.R.Sign() <= 0 || dsaSig.S.Sign() <= 0 {
+			return errors.New("DSA signature contained zero or negative values")
+		}
+		if !dsa.Verify(dsaKey, hash, dsaSig.R, dsaSig.S) {
+			return errors.New("failed to verify DSA signature")
+		}
+	case ECDSA:
+		ecdsaKey, ok := pubKey.(*ecdsa.PublicKey)
+		if !ok {
+			return fmt.Errorf("cannot verify ECDSA signature with %T key", pubKey)
+		}
+		var ecdsaSig dsaSig
+		rest, err := asn1.Unmarshal(sig.Signature, &ecdsaSig)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal ECDSA signature: %v", err)
+		}
+		if len(rest) != 0 {
+			log.Printf("Garbage following signature %v", rest)
+		}
+		if ecdsaSig.R.Sign() <= 0 || ecdsaSig.S.Sign() <= 0 {
+			return errors.New("ECDSA signature contained zero or negative values")
+		}
+
+		if !ecdsa.Verify(ecdsaKey, hash, ecdsaSig.R, ecdsaSig.S) {
+			return errors.New("failed to verify ECDSA signature")
+		}
+	default:
+		return fmt.Errorf("unsupported Algorithm.Signature in signature: %v", sig.Algorithm.Hash)
+	}
+	return nil
+}
+
+// CreateSignature builds a signature over the given data using the specified hash algorithm and private key.
+func CreateSignature(privKey crypto.PrivateKey, hashAlgo HashAlgorithm, data []byte) (DigitallySigned, error) {
+	var sig DigitallySigned
+	sig.Algorithm.Hash = hashAlgo
+	hash, hashType, err := generateHash(sig.Algorithm.Hash, data)
+	if err != nil {
+		return sig, err
+	}
+
+	switch privKey := privKey.(type) {
+	case rsa.PrivateKey:
+		sig.Algorithm.Signature = RSA
+		sig.Signature, err = rsa.SignPKCS1v15(rand.Reader, &privKey, hashType, hash)
+		return sig, err
+	case ecdsa.PrivateKey:
+		sig.Algorithm.Signature = ECDSA
+		var ecdsaSig dsaSig
+		ecdsaSig.R, ecdsaSig.S, err = ecdsa.Sign(rand.Reader, &privKey, hash)
+		if err != nil {
+			return sig, err
+		}
+		sig.Signature, err = asn1.Marshal(ecdsaSig)
+		return sig, err
+	default:
+		return sig, fmt.Errorf("unsupported private key type %T", privKey)
+	}
+}

--- a/go/tls/signature_test.go
+++ b/go/tls/signature_test.go
@@ -1,0 +1,199 @@
+package tls
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/pem"
+	mathrand "math/rand"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/certificate-transparency/go/testdata"
+	"github.com/google/certificate-transparency/go/x509"
+)
+
+func TestGenerateHash(t *testing.T) {
+	var tests = []struct {
+		in     string // hex encoded
+		algo   HashAlgorithm
+		want   string // hex encoded
+		errstr string
+	}{
+		// Empty hash values
+		{"", MD5, "d41d8cd98f00b204e9800998ecf8427e", ""},
+		{"", SHA1, "da39a3ee5e6b4b0d3255bfef95601890afd80709", ""},
+		{"", SHA224, "d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f", ""},
+		{"", SHA256, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", ""},
+		{"", SHA384, "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b", ""},
+		{"", SHA512, "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e", ""},
+		{"", 999, "", "unsupported"},
+
+		// Hashes of "abcd".
+		{"61626364", MD5, testdata.AbcdMD5, ""},
+		{"61626364", SHA1, testdata.AbcdSHA1, ""},
+		{"61626364", SHA224, testdata.AbcdSHA224, ""},
+		{"61626364", SHA256, testdata.AbcdSHA256, ""},
+		{"61626364", SHA384, testdata.AbcdSHA384, ""},
+		{"61626364", SHA512, testdata.AbcdSHA512, ""},
+	}
+	for _, test := range tests {
+		got, _, err := generateHash(test.algo, testdata.FromHex(test.in))
+		if test.errstr != "" {
+			if err == nil {
+				t.Errorf("generateHash(%s)=%s,nil; want error %q", test.in, hex.EncodeToString(got), test.errstr)
+			} else if !strings.Contains(err.Error(), test.errstr) {
+				t.Errorf("generateHash(%s)=nil,%q; want error %q", test.in, test.errstr, err.Error())
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("generateHash(%s)=nil,%q; want %s", test.in, err, test.want)
+		} else if hex.EncodeToString(got) != test.want {
+			t.Errorf("generateHash(%s)=%s,nil; want %s", test.in, hex.EncodeToString(got), test.want)
+		}
+	}
+}
+
+func TestVerifySignature(t *testing.T) {
+	var tests = []struct {
+		pubKey   crypto.PublicKey
+		in       string // hex encoded
+		hashAlgo HashAlgorithm
+		sigAlgo  SignatureAlgorithm
+		errstr   string
+		sig      string // hex encoded
+	}{
+		{PEM2PK(testdata.RsaPublicKeyPEM), "61626364", 99, ECDSA, "unsupported Algorithm.Hash", "1234"},
+		{PEM2PK(testdata.RsaPublicKeyPEM), "61626364", SHA256, 99, "unsupported Algorithm.Signature", "1234"},
+
+		{PEM2PK(testdata.RsaPublicKeyPEM), "61626364", SHA256, DSA, "cannot verify DSA", "1234"},
+		{PEM2PK(testdata.RsaPublicKeyPEM), "61626364", SHA256, ECDSA, "cannot verify ECDSA", "1234"},
+		{PEM2PK(testdata.RsaPublicKeyPEM), "61626364", SHA256, RSA, "verification error", "1234"},
+		{PEM2PK(testdata.RsaPublicKeyPEM), "61626364", SHA256, ECDSA, "cannot verify ECDSA", "1234"},
+
+		{PEM2PK(testdata.DsaPublicKeyPEM), "61626364", SHA1, RSA, "cannot verify RSA", "1234"},
+		{PEM2PK(testdata.DsaPublicKeyPEM), "61626364", SHA1, ECDSA, "cannot verify ECDSA", "1234"},
+		{PEM2PK(testdata.DsaPublicKeyPEM), "61626364", SHA1, DSA, "failed to unmarshal DSA signature", "1234"},
+		{PEM2PK(testdata.DsaPublicKeyPEM), "61626364", SHA1, DSA, "failed to verify DSA signature", "3006020101020101eeff"},
+		{PEM2PK(testdata.DsaPublicKeyPEM), "61626364", SHA1, DSA, "zero or negative values", "3006020100020181"},
+
+		{PEM2PK(testdata.EcdsaPublicKeyPEM), "61626364", SHA256, RSA, "cannot verify RSA", "1234"},
+		{PEM2PK(testdata.EcdsaPublicKeyPEM), "61626364", SHA256, DSA, "cannot verify DSA", "1234"},
+		{PEM2PK(testdata.EcdsaPublicKeyPEM), "61626364", SHA256, ECDSA, "failed to unmarshal ECDSA signature", "1234"},
+		{PEM2PK(testdata.EcdsaPublicKeyPEM), "61626364", SHA256, ECDSA, "failed to verify ECDSA signature", "3006020101020101eeff"},
+		{PEM2PK(testdata.EcdsaPublicKeyPEM), "61626364", SHA256, ECDSA, "zero or negative values", "3006020100020181"},
+
+		{PEM2PK(testdata.RsaPublicKeyPEM), "61626364", SHA256, RSA, "", testdata.RsaSignedAbcdHex},
+		{PEM2PK(testdata.DsaPublicKeyPEM), "61626364", SHA1, DSA, "", testdata.DsaSignedAbcdHex},
+		{PEM2PK(testdata.EcdsaPublicKeyPEM), "61626364", SHA256, ECDSA, "", testdata.EcdsaSignedAbcdHex},
+	}
+	for _, test := range tests {
+		algo := SignatureAndHashAlgorithm{Hash: test.hashAlgo, Signature: test.sigAlgo}
+		signed := DigitallySigned{Algorithm: algo, Signature: testdata.FromHex(test.sig)}
+
+		err := VerifySignature(test.pubKey, testdata.FromHex(test.in), signed)
+		if test.errstr != "" {
+			if err == nil {
+				t.Errorf("VerifySignature(%s)=nil; want %q", test.in, test.errstr)
+			} else if !strings.Contains(err.Error(), test.errstr) {
+				t.Errorf("VerifySignature(%s)=%q; want %q", test.in, err.Error(), test.errstr)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("VerifySignature(%s)=%q; want nil", test.in, err)
+		}
+	}
+}
+
+func TestCreateSignatureVerifySignatureRoundTrip(t *testing.T) {
+	var tests = []struct {
+		privKey  crypto.PrivateKey
+		pubKey   crypto.PublicKey
+		hashAlgo HashAlgorithm
+	}{
+		{PEM2PrivKey(testdata.RsaPrivateKeyPEM), PEM2PK(testdata.RsaPublicKeyPEM), SHA256},
+		{PEM2PrivKey(testdata.EcdsaPrivateKeyPKCS8PEM), PEM2PK(testdata.EcdsaPublicKeyPEM), SHA256},
+	}
+	seed := time.Now().UnixNano()
+	r := mathrand.New(mathrand.NewSource(seed))
+	for _, test := range tests {
+		for j := 0; j < 1; j++ {
+			dataLen := 10 + r.Intn(100)
+			data := make([]byte, dataLen)
+			_, _ = r.Read(data)
+			sig, err := CreateSignature(test.privKey, test.hashAlgo, data)
+			if err != nil {
+				t.Errorf("CreateSignature(%T, %v) failed with: %q", test.privKey, test.hashAlgo, err.Error())
+				continue
+			}
+
+			if err := VerifySignature(test.pubKey, data, sig); err != nil {
+				t.Errorf("VerifySignature(%T, %v) failed with: %q", test.pubKey, test.hashAlgo, err)
+			}
+		}
+	}
+}
+
+func TestCreateSignatureFailures(t *testing.T) {
+	var tests = []struct {
+		privKey  crypto.PrivateKey
+		hashAlgo HashAlgorithm
+		in       string // hex encoded
+		errstr   string
+	}{
+		{PEM2PrivKey(testdata.EcdsaPrivateKeyPKCS8PEM), 99, "abcd", "unsupported Algorithm.Hash"},
+		{nil, SHA256, "abcd", "unsupported private key type"},
+		// TODO(drysdale): the following test panics on Go < 1.7, so disable until the repo moves to 1.7
+		// {*bogusKey, MD5, "abcd", "zero parameter"},
+	}
+	for _, test := range tests {
+		if sig, err := CreateSignature(test.privKey, test.hashAlgo, testdata.FromHex(test.in)); err == nil {
+			t.Errorf("CreateSignature(%T, %v)=%v,nil; want error %q", test.privKey, test.hashAlgo, sig, test.errstr)
+		} else if !strings.Contains(err.Error(), test.errstr) {
+			t.Errorf("CreateSignature(%T, %v)=nil,%q; want error %q", test.privKey, test.hashAlgo, err.Error(), test.errstr)
+		}
+	}
+}
+
+func PEM2PK(s string) crypto.PublicKey {
+	p, _ := pem.Decode([]byte(s))
+	if p == nil {
+		panic("no PEM block found in " + s)
+	}
+	pubKey, _ := x509.ParsePKIXPublicKey(p.Bytes)
+	if pubKey == nil {
+		panic("public key not parsed from " + s)
+	}
+	return pubKey
+}
+func PEM2PrivKey(s string) crypto.PrivateKey {
+	p, _ := pem.Decode([]byte(s))
+	if p == nil {
+		panic("no PEM block found in " + s)
+	}
+
+	// Try various different private key formats one after another.
+	if rsaPrivKey, err := x509.ParsePKCS1PrivateKey(p.Bytes); err == nil {
+		return *rsaPrivKey
+	}
+	if pkcs8Key, err := x509.ParsePKCS8PrivateKey(p.Bytes); err == nil {
+		if reflect.TypeOf(pkcs8Key).Kind() == reflect.Ptr {
+			pkcs8Key = reflect.ValueOf(pkcs8Key).Elem().Interface()
+		}
+		return pkcs8Key
+	}
+
+	return nil
+}
+func bogusKey() crypto.PrivateKey {
+	bogusCurve := elliptic.P224()
+	bogusCurve.Params().N.SetInt64(0)
+	bogusKey, _ := ecdsa.GenerateKey(bogusCurve, rand.Reader)
+	return *bogusKey
+}

--- a/go/tls/tls.go
+++ b/go/tls/tls.go
@@ -1,0 +1,697 @@
+// Package tls implements functionality for dealing with TLS-encoded data,
+// as defined in RFC 5246.  This includes parsing and generation of TLS-encoded
+// data, together with utility functions for dealing with the DigitallySigned
+// TLS type.
+package tls
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+// This file holds utility functions for TLS encoding/decoding data
+// as per RFC 5246 section 4.
+
+// A structuralError suggests that the TLS data is valid, but the Go type
+// which is receiving it doesn't match.
+type structuralError struct {
+	field string
+	msg   string
+}
+
+func (e structuralError) Error() string {
+	var prefix string
+	if e.field != "" {
+		prefix = e.field + ": "
+	}
+	return "tls: structure error: " + prefix + e.msg
+}
+
+// A syntaxError suggests that the TLS data is invalid.
+type syntaxError struct {
+	field string
+	msg   string
+}
+
+func (e syntaxError) Error() string {
+	var prefix string
+	if e.field != "" {
+		prefix = e.field + ": "
+	}
+	return "tls: syntax error: " + prefix + e.msg
+}
+
+// Uint24 is an unsigned 3-byte integer.
+type Uint24 uint32
+
+// Enum is an unsigned integer.
+type Enum uint64
+
+var (
+	uint8Type  = reflect.TypeOf(uint8(0))
+	uint16Type = reflect.TypeOf(uint16(0))
+	uint24Type = reflect.TypeOf(Uint24(0))
+	uint32Type = reflect.TypeOf(uint32(0))
+	uint64Type = reflect.TypeOf(uint64(0))
+	enumType   = reflect.TypeOf(Enum(0))
+)
+
+// Unmarshal parses the TLS-encoded data in b and uses the reflect package to
+// fill in an arbitrary value pointed at by val.  Because Unmarshal uses the
+// reflect package, the structs being written to must use exported fields
+// (upper case names).
+//
+// The mappings between TLS types and Go types is as follows; some fields
+// must have tags (to indicate their encoded size).
+//
+//	TLS		Go		Required Tags
+//	opaque		byte / uint8
+//	uint8		byte / uint8
+//	uint16		uint16
+//	uint24		tls.Uint24
+//	uint32		uint32
+//	uint64		uint64
+//	enum		tls.Enum	size:S or maxval:N
+//	Type<N,M>	[]Type		minlen:N,maxlen:M
+//	opaque[N]	[N]byte / [N]uint8
+//	uint8[N]	[N]byte / [N]uint8
+//	struct { }	struct { }
+//	select(T) {
+//	 case e1: Type	*T		selector:Field,val:e1
+//	}
+//
+// TLS variants (RFC 5246 s4.6.1) are only supported when the value of the
+// associated enumeration type is available earlier in the same enclosing
+// struct, and each possible variant is marked with a selector tag (to
+// indicate which field selects the variants) and a val tag (to indicate
+// what value of the selector picks this particular field).
+//
+// For example, a TLS structure:
+//
+//   enum { e1(1), e2(2) } EnumType;
+//   struct {
+//      EnumType sel;
+//      select(sel) {
+//         case e1: uint16
+//         case e2: uint32
+//      } data;
+//   } VariantItem;
+//
+// would have a corresponding Go type:
+//
+//   type VariantItem struct {
+//      Sel    tls.Enum  `tls:"maxval:2"`
+//      Data16 *uint16   `tls:"selector:Sel,val:1"`
+//      Data32 *uint32   `tls:"selector:Sel,val:2"`
+//    }
+//
+// TLS fixed-length vectors of types other than opaque or uint8 are not supported.
+//
+// For TLS variable-length vectors that are themselves used in other vectors,
+// create a single-field structure to represent the inner type. For example, for:
+//
+//   opaque InnerType<1..65535>;
+//   struct {
+//     InnerType inners<1,65535>;
+//   } Something;
+//
+// convert to:
+//
+//   type InnerType struct {
+//      Val    []byte       `tls:"minlen:1,maxlen:65535"`
+//   }
+//   type Something struct {
+//      Inners []InnerType  `tls:"minlen:1,maxlen:65535"`
+//   }
+//
+// If the encoded value does not fit in the Go type, Unmarshal returns a parse error.
+func Unmarshal(b []byte, val interface{}) ([]byte, error) {
+	return UnmarshalWithParams(b, val, "")
+}
+
+// UnmarshalWithParams allows field parameters to be specified for the
+// top-level element. The form of the params is the same as the field tags.
+func UnmarshalWithParams(b []byte, val interface{}, params string) ([]byte, error) {
+	info, err := fieldTagToFieldInfo(params, "")
+	if err != nil {
+		return nil, err
+	}
+	// The passed in interface{} is a pointer (to allow the value to be written
+	// to); extract the pointed-to object as a reflect.Value, so parseField
+	// can do various introspection things.
+	v := reflect.ValueOf(val).Elem()
+	offset, err := parseField(v, b, 0, info)
+	if err != nil {
+		return nil, err
+	}
+	return b[offset:], nil
+}
+
+// Return the number of bytes needed to encode values up to (and including) x.
+func byteCount(x uint64) uint {
+	switch {
+	case x < 0x100:
+		return 1
+	case x < 0x10000:
+		return 2
+	case x < 0x1000000:
+		return 3
+	case x < 0x100000000:
+		return 4
+	case x < 0x10000000000:
+		return 5
+	case x < 0x1000000000000:
+		return 6
+	case x < 0x100000000000000:
+		return 7
+	default:
+		return 8
+	}
+}
+
+type fieldInfo struct {
+	count    uint // Number of bytes
+	countSet bool
+	minlen   uint64 // Only relevant for slices
+	maxlen   uint64 // Only relevant for slices
+	selector string // Only relevant for select sub-values
+	val      uint64 // Only relevant for select sub-values
+	name     string // Used for better error messages
+}
+
+func (i *fieldInfo) fieldName() string {
+	if i == nil {
+		return ""
+	}
+	return i.name
+}
+
+// Given a tag string, return a fieldInfo describing the field.
+func fieldTagToFieldInfo(str string, name string) (*fieldInfo, error) {
+	var info *fieldInfo
+	// Iterate over clauses in the tag, ignoring any that don't parse properly.
+	for _, part := range strings.Split(str, ",") {
+		switch {
+		case strings.HasPrefix(part, "maxval:"):
+			if v, err := strconv.ParseUint(part[7:], 10, 64); err == nil {
+				info = &fieldInfo{count: byteCount(v), countSet: true}
+			}
+		case strings.HasPrefix(part, "size:"):
+			if sz, err := strconv.ParseUint(part[5:], 10, 32); err == nil {
+				info = &fieldInfo{count: uint(sz), countSet: true}
+			}
+		case strings.HasPrefix(part, "maxlen:"):
+			v, err := strconv.ParseUint(part[7:], 10, 64)
+			if err != nil {
+				continue
+			}
+			if info == nil {
+				info = &fieldInfo{}
+			}
+			info.count = byteCount(v)
+			info.countSet = true
+			info.maxlen = v
+		case strings.HasPrefix(part, "minlen:"):
+			v, err := strconv.ParseUint(part[7:], 10, 64)
+			if err != nil {
+				continue
+			}
+			if info == nil {
+				info = &fieldInfo{}
+			}
+			info.minlen = v
+		case strings.HasPrefix(part, "selector:"):
+			if info == nil {
+				info = &fieldInfo{}
+			}
+			info.selector = part[9:]
+		case strings.HasPrefix(part, "val:"):
+			v, err := strconv.ParseUint(part[4:], 10, 64)
+			if err != nil {
+				continue
+			}
+			if info == nil {
+				info = &fieldInfo{}
+			}
+			info.val = v
+		}
+	}
+	if info != nil {
+		info.name = name
+		if info.selector == "" {
+			if info.count < 1 {
+				return nil, structuralError{name, "field of unknown size in " + str}
+			} else if info.count > 8 {
+				return nil, structuralError{name, "specified size too large in " + str}
+			} else if info.minlen > info.maxlen {
+				return nil, structuralError{name, "specified length range inverted in " + str}
+			} else if info.val > 0 {
+				return nil, structuralError{name, "specified selector value but not field in " + str}
+			}
+		}
+	} else if name != "" {
+		info = &fieldInfo{name: name}
+	}
+	return info, nil
+}
+
+// Check that a value fits into a field described by a fieldInfo structure.
+func (i fieldInfo) check(val uint64, fldName string) error {
+	if val >= (1 << (8 * i.count)) {
+		return structuralError{fldName, fmt.Sprintf("value %d too large for size", val)}
+	}
+	if i.maxlen != 0 {
+		if val < i.minlen {
+			return structuralError{fldName, fmt.Sprintf("value %d too small for minimum %d", val, i.minlen)}
+		}
+		if val > i.maxlen {
+			return structuralError{fldName, fmt.Sprintf("value %d too large for maximum %d", val, i.maxlen)}
+		}
+	}
+	return nil
+}
+
+// readVarUint reads an big-endian unsigned integer of the given size in
+// bytes.
+func readVarUint(data []byte, info *fieldInfo) (uint64, error) {
+	if info == nil || !info.countSet {
+		return 0, structuralError{info.fieldName(), "no field size information available"}
+	}
+	if len(data) < int(info.count) {
+		return 0, syntaxError{info.fieldName(), "truncated variable-length integer"}
+	}
+	var result uint64
+	for i := uint(0); i < info.count; i++ {
+		result = (result << 8) | uint64(data[i])
+	}
+	if err := info.check(result, info.name); err != nil {
+		return 0, err
+	}
+	return result, nil
+}
+
+// parseField is the main parsing function. Given a byte slice and an offset
+// (in bytes) into the data, it will try to parse a suitable ASN.1 value out
+// and store it in the given Value.
+func parseField(v reflect.Value, data []byte, initOffset int, info *fieldInfo) (int, error) {
+	offset := initOffset
+	rest := data[offset:]
+
+	fieldType := v.Type()
+	// First look for known fixed types.
+	switch fieldType {
+	case uint8Type:
+		if len(rest) < 1 {
+			return offset, syntaxError{info.fieldName(), "truncated uint8"}
+		}
+		v.SetUint(uint64(rest[0]))
+		offset++
+		return offset, nil
+	case uint16Type:
+		if len(rest) < 2 {
+			return offset, syntaxError{info.fieldName(), "truncated uint16"}
+		}
+		v.SetUint(uint64(binary.BigEndian.Uint16(rest)))
+		offset += 2
+		return offset, nil
+	case uint24Type:
+		if len(rest) < 3 {
+			return offset, syntaxError{info.fieldName(), "truncated uint24"}
+		}
+		v.SetUint(uint64(data[0])<<16 | uint64(data[1])<<8 | uint64(data[2]))
+		offset += 3
+		return offset, nil
+	case uint32Type:
+		if len(rest) < 4 {
+			return offset, syntaxError{info.fieldName(), "truncated uint32"}
+		}
+		v.SetUint(uint64(binary.BigEndian.Uint32(rest)))
+		offset += 4
+		return offset, nil
+	case uint64Type:
+		if len(rest) < 8 {
+			return offset, syntaxError{info.fieldName(), "truncated uint64"}
+		}
+		v.SetUint(uint64(binary.BigEndian.Uint64(rest)))
+		offset += 8
+		return offset, nil
+	}
+
+	// Now deal with user-defined types.
+	switch v.Kind() {
+	case enumType.Kind():
+		// Assume that anything of the same kind as Enum is an Enum, so that
+		// users can alias types of their own to Enum.
+		val, err := readVarUint(rest, info)
+		if err != nil {
+			return offset, err
+		}
+		v.SetUint(val)
+		offset += int(info.count)
+		return offset, nil
+	case reflect.Struct:
+		structType := fieldType
+		// TLS includes a select(Enum) {..} construct, where the value of an enum
+		// indicates which variant field is present (like a C union). We require
+		// that the enum value be an earlier field in the same structure (the selector),
+		// and that each of the possible variant destination fields be pointers.
+		// So the Go mapping looks like:
+		//     type variantType struct {
+		//         Which  tls.Enum  `tls:"size:1"`                // this is the selector
+		//         Val1   *type1    `tls:"selector:Which,val:1"`  // this is a destination
+		//         Val2   *type2    `tls:"selector:Which,val:1"`  // this is a destination
+		//     }
+
+		// To deal with this, we track any enum-like fields and their values...
+		enums := make(map[string]uint64)
+		// .. and we track which selector names we've seen (in the destination field tags),
+		// and whether a destination for that selector has been chosen.
+		selectorSeen := make(map[string]bool)
+		for i := 0; i < structType.NumField(); i++ {
+			// Find information about this field.
+			tag := structType.Field(i).Tag.Get("tls")
+			fieldInfo, err := fieldTagToFieldInfo(tag, structType.Field(i).Name)
+			if err != nil {
+				return offset, err
+			}
+
+			destination := v.Field(i)
+			if fieldInfo.selector != "" {
+				// This is a possible select(Enum) destination, so first check that the referenced
+				// selector field has already been seen earlier in the struct.
+				choice, ok := enums[fieldInfo.selector]
+				if !ok {
+					return offset, structuralError{fieldInfo.name, "selector not seen: " + fieldInfo.selector}
+				}
+				if structType.Field(i).Type.Kind() != reflect.Ptr {
+					return offset, structuralError{fieldInfo.name, "choice field not a pointer type"}
+				}
+				// Is this the first mention of the selector field name?  If so, remember it.
+				seen, ok := selectorSeen[fieldInfo.selector]
+				if !ok {
+					selectorSeen[fieldInfo.selector] = false
+				}
+				if choice != fieldInfo.val {
+					// This destination field was not the chosen one, so make it nil (we checked
+					// it was a pointer above).
+					v.Field(i).Set(reflect.Zero(structType.Field(i).Type))
+					continue
+				}
+				if seen {
+					// We already saw a different destination field receive the value for this
+					// selector value, which indicates a badly annotated structure.
+					return offset, structuralError{fieldInfo.name, "duplicate selector value for " + fieldInfo.selector}
+				}
+				selectorSeen[fieldInfo.selector] = true
+				// Make an object of the pointed-to type and parse into that.
+				v.Field(i).Set(reflect.New(structType.Field(i).Type.Elem()))
+				destination = v.Field(i).Elem()
+			}
+			offset, err = parseField(destination, data, offset, fieldInfo)
+			if err != nil {
+				return offset, err
+			}
+
+			// Remember any possible tls.Enum values encountered in case they are selectors.
+			if structType.Field(i).Type.Kind() == enumType.Kind() {
+				enums[structType.Field(i).Name] = v.Field(i).Uint()
+			}
+
+		}
+
+		// Now we have seen all fields in the structure, check that all select(Enum) {..} selector
+		// fields found a destination to put their data in.
+		for selector, seen := range selectorSeen {
+			if !seen {
+				return offset, syntaxError{info.fieldName(), selector + ": unhandled value for selector"}
+			}
+		}
+		return offset, nil
+	case reflect.Array:
+		datalen := v.Len()
+
+		if datalen > len(rest) {
+			return offset, syntaxError{info.fieldName(), "truncated array"}
+		}
+		inner := rest[:datalen]
+		offset += datalen
+		if fieldType.Elem().Kind() != reflect.Uint8 {
+			// Only byte/uint8 arrays are supported
+			return offset, structuralError{info.fieldName(), "unsupported array type: " + v.Type().String()}
+		}
+		reflect.Copy(v, reflect.ValueOf(inner))
+		return offset, nil
+
+	case reflect.Slice:
+		sliceType := fieldType
+		// Slices represent variable-length vectors, which are prefixed by a length field.
+		// The fieldInfo indicates the size of that length field.
+		varlen, err := readVarUint(rest, info)
+		if err != nil {
+			return offset, err
+		}
+		datalen := int(varlen)
+		offset += int(info.count)
+		rest = rest[info.count:]
+
+		if datalen > len(rest) {
+			return offset, syntaxError{info.fieldName(), "truncated slice"}
+		}
+		inner := rest[:datalen]
+		offset += datalen
+		if fieldType.Elem().Kind() == reflect.Uint8 {
+			// Fast version for []byte
+			v.Set(reflect.MakeSlice(sliceType, datalen, datalen))
+			reflect.Copy(v, reflect.ValueOf(inner))
+			return offset, nil
+		}
+
+		v.Set(reflect.MakeSlice(sliceType, 0, datalen))
+		single := reflect.New(sliceType.Elem())
+		for innerOffset := 0; innerOffset < len(inner); {
+			var err error
+			innerOffset, err = parseField(single.Elem(), inner, innerOffset, nil)
+			if err != nil {
+				return offset, err
+			}
+			v.Set(reflect.Append(v, single.Elem()))
+		}
+		return offset, nil
+
+	default:
+		return offset, structuralError{info.fieldName(), fmt.Sprintf("unsupported type: %s of kind %s", fieldType, v.Kind())}
+	}
+}
+
+// Marshal returns the TLS encoding of val.
+func Marshal(val interface{}) ([]byte, error) {
+	return MarshalWithParams(val, "")
+}
+
+// MarshalWithParams returns the TLS encoding of val, and allows field
+// parameters to be specified for the top-level element.  The form
+// of the params is the same as the field tags.
+func MarshalWithParams(val interface{}, params string) ([]byte, error) {
+	info, err := fieldTagToFieldInfo(params, "")
+	if err != nil {
+		return nil, err
+	}
+	var out bytes.Buffer
+	v := reflect.ValueOf(val)
+	if err := marshalField(&out, v, info); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), err
+}
+
+func marshalField(out *bytes.Buffer, v reflect.Value, info *fieldInfo) error {
+	var prefix string
+	if info != nil && len(info.name) > 0 {
+		prefix = info.name + ": "
+	}
+	fieldType := v.Type()
+	// First look for known fixed types.
+	switch fieldType {
+	case uint8Type:
+		out.WriteByte(byte(v.Uint()))
+		return nil
+	case uint16Type:
+		scratch := make([]byte, 2)
+		binary.BigEndian.PutUint16(scratch, uint16(v.Uint()))
+		out.Write(scratch)
+		return nil
+	case uint24Type:
+		i := v.Uint()
+		if i > 0xffffff {
+			return structuralError{info.fieldName(), fmt.Sprintf("uint24 overflow %d", i)}
+		}
+		scratch := make([]byte, 4)
+		binary.BigEndian.PutUint32(scratch, uint32(i))
+		out.Write(scratch[1:])
+		return nil
+	case uint32Type:
+		scratch := make([]byte, 4)
+		binary.BigEndian.PutUint32(scratch, uint32(v.Uint()))
+		out.Write(scratch)
+		return nil
+	case uint64Type:
+		scratch := make([]byte, 8)
+		binary.BigEndian.PutUint64(scratch, uint64(v.Uint()))
+		out.Write(scratch)
+		return nil
+	}
+
+	// Now deal with user-defined types.
+	switch v.Kind() {
+	case enumType.Kind():
+		i := v.Uint()
+		if info == nil {
+			return structuralError{info.fieldName(), "enum field tag missing"}
+		}
+		if err := info.check(i, prefix); err != nil {
+			return err
+		}
+		scratch := make([]byte, 8)
+		binary.BigEndian.PutUint64(scratch, uint64(i))
+		out.Write(scratch[(8 - info.count):])
+		return nil
+	case reflect.Struct:
+		structType := fieldType
+		enums := make(map[string]uint64) // Values of any Enum fields
+		// The comment parseField() describes the mapping of the TLS select(Enum) {..} construct;
+		// here we have selector and source (rather than destination) fields.
+
+		// Track which selector names we've seen (in the source field tags), and whether a source
+		// value for that selector has been processed.
+		selectorSeen := make(map[string]bool)
+		for i := 0; i < structType.NumField(); i++ {
+			// Find information about this field.
+			tag := structType.Field(i).Tag.Get("tls")
+			fieldInfo, err := fieldTagToFieldInfo(tag, structType.Field(i).Name)
+			if err != nil {
+				return err
+			}
+
+			source := v.Field(i)
+			if fieldInfo.selector != "" {
+				// This field is a possible source for a select(Enum) {..}.  First check
+				// the selector field name has been seen.
+				choice, ok := enums[fieldInfo.selector]
+				if !ok {
+					return structuralError{fieldInfo.name, "selector not seen: " + fieldInfo.selector}
+				}
+				if structType.Field(i).Type.Kind() != reflect.Ptr {
+					return structuralError{fieldInfo.name, "choice field not a pointer type"}
+				}
+				// Is this the first mention of the selector field name? If so, remember it.
+				seen, ok := selectorSeen[fieldInfo.selector]
+				if !ok {
+					selectorSeen[fieldInfo.selector] = false
+				}
+				if choice != fieldInfo.val {
+					// This source was not chosen; police that it should be nil.
+					if v.Field(i).Pointer() != uintptr(0) {
+						return structuralError{fieldInfo.name, "unchosen field is non-nil"}
+					}
+					continue
+				}
+				if seen {
+					// We already saw a different source field generate the value for this
+					// selector value, which indicates a badly annotated structure.
+					return structuralError{fieldInfo.name, "duplicate selector value for " + fieldInfo.selector}
+				}
+				selectorSeen[fieldInfo.selector] = true
+				if v.Field(i).Pointer() == uintptr(0) {
+					return structuralError{fieldInfo.name, "chosen field is nil"}
+				}
+				// Marshal from the pointed-to source object.
+				source = v.Field(i).Elem()
+			}
+
+			var fieldData bytes.Buffer
+			if err := marshalField(&fieldData, source, fieldInfo); err != nil {
+				return err
+			}
+			out.Write(fieldData.Bytes())
+
+			// Remember any tls.Enum values encountered in case they are selectors.
+			if structType.Field(i).Type.Kind() == enumType.Kind() {
+				enums[structType.Field(i).Name] = v.Field(i).Uint()
+			}
+		}
+		// Now we have seen all fields in the structure, check that all select(Enum) {..} selector
+		// fields found a source field get get their data from.
+		for selector, seen := range selectorSeen {
+			if !seen {
+				return syntaxError{info.fieldName(), selector + ": unhandled value for selector"}
+			}
+		}
+		return nil
+
+	case reflect.Array:
+		datalen := v.Len()
+		arrayType := fieldType
+		if arrayType.Elem().Kind() != reflect.Uint8 {
+			// Only byte/uint8 arrays are supported
+			return structuralError{info.fieldName(), "unsupported array type"}
+		}
+		bytes := make([]byte, datalen)
+		for i := 0; i < datalen; i++ {
+			bytes[i] = uint8(v.Index(i).Uint())
+		}
+		_, err := out.Write(bytes)
+		return err
+
+	case reflect.Slice:
+		if info == nil {
+			return structuralError{info.fieldName(), "slice field tag missing"}
+		}
+
+		sliceType := fieldType
+		if sliceType.Elem().Kind() == reflect.Uint8 {
+			// Fast version for []byte: first write the length as info.count bytes.
+			datalen := v.Len()
+			scratch := make([]byte, 8)
+			binary.BigEndian.PutUint64(scratch, uint64(datalen))
+			out.Write(scratch[(8 - info.count):])
+
+			if err := info.check(uint64(datalen), prefix); err != nil {
+				return err
+			}
+			// Then just write the data.
+			bytes := make([]byte, datalen)
+			for i := 0; i < datalen; i++ {
+				bytes[i] = uint8(v.Index(i).Uint())
+			}
+			_, err := out.Write(bytes)
+			return err
+		}
+		// General version: use a separate Buffer to write the slice entries into.
+		var innerBuf bytes.Buffer
+		for i := 0; i < v.Len(); i++ {
+			if err := marshalField(&innerBuf, v.Index(i), nil); err != nil {
+				return err
+			}
+		}
+
+		// Now insert (and check) the size.
+		size := uint64(innerBuf.Len())
+		if err := info.check(size, prefix); err != nil {
+			return err
+		}
+		scratch := make([]byte, 8)
+		binary.BigEndian.PutUint64(scratch, size)
+		out.Write(scratch[(8 - info.count):])
+
+		// Then copy the data.
+		_, err := out.Write(innerBuf.Bytes())
+		return err
+
+	default:
+		return structuralError{info.fieldName(), fmt.Sprintf("unsupported type: %s of kind %s", fieldType, v.Kind())}
+	}
+}

--- a/go/tls/tls_test.go
+++ b/go/tls/tls_test.go
@@ -1,0 +1,341 @@
+package tls
+
+import (
+	"bytes"
+	"encoding/hex"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type testStruct struct {
+	Data   []byte `tls:"minlen:2,maxlen:4"`
+	IntVal uint16
+	Other  [4]byte
+	Enum   Enum `tls:"size:2"`
+}
+
+type testVariant struct {
+	Which Enum    `tls:"size:1"`
+	Val16 *uint16 `tls:"selector:Which,val:0"`
+	Val32 *uint32 `tls:"selector:Which,val:1"`
+}
+
+type testTwoVariants struct {
+	Which    Enum    `tls:"size:1"`
+	Val16    *uint16 `tls:"selector:Which,val:0"`
+	Val32    *uint32 `tls:"selector:Which,val:1"`
+	Second   Enum    `tls:"size:1"`
+	Second16 *uint16 `tls:"selector:Second,val:0"`
+	Second32 *uint32 `tls:"selector:Second,val:1"`
+}
+
+// Check that library users can define their own Enum types.
+type aliasEnum Enum
+type testAliasEnum struct {
+	Val   aliasEnum `tls:"size:1"`
+	Val16 *uint16   `tls:"selector:Val,val:1"`
+	Val32 *uint32   `tls:"selector:Val,val:2"`
+}
+
+type testNonByteSlice struct {
+	Vals []uint16 `tls:"minlen:2,maxlen:6"`
+}
+
+type testSliceOfStructs struct {
+	Vals []testVariant `tls:"minlen:0,maxlen:100"`
+}
+
+type testInnerType struct {
+	Val []byte `tls:"minlen:0,maxlen:65535"`
+}
+
+type testSliceOfSlices struct {
+	Inners []testInnerType `tls:"minlen:0,maxlen:65535"`
+}
+
+func TestMarshalUnmarshalRoundTrip(t *testing.T) {
+	thing := testStruct{Data: []byte{0x01, 0x02, 0x03}, IntVal: 42, Other: [4]byte{1, 2, 3, 4}, Enum: 17}
+	data, err := Marshal(thing)
+	if err != nil {
+		t.Fatalf("Failed to Marshal(%+v): %s", thing, err.Error())
+	}
+	var other testStruct
+	rest, err := Unmarshal(data, &other)
+	if err != nil {
+		t.Fatalf("Failed to Unmarshal(%s)", hex.EncodeToString(data))
+	}
+	if len(rest) > 0 {
+		t.Errorf("Data left over after Unmarshal(%s): %s", hex.EncodeToString(data), hex.EncodeToString(rest))
+	}
+}
+
+func TestFieldTagToFieldInfo(t *testing.T) {
+	var tests = []struct {
+		tag    string
+		want   *fieldInfo
+		errstr string
+	}{
+		{"", nil, ""},
+		{"bogus", nil, ""},
+		{"also,bogus", nil, ""},
+		{"also,bogus:99", nil, ""},
+		{"maxval:1xyz", nil, ""},
+		{"maxval:1", &fieldInfo{count: 1, countSet: true}, ""},
+		{"maxval:255", &fieldInfo{count: 1, countSet: true}, ""},
+		{"maxval:256", &fieldInfo{count: 2, countSet: true}, ""},
+		{"maxval:65535", &fieldInfo{count: 2, countSet: true}, ""},
+		{"maxval:65536", &fieldInfo{count: 3, countSet: true}, ""},
+		{"maxval:16777215", &fieldInfo{count: 3, countSet: true}, ""},
+		{"maxval:16777216", &fieldInfo{count: 4, countSet: true}, ""},
+		{"maxval:16777216", &fieldInfo{count: 4, countSet: true}, ""},
+		{"maxval:4294967295", &fieldInfo{count: 4, countSet: true}, ""},
+		{"maxval:4294967296", &fieldInfo{count: 5, countSet: true}, ""},
+		{"maxval:1099511627775", &fieldInfo{count: 5, countSet: true}, ""},
+		{"maxval:1099511627776", &fieldInfo{count: 6, countSet: true}, ""},
+		{"maxval:281474976710655", &fieldInfo{count: 6, countSet: true}, ""},
+		{"maxval:281474976710656", &fieldInfo{count: 7, countSet: true}, ""},
+		{"maxval:72057594037927935", &fieldInfo{count: 7, countSet: true}, ""},
+		{"maxval:72057594037927936", &fieldInfo{count: 8, countSet: true}, ""},
+		{"minlen:1x", nil, ""},
+		{"maxlen:1x", nil, ""},
+		{"maxlen:1", &fieldInfo{count: 1, countSet: true, maxlen: 1}, ""},
+		{"maxlen:255", &fieldInfo{count: 1, countSet: true, maxlen: 255}, ""},
+		{"maxlen:65535", &fieldInfo{count: 2, countSet: true, maxlen: 65535}, ""},
+		{"minlen:65530,maxlen:65535", &fieldInfo{count: 2, countSet: true, minlen: 65530, maxlen: 65535}, ""},
+		{"maxlen:65535,minlen:65530", &fieldInfo{count: 2, countSet: true, minlen: 65530, maxlen: 65535}, ""},
+		{"minlen:65536,maxlen:65535", nil, "inverted"},
+		{"maxlen:16777215", &fieldInfo{count: 3, countSet: true, maxlen: 16777215}, ""},
+		{"maxlen:281474976710655", &fieldInfo{count: 6, countSet: true, maxlen: 281474976710655}, ""},
+		{"maxlen:72057594037927936", &fieldInfo{count: 8, countSet: true, maxlen: 72057594037927936}, ""},
+		{"size:0", nil, "unknown size"},
+		{"size:1", &fieldInfo{count: 1, countSet: true}, ""},
+		{"size:2", &fieldInfo{count: 2, countSet: true}, ""},
+		{"size:3", &fieldInfo{count: 3, countSet: true}, ""},
+		{"size:4", &fieldInfo{count: 4, countSet: true}, ""},
+		{"size:5", &fieldInfo{count: 5, countSet: true}, ""},
+		{"size:6", &fieldInfo{count: 6, countSet: true}, ""},
+		{"size:7", &fieldInfo{count: 7, countSet: true}, ""},
+		{"size:8", &fieldInfo{count: 8, countSet: true}, ""},
+		{"size:9", nil, "too large"},
+		{"size:1x", nil, ""},
+		{"size:1,val:9", nil, "selector value"},
+		{"selector:Bob,val:x9", &fieldInfo{selector: "Bob"}, ""},
+		{"selector:Fred,val:1", &fieldInfo{selector: "Fred", val: 1}, ""},
+		{"val:9,selector:Fred,val:1", &fieldInfo{selector: "Fred", val: 1}, ""},
+	}
+	for _, test := range tests {
+		got, err := fieldTagToFieldInfo(test.tag, "")
+		if test.errstr != "" {
+			if err == nil {
+				t.Errorf("fieldTagToFieldInfo('%v')=%+v,nil; want error %q", test.tag, got, test.errstr)
+			} else if !strings.Contains(err.Error(), test.errstr) {
+				t.Errorf("fieldTagToFieldInfo('%v')=nil,%q; want error %q", test.tag, test.errstr, err.Error())
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("fieldTagToFieldInfo('%v')=nil,%q; want %+v", test.tag, err.Error(), test.want)
+		} else if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("fieldTagToFieldInfo('%v')=%+v,nil; want %+v", test.tag, got, test.want)
+		}
+	}
+}
+
+// Can't take the address of a numeric constant so use helper functions
+func newByte(n byte) *byte       { return &n }
+func newUint8(n uint8) *uint8    { return &n }
+func newUint16(n uint16) *uint16 { return &n }
+func newUint24(n Uint24) *Uint24 { return &n }
+func newUint32(n uint32) *uint32 { return &n }
+func newUint64(n uint64) *uint64 { return &n }
+func newInt16(n int16) *int16    { return &n }
+func newEnum(n Enum) *Enum       { return &n }
+
+func TestUnmarshalMarshalWithParamsRoundTrip(t *testing.T) {
+	var tests = []struct {
+		data   string // hex encoded
+		params string
+		item   interface{}
+	}{
+		{"00", "", newUint8(0)},
+		{"03", "", newByte(3)},
+		{"0101", "", newUint16(0x0101)},
+		{"010203", "", newUint24(0x010203)},
+		{"000000", "", newUint24(0x00)},
+		{"00000009", "", newUint32(0x09)},
+		{"0000000901020304", "", newUint64(0x0901020304)},
+		{"030405", "", &[3]byte{3, 4, 5}},
+		{"03", "", &[1]byte{3}},
+		{"0001", "size:2", newEnum(1)},
+		{"0100000001", "size:5", newEnum(0x100000001)},
+		{"12", "maxval:18", newEnum(18)},
+		// Note that maxval is just used to give enum size; it's not policed
+		{"20", "maxval:18", newEnum(32)},
+		{"020a0b", "minlen:1,maxlen:5", &[]byte{0xa, 0xb}},
+		{"020a0b0101010203040011", "", &testStruct{Data: []byte{0xa, 0xb}, IntVal: 0x101, Other: [4]byte{1, 2, 3, 4}, Enum: 17}},
+		{"000102", "", &testVariant{Which: 0, Val16: newUint16(0x0102)}},
+		{"0101020304", "", &testVariant{Which: 1, Val32: newUint32(0x01020304)}},
+		{"0001020104030201", "", &testTwoVariants{Which: 0, Val16: newUint16(0x0102), Second: 1, Second32: newUint32(0x04030201)}},
+		{"06010102020303", "", &testNonByteSlice{Vals: []uint16{0x101, 0x202, 0x303}}},
+		{"00", "", &testSliceOfStructs{Vals: []testVariant{}}},
+		{"080001020101020304", "",
+			&testSliceOfStructs{
+				Vals: []testVariant{
+					testVariant{Which: 0, Val16: newUint16(0x0102)},
+					testVariant{Which: 1, Val32: newUint32(0x01020304)},
+				},
+			},
+		},
+		{"000a00030102030003040506", "",
+			&testSliceOfSlices{
+				Inners: []testInnerType{
+					testInnerType{Val: []byte{1, 2, 3}},
+					testInnerType{Val: []byte{4, 5, 6}},
+				},
+			},
+		},
+		{"011011", "", &testAliasEnum{Val: 1, Val16: newUint16(0x1011)}},
+		{"0403", "", &SignatureAndHashAlgorithm{Hash: SHA256, Signature: ECDSA}},
+		{"04030003010203", "",
+			&DigitallySigned{
+				Algorithm: SignatureAndHashAlgorithm{Hash: SHA256, Signature: ECDSA},
+				Signature: []byte{1, 2, 3},
+			},
+		},
+	}
+	for _, test := range tests {
+		inVal := reflect.ValueOf(test.item).Elem()
+		pv := reflect.New(reflect.TypeOf(test.item).Elem())
+		val := pv.Interface()
+		inData, _ := hex.DecodeString(test.data)
+		if _, err := UnmarshalWithParams(inData, val, test.params); err != nil {
+			t.Errorf("Unmarshal(%s)=nil,%q; want %+v", test.data, err.Error(), inVal)
+		} else if !reflect.DeepEqual(val, test.item) {
+			t.Errorf("Unmarshal(%s)=%+v,nil; want %+v", test.data, reflect.ValueOf(val).Elem(), inVal)
+		}
+
+		if data, err := MarshalWithParams(inVal.Interface(), test.params); err != nil {
+			t.Errorf("Marshal(%+v)=nil,%q; want %s", inVal, err.Error(), test.data)
+		} else if !bytes.Equal(data, inData) {
+			t.Errorf("Marshal(%+v)=%s,nil; want %s", inVal, hex.EncodeToString(data), test.data)
+		}
+	}
+}
+
+type testInvalidFieldTag struct {
+	Data []byte `tls:"minlen:3,maxlen:2"`
+}
+
+type testDuplicateSelectorVal struct {
+	Which  Enum    `tls:"size:1"`
+	Val    *uint16 `tls:"selector:Which,val:0"`
+	DupVal *uint32 `tls:"selector:Which"` // implicit val:0
+}
+
+type testMissingSelector struct {
+	Val *uint16 `tls:"selector:Missing,val:0"`
+}
+
+type testChoiceNotPointer struct {
+	Which Enum   `tls:"size:1"`
+	Val   uint16 `tls:"selector:Which,val:0"`
+}
+
+type nonEnumAlias uint16
+
+func newNonEnumAlias(n nonEnumAlias) *nonEnumAlias { return &n }
+
+func TestUnmarshalWithParamsFailures(t *testing.T) {
+	var tests = []struct {
+		data   string // hex encoded
+		params string
+		item   interface{}
+		errstr string
+	}{
+		{"", "", newUint8(0), "truncated"},
+		{"0x01", "", newUint16(0x0101), "truncated"},
+		{"0103", "", newUint24(0x010203), "truncated"},
+		{"00", "", newUint24(0x00), "truncated"},
+		{"000009", "", newUint32(0x09), "truncated"},
+		{"00000901020304", "", newUint64(0x0901020304), "truncated"},
+		{"0102", "", newInt16(0x0102), "unsupported type"}, // TLS encoding only supports unsigned integers
+		{"0607", "", &[3]byte{6, 7, 8}, "truncated array"},
+		{"01010202", "", &[3]uint16{0x101, 0x202}, "unsupported array"},
+		{"01", "", newEnum(1), "no field size"},
+		{"00", "size:2", newEnum(0), "truncated"},
+		{"00", "size:9", newEnum(0), "too large"},
+		{"020a0b", "minlen:4,maxlen:8", &[]byte{0x0a, 0x0b}, "too small"},
+		{"040a0b0c0d", "minlen:1,maxlen:3", &[]byte{0x0a, 0x0b, 0x0c, 0x0d}, "too large"},
+		{"020a0b", "minlen:8,maxlen:6", &[]byte{0x0a, 0x0b}, "inverted"},
+		{"020a", "minlen:0,maxlen:6", &[]byte{0x0a, 0x0b}, "truncated"},
+		{"02", "minlen:0,maxlen:6", &[]byte{0x0a, 0x0b}, "truncated"},
+		{"0001", "minlen:0,maxlen:256", &[]byte{0x0a, 0x0b}, "truncated"},
+		{"020a", "minlen:0", &[]byte{0x0a, 0x0b}, "unknown size"},
+		{"020a", "", &[]byte{0x0a, 0x0b}, "no field size information"},
+		{"020a0b", "", &testInvalidFieldTag{}, "range inverted"},
+		{"020a0b01010102030400", "",
+			&testStruct{Data: []byte{0xa, 0xb}, IntVal: 0x101, Other: [4]byte{1, 2, 3, 4}, Enum: 17}, "truncated"},
+		{"010102", "", &testVariant{Which: 1, Val32: newUint32(0x01020304)}, "truncated"},
+		{"092122", "", &testVariant{Which: 0, Val16: newUint16(0x2122)}, "unhandled value for selector"},
+		{"0001020304", "", &testDuplicateSelectorVal{Which: 0, Val: newUint16(0x0102)}, "duplicate selector value"},
+		{"0102", "", &testMissingSelector{Val: newUint16(1)}, "selector not seen"},
+		{"000007", "", &testChoiceNotPointer{Which: 0, Val: 7}, "choice field not a pointer type"},
+		{"05010102020303", "", &testNonByteSlice{Vals: []uint16{0x101, 0x202, 0x303}}, "truncated"},
+		{"0101", "size:2", newNonEnumAlias(0x0102), "unsupported type"},
+		{"0403010203", "",
+			&DigitallySigned{
+				Algorithm: SignatureAndHashAlgorithm{Hash: SHA256, Signature: ECDSA},
+				Signature: []byte{1, 2, 3}}, "truncated"},
+	}
+	for _, test := range tests {
+		pv := reflect.New(reflect.TypeOf(test.item).Elem())
+		val := pv.Interface()
+		in, _ := hex.DecodeString(test.data)
+		if _, err := UnmarshalWithParams(in, val, test.params); err == nil {
+			t.Errorf("Unmarshal(%s)=%+v,nil; want error %q", test.data, reflect.ValueOf(val).Elem(), test.errstr)
+		} else if !strings.Contains(err.Error(), test.errstr) {
+			t.Errorf("Unmarshal(%s)=nil,%q; want error %q", test.data, err.Error(), test.errstr)
+		}
+	}
+}
+
+func TestMarshalWithParamsFailures(t *testing.T) {
+	var tests = []struct {
+		item   interface{}
+		params string
+		errstr string
+	}{
+		{Uint24(0x1000000), "", "overflow"},
+		{int16(0x0102), "", "unsupported type"}, // All TLS ints are unsigned
+		{Enum(1), "", "field tag missing"},
+		{Enum(256), "size:1", "too large"},
+		{Enum(256), "maxval:255", "too large"},
+		{Enum(2), "", "field tag missing"},
+		{Enum(256), "size:9", "too large"},
+		{[]byte{0xa, 0xb, 0xc, 0xd}, "minlen:1,maxlen:3", "too large"},
+		{[]byte{0xa, 0xb, 0xc, 0xd}, "minlen:6,maxlen:13", "too small"},
+		{[]byte{0xa, 0xb, 0xc, 0xd}, "minlen:6,maxlen:3", "inverted"},
+		{[]byte{0xa, 0xb, 0xc, 0xd}, "minlen:6", "unknown size"},
+		{[]byte{0xa, 0xb, 0xc, 0xd}, "", "field tag missing"},
+		{[3]uint16{0x101, 0x202}, "", "unsupported array"},
+		{testInvalidFieldTag{}, "", "inverted"},
+		{testStruct{Data: []byte{0xa}, IntVal: 0x101, Other: [4]byte{1, 2, 3, 4}, Enum: 17}, "", "too small"},
+		{testVariant{Which: 0, Val32: newUint32(0x01020304)}, "", "chosen field is nil"},
+		{testVariant{Which: 0, Val16: newUint16(11), Val32: newUint32(0x01020304)}, "", "unchosen field is non-nil"},
+		{testVariant{Which: 3}, "", "unhandled value for selector"},
+		{testMissingSelector{Val: newUint16(1)}, "", "selector not seen"},
+		{testChoiceNotPointer{Which: 0, Val: 7}, "", "choice field not a pointer"},
+		{testDuplicateSelectorVal{Which: 0, Val: newUint16(1)}, "", "duplicate selector value"},
+		{testNonByteSlice{Vals: []uint16{1, 2, 3, 4}}, "", "too large"},
+		{testSliceOfStructs{[]testVariant{testVariant{Which: 3}}}, "", "unhandled value for selector"},
+		{nonEnumAlias(0x0102), "", "unsupported type"},
+	}
+	for _, test := range tests {
+		if data, err := MarshalWithParams(test.item, test.params); err == nil {
+			t.Errorf("Marshal(%+v)=%x,nil; want error %q", test.item, data, test.errstr)
+		} else if !strings.Contains(err.Error(), test.errstr) {
+			t.Errorf("Marshal(%+v)=nil,%q; want error %q", test.item, err.Error(), test.errstr)
+		}
+	}
+}

--- a/go/tls/types.go
+++ b/go/tls/types.go
@@ -1,0 +1,78 @@
+package tls
+
+import "fmt"
+
+// DigitallySigned gives information about a signature, including the algorithm used
+// and the signature value.  Defined in RFC 5246 s4.7.
+type DigitallySigned struct {
+	Algorithm SignatureAndHashAlgorithm
+	Signature []byte `tls:"minlen:0,maxlen:65535"`
+}
+
+// SignatureAndHashAlgorithm gives information about the algorithms used for a
+// signature.  Defined in RFC 5246 s7.4.1.4.1.
+type SignatureAndHashAlgorithm struct {
+	Hash      HashAlgorithm      `tls:"maxval:255"`
+	Signature SignatureAlgorithm `tls:"maxval:255"`
+}
+
+// HashAlgorithm enum from RFC 5246 s7.4.1.4.1.
+type HashAlgorithm Enum
+
+// HashAlgorithm constants from RFC 5246 s7.4.1.4.1.
+const (
+	None   HashAlgorithm = 0
+	MD5    HashAlgorithm = 1
+	SHA1   HashAlgorithm = 2
+	SHA224 HashAlgorithm = 3
+	SHA256 HashAlgorithm = 4
+	SHA384 HashAlgorithm = 5
+	SHA512 HashAlgorithm = 6
+)
+
+func (h HashAlgorithm) String() string {
+	switch h {
+	case None:
+		return "None"
+	case MD5:
+		return "MD5"
+	case SHA1:
+		return "SHA1"
+	case SHA224:
+		return "SHA224"
+	case SHA256:
+		return "SHA256"
+	case SHA384:
+		return "SHA384"
+	case SHA512:
+		return "SHA512"
+	default:
+		return fmt.Sprintf("UNKNOWN(%d)", h)
+	}
+}
+
+// SignatureAlgorithm enum from RFC 5246 s7.4.1.4.1.
+type SignatureAlgorithm Enum
+
+// SignatureAlgorithm constants from RFC 5246 s7.4.1.4.1.
+const (
+	Anonymous SignatureAlgorithm = 0
+	RSA       SignatureAlgorithm = 1
+	DSA       SignatureAlgorithm = 2
+	ECDSA     SignatureAlgorithm = 3
+)
+
+func (s SignatureAlgorithm) String() string {
+	switch s {
+	case Anonymous:
+		return "Anonymous"
+	case RSA:
+		return "RSA"
+	case DSA:
+		return "DSA"
+	case ECDSA:
+		return "ECDSA"
+	default:
+		return fmt.Sprintf("UNKNOWN(%d)", s)
+	}
+}

--- a/go/tls/types_test.go
+++ b/go/tls/types_test.go
@@ -1,0 +1,42 @@
+package tls
+
+import "testing"
+
+func TestHashAlgorithmString(t *testing.T) {
+	var tests = []struct {
+		algo HashAlgorithm
+		want string
+	}{
+		{None, "None"},
+		{MD5, "MD5"},
+		{SHA1, "SHA1"},
+		{SHA224, "SHA224"},
+		{SHA256, "SHA256"},
+		{SHA384, "SHA384"},
+		{SHA512, "SHA512"},
+		{99, "UNKNOWN(99)"},
+	}
+	for _, test := range tests {
+		if got := test.algo.String(); got != test.want {
+			t.Errorf("%v.String()=%q; want %q", test.algo, got, test.want)
+		}
+	}
+}
+
+func TestSignatureAlgorithmString(t *testing.T) {
+	var tests = []struct {
+		algo SignatureAlgorithm
+		want string
+	}{
+		{Anonymous, "Anonymous"},
+		{RSA, "RSA"},
+		{DSA, "DSA"},
+		{ECDSA, "ECDSA"},
+		{99, "UNKNOWN(99)"},
+	}
+	for _, test := range tests {
+		if got := test.algo.String(); got != test.want {
+			t.Errorf("%v.String()=%q; want %q", test.algo, got, test.want)
+		}
+	}
+}

--- a/go/types.go
+++ b/go/types.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/google/certificate-transparency/go/tls"
 	"github.com/google/certificate-transparency/go/x509"
 )
 
@@ -125,73 +126,9 @@ type AuditPath []MerkleTreeNode
 // LeafInput represents a serialized MerkleTreeLeaf structure
 type LeafInput []byte
 
-// HashAlgorithm from the DigitallySigned struct
-type HashAlgorithm byte
-
-// HashAlgorithm constants
-const (
-	None   HashAlgorithm = 0
-	MD5    HashAlgorithm = 1
-	SHA1   HashAlgorithm = 2
-	SHA224 HashAlgorithm = 3
-	SHA256 HashAlgorithm = 4
-	SHA384 HashAlgorithm = 5
-	SHA512 HashAlgorithm = 6
-)
-
-func (h HashAlgorithm) String() string {
-	switch h {
-	case None:
-		return "None"
-	case MD5:
-		return "MD5"
-	case SHA1:
-		return "SHA1"
-	case SHA224:
-		return "SHA224"
-	case SHA256:
-		return "SHA256"
-	case SHA384:
-		return "SHA384"
-	case SHA512:
-		return "SHA512"
-	default:
-		return fmt.Sprintf("UNKNOWN(%d)", h)
-	}
-}
-
-// SignatureAlgorithm from the the DigitallySigned struct
-type SignatureAlgorithm byte
-
-// SignatureAlgorithm constants
-const (
-	Anonymous SignatureAlgorithm = 0
-	RSA       SignatureAlgorithm = 1
-	DSA       SignatureAlgorithm = 2
-	ECDSA     SignatureAlgorithm = 3
-)
-
-func (s SignatureAlgorithm) String() string {
-	switch s {
-	case Anonymous:
-		return "Anonymous"
-	case RSA:
-		return "RSA"
-	case DSA:
-		return "DSA"
-	case ECDSA:
-		return "ECDSA"
-	default:
-		return fmt.Sprintf("UNKNOWN(%d)", s)
-	}
-}
-
-// DigitallySigned represents an RFC5246 DigitallySigned structure
-type DigitallySigned struct {
-	HashAlgorithm      HashAlgorithm
-	SignatureAlgorithm SignatureAlgorithm
-	Signature          []byte
-}
+// DigitallySigned is a local alias for tls.DigitallySigned so that we can
+// attach a MarshalJSON method.
+type DigitallySigned tls.DigitallySigned
 
 // FromBase64String populates the DigitallySigned structure from the base64 data passed in.
 // Returns an error if the base64 data is invalid.


### PR DESCRIPTION
Summary:
 - create a general TLS encoding/decoding library, analogous to `asn1/`
 - copy/move signature code into it
 - extract common parts of the `LogClient` into `JSONClient` (and tweak slightly) to allow re-use
 - convert existing v1 client code to use the extracted/generalized versions.

Opinions sought on whether I should do less or more commonization:
 - I could commonize less; for example, I could leave the existing `client/` with its own version of `DigitallySigned` by just omitting commit	 5e8bfae (the current change has knock-on compilation failures for anything that uses `ct.DigitallySigned`, e.g. Trillian).
 - I could commonize more, and work through all of the v1 `client` code to replace the hand-rolled TLS-encoding code with use of the `tls/` library. 
