### PR TITLE
Revert "Only parse test flags if the test is being executed directly"

### DIFF
--- a/python/ct/client/async_log_client_test.py
+++ b/python/ct/client/async_log_client_test.py
@@ -387,5 +387,5 @@ class AsyncLogClientTest(unittest.TestCase):
         self.pump_get_entries()
         self.assertTrue(consumer.result.check(ValueError))
 
-if __name__ == "__main__":
+if __name__ == "__main__" or __name__ == "ct.client.async_log_client_test":
     sys.argv = FLAGS(sys.argv)

--- a/python/ct/client/monitor_test.py
+++ b/python/ct/client/monitor_test.py
@@ -507,5 +507,5 @@ class MonitorTest(unittest.TestCase):
                 ).addCallback(try_again_with_all_entries).addCallback(lambda _:
                     fake_fetch.assert_called_once_with(15, 19))
 
-if __name__ == "__main__":
+if __name__ == "__main__" or __name__ == "ct.client.monitor_test":
     sys.argv = FLAGS(sys.argv)


### PR DESCRIPTION
Reverts google/certificate-transparency#1350.

Caused warnings in the test log about flags not being parsed.