### PR TITLE
Golang: Add RFC1123 Retry-After support and cleanup back-off logic

### DIFF
--- a/go/jsonclient/client.go
+++ b/go/jsonclient/client.go
@@ -137,6 +137,17 @@ func (c *JSONClient) PostAndParse(ctx context.Context, path string, req, rsp int
 	return httpRsp, nil
 }
 
+var maxBackoffInterval = 128 * time.Second
+
+func setBackoff(interval time.Duration) (time.Duration, time.Duration) {
+	backoff := interval
+	interval *= 2
+	if interval > maxBackoffInterval {
+		interval = maxBackoffInterval
+	}
+	return backoff, interval
+}
+
 // PostAndParseWithRetry makes a HTTP POST call, but retries (with backoff) on
 // retriable errors.
 func (c *JSONClient) PostAndParseWithRetry(ctx context.Context, path string, req, rsp interface{}) (*http.Response, error) {
@@ -145,7 +156,6 @@ func (c *JSONClient) PostAndParseWithRetry(ctx context.Context, path string, req
 	}
 	httpStatus := "Unknown"
 	// Retry after 1s, 2s, 4s, 8s, 16s, 32s, 64s, 128s, 128s, ....
-	maxInterval := 128 * time.Second
 	backoffInterval := 1 * time.Second
 	backoffSeconds := time.Duration(0)
 	for {
@@ -161,11 +171,7 @@ func (c *JSONClient) PostAndParseWithRetry(ctx context.Context, path string, req
 		}
 		httpRsp, err := c.PostAndParse(ctx, path, req, rsp)
 		if err != nil {
-			backoffSeconds = backoffInterval
-			backoffInterval *= 2.0
-			if backoffInterval > maxInterval {
-				backoffInterval = maxInterval
-			}
+			backoffSeconds, backoffInterval = setBackoff(backoffInterval)
 			continue
 		}
 		switch {
@@ -175,11 +181,7 @@ func (c *JSONClient) PostAndParseWithRetry(ctx context.Context, path string, req
 			// Request timeout, retry immediately
 		case httpRsp.StatusCode == http.StatusServiceUnavailable:
 			// Retry
-			backoffSeconds = backoffInterval
-			backoffInterval *= 2.0
-			if backoffInterval > maxInterval {
-				backoffInterval = maxInterval
-			}
+			backoffSeconds, backoffInterval = setBackoff(backoffInterval)
 			if retryAfter := httpRsp.Header.Get("Retry-After"); retryAfter != "" {
 				// TODO(drysdale): cope with a retry-after timestamp (RFC 7231 s7.1.3)
 				if seconds, err := strconv.Atoi(retryAfter); err == nil {


### PR DESCRIPTION
Fixes a `TODO` to add support for RFC1123 dates in the `Retry-After` header and removes some code reuse in the back-off logic in `PostAndParseWithRetry`.