### PR TITLE
Rename CT python proto namespace from ct to ctpy.

### DIFF
--- a/python/ct/proto/certificate.proto
+++ b/python/ct/proto/certificate.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package ct;
+package ctpy;
 
 import "ct/proto/client.proto";
 

--- a/python/ct/proto/client.proto
+++ b/python/ct/proto/client.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto2";
 
-package ct;
+package ctpy;
 
 import "ct/proto/tls_options.proto";
 

--- a/python/ct/proto/client_v2.proto
+++ b/python/ct/proto/client_v2.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package ct;
+package ctpy;
 
 import "ct/proto/client.proto";
 import "ct/proto/tls_options.proto";

--- a/python/ct/proto/test_message.proto
+++ b/python/ct/proto/test_message.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package ct;
+package ctpy;
 
 import "ct/proto/tls_options.proto";
 

--- a/python/ct/proto/tls_options.proto
+++ b/python/ct/proto/tls_options.proto
@@ -2,7 +2,7 @@ syntax = "proto2";
 
 import "google/protobuf/descriptor.proto";
 
-package ct;
+package ctpy;
 
 // TLS field options specify the wire format for parsing TLS wire messages
 // to protocol buffers, using the custom encoder/decoder in tls_message.py.


### PR DESCRIPTION
This is done to avoid conflicts with the protos defined in
certificate_transparency/proto which also use 'ct' for a namespace.

Conflicts occur in the generated code (C++ in particular) and can cause
compilation failures and run-time failures if a binary is linked using
protos from both origins.