### PR TITLE
Golang: Make usage of contexts consistent

### DIFF
--- a/go/client/ctclient/ctclient.go
+++ b/go/client/ctclient/ctclient.go
@@ -13,6 +13,7 @@ import (
 	ct "github.com/google/certificate-transparency/go"
 	"github.com/google/certificate-transparency/go/client"
 	httpclient "github.com/mreiferson/go-httpclient"
+	"golang.org/x/net/context"
 )
 
 var logURI = flag.String("log_uri", "http://ct.googleapis.com/aviator", "CT log base URI")
@@ -30,7 +31,7 @@ func signatureToString(signed *ct.DigitallySigned) string {
 }
 
 func getSTH(logClient *client.LogClient) {
-	sth, err := logClient.GetSTH()
+	sth, err := logClient.GetSTH(context.Background())
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -60,7 +61,7 @@ func addChain(logClient *client.LogClient) {
 		}
 	}
 
-	sct, err := logClient.AddChain(chain)
+	sct, err := logClient.AddChain(context.Background(), chain)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go/client/logclient.go
+++ b/go/client/logclient.go
@@ -124,9 +124,6 @@ func NewWithPubKey(uri string, hc *http.Client, pemEncodedKey string) (*LogClien
 // |path|. If provided context expires before submission is complete an
 // error will be returned.
 func (c *LogClient) addChainWithRetry(ctx context.Context, ctype ct.LogEntryType, path string, chain []ct.ASN1Cert) (*ct.SignedCertificateTimestamp, error) {
-	if ctx == nil {
-		ctx = context.TODO()
-	}
 	var resp addChainResponse
 	var req addChainRequest
 	for _, link := range chain {

--- a/go/client/logclient.go
+++ b/go/client/logclient.go
@@ -158,28 +158,22 @@ func (c *LogClient) addChainWithRetry(ctx context.Context, ctype ct.LogEntryType
 }
 
 // AddChain adds the (DER represented) X509 |chain| to the log.
-func (c *LogClient) AddChain(chain []ct.ASN1Cert) (*ct.SignedCertificateTimestamp, error) {
-	return c.addChainWithRetry(nil, ct.X509LogEntryType, AddChainPath, chain)
-}
-
-// AddPreChain adds the (DER represented) Precertificate |chain| to the log.
-func (c *LogClient) AddPreChain(chain []ct.ASN1Cert) (*ct.SignedCertificateTimestamp, error) {
-	return c.addChainWithRetry(nil, ct.PrecertLogEntryType, AddPreChainPath, chain)
-}
-
-// AddChainWithContext adds the (DER represented) X509 |chain| to the log and
-// fails if the provided context expires before the chain is submitted.
-func (c *LogClient) AddChainWithContext(ctx context.Context, chain []ct.ASN1Cert) (*ct.SignedCertificateTimestamp, error) {
+func (c *LogClient) AddChain(ctx context.Context, chain []ct.ASN1Cert) (*ct.SignedCertificateTimestamp, error) {
 	return c.addChainWithRetry(ctx, ct.X509LogEntryType, AddChainPath, chain)
 }
 
+// AddPreChain adds the (DER represented) Precertificate |chain| to the log.
+func (c *LogClient) AddPreChain(ctx context.Context, chain []ct.ASN1Cert) (*ct.SignedCertificateTimestamp, error) {
+	return c.addChainWithRetry(ctx, ct.PrecertLogEntryType, AddPreChainPath, chain)
+}
+
 // AddJSON submits arbitrary data to to XJSON server.
-func (c *LogClient) AddJSON(data interface{}) (*ct.SignedCertificateTimestamp, error) {
+func (c *LogClient) AddJSON(ctx context.Context, data interface{}) (*ct.SignedCertificateTimestamp, error) {
 	req := addJSONRequest{
 		Data: data,
 	}
 	var resp addChainResponse
-	_, err := c.PostAndParse(context.TODO(), AddJSONPath, &req, &resp)
+	_, err := c.PostAndParse(ctx, AddJSONPath, &req, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -199,9 +193,9 @@ func (c *LogClient) AddJSON(data interface{}) (*ct.SignedCertificateTimestamp, e
 
 // GetSTH retrieves the current STH from the log.
 // Returns a populated SignedTreeHead, or a non-nil error.
-func (c *LogClient) GetSTH() (sth *ct.SignedTreeHead, err error) {
+func (c *LogClient) GetSTH(ctx context.Context) (sth *ct.SignedTreeHead, err error) {
 	var resp getSTHResponse
-	_, err = c.GetAndParse(context.TODO(), GetSTHPath, nil, &resp)
+	_, err = c.GetAndParse(ctx, GetSTHPath, nil, &resp)
 	if err != nil {
 		return
 	}

--- a/go/client/logclient_test.go
+++ b/go/client/logclient_test.go
@@ -135,7 +135,7 @@ func TestGetSTHWorks(t *testing.T) {
 	defer ts.Close()
 
 	client := New(ts.URL, &http.Client{})
-	sth, err := client.GetSTH()
+	sth, err := client.GetSTH(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +167,7 @@ func TestGetSTHWorks(t *testing.T) {
 	}
 }
 
-func TestAddChainWithContext(t *testing.T) {
+func TestAddChain(t *testing.T) {
 	retryAfter := 0
 	currentFailures := 0
 	failuresBeforeSuccess := 0
@@ -228,7 +228,7 @@ func TestAddChainWithContext(t *testing.T) {
 		currentFailures = 0
 
 		started := time.Now()
-		sct, err := c.AddChainWithContext(deadline, chain)
+		sct, err := c.AddChain(deadline, chain)
 		took := time.Since(started)
 		if math.Abs(float64(took-tc.expected)) > float64(leeway) {
 			t.Errorf("#%d Submission took an unexpected length of time: %s, expected ~%s", i, took, tc.expected)
@@ -236,7 +236,7 @@ func TestAddChainWithContext(t *testing.T) {
 		if tc.success && err != nil {
 			t.Errorf("#%d Failed to submit chain: %s", i, err)
 		} else if !tc.success && err == nil {
-			t.Errorf("#%d Expected AddChainWithContext to fail", i)
+			t.Errorf("#%d Expected AddChain to fail", i)
 		}
 		if tc.success && sct == nil {
 			t.Errorf("#%d Nil SCT returned", i)
@@ -263,7 +263,7 @@ func TestAddJSON(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		sct, err := c.AddJSON(tc.data)
+		sct, err := c.AddJSON(context.Background(), tc.data)
 		if tc.success && err != nil {
 			t.Fatalf("Failed to submit json: %s", err)
 		} else if !tc.success && err == nil {

--- a/go/client/logclient_test.go
+++ b/go/client/logclient_test.go
@@ -227,7 +227,7 @@ func TestAddChain(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		var deadline context.Context
+		deadline := context.Background()
 		if tc.deadlineLength >= 0 {
 			deadline, _ = context.WithDeadline(context.Background(), time.Now().Add(time.Duration(tc.deadlineLength)*time.Second))
 		}

--- a/go/preload/main/preload.go
+++ b/go/preload/main/preload.go
@@ -92,13 +92,13 @@ func sctWriterJob(addedCerts <-chan *preload.AddedCert, sctWriter io.Writer, wg 
 	wg.Done()
 }
 
-func certSubmitterJob(addedCerts chan<- *preload.AddedCert, log_client *client.LogClient, certs <-chan *ct.LogEntry,
+func certSubmitterJob(ctx context.Context, addedCerts chan<- *preload.AddedCert, log_client *client.LogClient, certs <-chan *ct.LogEntry,
 	wg *sync.WaitGroup) {
 	for c := range certs {
 		chain := make([]ct.ASN1Cert, len(c.Chain)+1)
 		chain[0] = c.X509Cert.Raw
 		copy(chain[1:], c.Chain)
-		sct, err := log_client.AddChain(context.Background(), chain)
+		sct, err := log_client.AddChain(ctx, chain)
 		if err != nil {
 			log.Printf("failed to add chain with CN %s: %v\n", c.X509Cert.Subject.CommonName, err)
 			recordFailure(addedCerts, chain[0], err)
@@ -112,11 +112,11 @@ func certSubmitterJob(addedCerts chan<- *preload.AddedCert, log_client *client.L
 	wg.Done()
 }
 
-func precertSubmitterJob(addedCerts chan<- *preload.AddedCert, log_client *client.LogClient,
+func precertSubmitterJob(ctx context.Context, addedCerts chan<- *preload.AddedCert, log_client *client.LogClient,
 	precerts <-chan *ct.LogEntry,
 	wg *sync.WaitGroup) {
 	for c := range precerts {
-		sct, err := log_client.AddPreChain(context.Background(), c.Chain)
+		sct, err := log_client.AddPreChain(ctx, c.Chain)
 		if err != nil {
 			log.Printf("failed to add pre-chain with CN %s: %v", c.Precert.TBSCertificate.Subject.CommonName, err)
 			recordFailure(addedCerts, c.Chain[0], err)
@@ -190,11 +190,12 @@ func main() {
 		Transport: transport,
 	})
 
+	backgroundCtx := context.Background()
 	var submitterWG sync.WaitGroup
 	for w := 0; w < *parallelSubmit; w++ {
 		submitterWG.Add(2)
-		go certSubmitterJob(addedCerts, submitLogClient, certs, &submitterWG)
-		go precertSubmitterJob(addedCerts, submitLogClient, precerts, &submitterWG)
+		go certSubmitterJob(backgroundCtx, addedCerts, submitLogClient, certs, &submitterWG)
+		go precertSubmitterJob(backgroundCtx, addedCerts, submitLogClient, precerts, &submitterWG)
 	}
 
 	addChainFunc := func(entry *ct.LogEntry) {

--- a/go/preload/main/preload.go
+++ b/go/preload/main/preload.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/certificate-transparency/go/preload"
 	"github.com/google/certificate-transparency/go/scanner"
 	httpclient "github.com/mreiferson/go-httpclient"
+	"golang.org/x/net/context"
 )
 
 const (
@@ -97,7 +98,7 @@ func certSubmitterJob(addedCerts chan<- *preload.AddedCert, log_client *client.L
 		chain := make([]ct.ASN1Cert, len(c.Chain)+1)
 		chain[0] = c.X509Cert.Raw
 		copy(chain[1:], c.Chain)
-		sct, err := log_client.AddChain(chain)
+		sct, err := log_client.AddChain(context.Background(), chain)
 		if err != nil {
 			log.Printf("failed to add chain with CN %s: %v\n", c.X509Cert.Subject.CommonName, err)
 			recordFailure(addedCerts, chain[0], err)
@@ -115,7 +116,7 @@ func precertSubmitterJob(addedCerts chan<- *preload.AddedCert, log_client *clien
 	precerts <-chan *ct.LogEntry,
 	wg *sync.WaitGroup) {
 	for c := range precerts {
-		sct, err := log_client.AddPreChain(c.Chain)
+		sct, err := log_client.AddPreChain(context.Background(), c.Chain)
 		if err != nil {
 			log.Printf("failed to add pre-chain with CN %s: %v", c.Precert.TBSCertificate.Subject.CommonName, err)
 			recordFailure(addedCerts, c.Chain[0], err)

--- a/go/scanner/scanner.go
+++ b/go/scanner/scanner.go
@@ -13,6 +13,7 @@ import (
 	ct "github.com/google/certificate-transparency/go"
 	"github.com/google/certificate-transparency/go/client"
 	"github.com/google/certificate-transparency/go/x509"
+	"golang.org/x/net/context"
 )
 
 // Clients wishing to implement their own Matchers should implement this interface:
@@ -342,7 +343,7 @@ func (s *Scanner) Scan(foundCert func(*ct.LogEntry),
 	s.unparsableEntries = 0
 	s.entriesWithNonFatalErrors = 0
 
-	latestSth, err := s.logClient.GetSTH()
+	latestSth, err := s.logClient.GetSTH(context.Background())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Remove the special method `client.AddChainWithContext` and make the following methods
take a `x/net/context.Context` as their first parameter:

* `GetSTH`
* `AddPreChain`
* `AddChain`
* `AddJSON`

Fixes #1326.