### PR TITLE
Do not treat loading an empty certificate file as an error

### DIFF
--- a/cpp/log/cert_checker.cc
+++ b/cpp/log/cert_checker.cc
@@ -72,9 +72,6 @@ bool CertChecker::LoadTrustedCertificatesFromBIO(BIO* bio_in) {
   CHECK_NOTNULL(bio_in);
   vector<pair<string, unique_ptr<const Cert>>> certs_to_add;
   bool error = false;
-  // certs_to_add may be empty if no new certs were added, so keep track of
-  // successfully parsed cert count separately.
-  size_t cert_count = 0;
 
   while (!error) {
     ScopedX509 x509(PEM_read_bio_X509(bio_in, nullptr, nullptr, nullptr));
@@ -89,7 +86,6 @@ bool CertChecker::LoadTrustedCertificatesFromBIO(BIO* bio_in) {
         break;
       }
 
-      ++cert_count;
       if (!is_trusted.ValueOrDie()) {
         certs_to_add.push_back(make_pair(subject_name, move(cert)));
       }
@@ -110,7 +106,7 @@ bool CertChecker::LoadTrustedCertificatesFromBIO(BIO* bio_in) {
     }
   }
 
-  if (error || !cert_count) {
+  if (error) {
     return false;
   }
 

--- a/cpp/log/cert_checker_test.cc
+++ b/cpp/log/cert_checker_test.cc
@@ -59,6 +59,8 @@ static const char kMd2Chain[] = "test-md2-chain.pem";
 static const char kNonexistent[] = "test-nonexistent.pem";
 // A file with corrupted contents (bit flip from ca-cert.pem).
 static const char kCorrupted[] = "test-corrupted.pem";
+// A file that is empty.
+static const char kEmpty[] = "test-empty.pem";
 
 // Corresponds to kCaCert.
 static const char kCaCertPem[] =
@@ -381,6 +383,13 @@ TEST_F(CertCheckerTest, LoadTrustedCertificatesCorruptedFile) {
   EXPECT_EQ(0U, checker_.NumTrustedCertificates());
 
   EXPECT_FALSE(checker_.LoadTrustedCertificates(cert_dir_ + "/" + kCorrupted));
+  EXPECT_EQ(0U, checker_.NumTrustedCertificates());
+}
+
+TEST_F(CertCheckerTest, LoadTrustedCertificatesEmptyFile) {
+  EXPECT_EQ(0U, checker_.NumTrustedCertificates());
+
+  EXPECT_TRUE(checker_.LoadTrustedCertificates(cert_dir_ + "/" + kEmpty));
   EXPECT_EQ(0U, checker_.NumTrustedCertificates());
 }
 


### PR DESCRIPTION
This will cause `CertChecker::LoadTrustedCertificatesFromBIO` to return true when loading an empty file. It previously returned false, indicating an error.