### PR TITLE
Golang: Fix formatting specifiers for time.Duration log message

### DIFF
--- a/go/jsonclient/client.go
+++ b/go/jsonclient/client.go
@@ -187,7 +187,7 @@ func (c *JSONClient) PostAndParseWithRetry(ctx context.Context, path string, req
 		httpRsp, err := c.PostAndParse(ctx, path, req, rsp)
 		if err != nil {
 			backoffSeconds, backoffInterval = calculateBackoff(backoffInterval)
-			c.logger.Printf("Request failed, backing-off for %d seconds: %s", backoffSeconds, err)
+			c.logger.Printf("Request failed, backing-off for %s: %s", backoffSeconds, err)
 			continue
 		}
 		switch {
@@ -208,7 +208,7 @@ func (c *JSONClient) PostAndParseWithRetry(ctx context.Context, path string, req
 					backoffSeconds = date.Sub(time.Now())
 				}
 			}
-			c.logger.Printf("Request failed, backing-off for %d seconds: got HTTP status %s", backoffSeconds, httpRsp.Status)
+			c.logger.Printf("Request failed, backing-off for %s: got HTTP status %s", backoffSeconds, httpRsp.Status)
 		default:
 			return nil, fmt.Errorf("got HTTP Status %q", httpRsp.Status)
 		}


### PR DESCRIPTION
In # I switched the format specifiers for `backoffSeconds` from `%v` to `%s`. This resulted in log messages that were using nanoseconds but were said to be in seconds (i.e. `Request failed, backing-off for 2000000000 seconds` when `backoffSeconds` was 2 seconds). This patch switches to using `%s` which correctly specifies the units and is the 'proper' format specifier for a `time.Duration`.