### PR TITLE
Remove flag parsing from tests

### DIFF
--- a/python/ct/client/async_log_client_test.py
+++ b/python/ct/client/async_log_client_test.py
@@ -387,5 +387,3 @@ class AsyncLogClientTest(unittest.TestCase):
         self.pump_get_entries()
         self.assertTrue(consumer.result.check(ValueError))
 
-if __name__ == "__main__" or __name__ == "ct.client.async_log_client_test":
-    sys.argv = FLAGS(sys.argv)

--- a/python/ct/client/monitor_test.py
+++ b/python/ct/client/monitor_test.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env trial
 import copy
 import difflib
-import gflags
 import logging
 import mock
 import os
@@ -20,10 +19,8 @@ from twisted.trial import unittest
 from twisted.web import iweb
 from zope.interface import implements
 
-FLAGS = gflags.FLAGS
-
-#TODO(ekasper) to make this setup common to all tests
-gflags.DEFINE_bool("verbose_tests", False, "Print test logs")
+# Print test logs
+VERBOSE_TESTS=False
 
 
 def dummy_compute_projected_sth(old_sth):
@@ -153,7 +150,7 @@ class MonitorTest(unittest.TestCase):
             _DEFAULT_STATE.verified_tree)
 
     def setUp(self):
-        if not FLAGS.verbose_tests:
+        if not VERBOSE_TESTS:
           logging.disable(logging.CRITICAL)
         self.db = sqlite_log_db.SQLiteLogDB(
             sqlitecon.SQLiteConnectionManager(":memory:", keepalive=True))
@@ -507,5 +504,3 @@ class MonitorTest(unittest.TestCase):
                 ).addCallback(try_again_with_all_entries).addCallback(lambda _:
                     fake_fetch.assert_called_once_with(15, 19))
 
-if __name__ == "__main__" or __name__ == "ct.client.monitor_test":
-    sys.argv = FLAGS(sys.argv)

--- a/python/ct/client/monitor_test.py
+++ b/python/ct/client/monitor_test.py
@@ -19,9 +19,6 @@ from twisted.trial import unittest
 from twisted.web import iweb
 from zope.interface import implements
 
-# Print test logs
-VERBOSE_TESTS=False
-
 
 def dummy_compute_projected_sth(old_sth):
     sth = client_pb2.SthResponse()
@@ -150,8 +147,9 @@ class MonitorTest(unittest.TestCase):
             _DEFAULT_STATE.verified_tree)
 
     def setUp(self):
-        if not VERBOSE_TESTS:
-          logging.disable(logging.CRITICAL)
+        # For verbose tests, comment out the next line.
+        logging.disable(logging.CRITICAL)
+
         self.db = sqlite_log_db.SQLiteLogDB(
             sqlitecon.SQLiteConnectionManager(":memory:", keepalive=True))
         # We can't simply use DB in memory with keepalive True, because different

--- a/python/ct/crypto/verify_test.py
+++ b/python/ct/crypto/verify_test.py
@@ -3,7 +3,6 @@
 import unittest
 
 import base64
-import gflags
 import os
 import sys
 
@@ -15,9 +14,8 @@ from ct.proto import client_pb2
 from ct.serialization import tls_message
 import mock
 
-FLAGS = gflags.FLAGS
-gflags.DEFINE_string("testdata_dir", "../test/testdata",
-                     "Location of test certs")
+# Location of test certs
+TESTDATA_DIR="../test/testdata"
 
 SYMANTEC_B64_KEY = (
     'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEluqsHEYMG1XcDfy1lCdGV0JwOmkY4r'
@@ -34,7 +32,7 @@ VENAFI_B64_KEY = (
 )
 
 def read_testdata_file(test_file):
-    with open(os.path.join(FLAGS.testdata_dir, test_file), 'rb') as f:
+    with open(os.path.join(TESTDATA_DIR, test_file), 'rb') as f:
         return f.read()
 
 
@@ -189,7 +187,7 @@ class LogVerifierTest(object):
             sct.timestamp = fake_timestamp
 
         chain = map(lambda name: cert.Certificate.from_pem_file(
-                        os.path.join(FLAGS.testdata_dir, name)), chain)
+                        os.path.join(TESTDATA_DIR, name)), chain)
 
         key_info = client_pb2.KeyInfo()
         key_info.type = client_pb2.KeyInfo.ECDSA
@@ -200,7 +198,7 @@ class LogVerifierTest(object):
 
     def _test_verify_embedded_scts(self, chain):
         chain = map(lambda name: cert.Certificate.from_pem_file(
-                        os.path.join(FLAGS.testdata_dir, name)), chain)
+                        os.path.join(TESTDATA_DIR, name)), chain)
 
         key_info = client_pb2.KeyInfo()
         key_info.type = client_pb2.KeyInfo.ECDSA
@@ -482,7 +480,3 @@ class CreateKeyInfoTest(unittest.TestCase):
         self.assertEqual(key_info.type, client_pb2.KeyInfo.ECDSA)
         self.assertTrue('PUBLIC KEY' in key_info.pem_key)
 
-
-if __name__ == "__main__":
-    sys.argv = FLAGS(sys.argv)
-    unittest.main()


### PR DESCRIPTION
This stops flags being passed to the test runner, because gflags raises an exception when it encounters an unrecognised flag. Replaced flags with constants.