### PR TITLE
Python: Export the TBSCertificate

### DIFF
--- a/python/ct/crypto/cert.py
+++ b/python/ct/crypto/cert.py
@@ -221,6 +221,14 @@ class Certificate(object):
         """
         return self._asn1_cert["tbsCertificate"]["extensions"] or []
 
+    def tbscertificate(self):
+        """Returns the underlying tbsCertificate
+
+        Returns:
+            An x509.TBSCertificate instance.
+        """
+        return self._asn1_cert["tbsCertificate"]
+
     def version(self):
         """Get the version.
 

--- a/python/ct/crypto/cert_test.py
+++ b/python/ct/crypto/cert_test.py
@@ -7,8 +7,10 @@ import time
 from ct.crypto import cert
 from ct.crypto import error
 from ct.crypto.asn1 import oid
+from ct.crypto.asn1 import x509_common
 from ct.crypto.asn1 import x509_extension as x509_ext
 from ct.crypto.asn1 import x509_name
+from ct.crypto.asn1 import x509
 from ct.test import test_config
 
 class CertificateTest(unittest.TestCase):
@@ -723,6 +725,14 @@ class CertificateTest(unittest.TestCase):
                                oid.ID_CE_CERTIFICATE_POLICIES,
                                oid.ID_CE_CRL_DISTRIBUTION_POINTS),
                               extensions_oids)
+
+    def test_tbscertificate(self):
+        c = self.cert_from_pem_file(self._PEM_FILE)
+        tbs = c.tbscertificate()
+        self.assertTrue(isinstance(tbs, x509.TBSCertificate))
+        self.assertEqual(
+                x509_common.CertificateSerialNumber(454887626504608315115709L),
+                tbs["serialNumber"])
 
     def test_indefinite_encoding(self):
         self.assertRaises(error.ASN1Error, self.cert_from_pem_file,


### PR DESCRIPTION
Add a method to export the TBSCertificate part of the certificate.

In RFC6962-bis, the signature in the SCT for X.509 certs does not cover
the entire certificate, but the TBSCertificate and the issuer key hash.

To implement issuance of V2 SCTs, access to the TBSCertificate is necessary.