### PR TITLE
Python: Add ECDSA signing code.

### DIFF
--- a/python/README
+++ b/python/README
@@ -8,6 +8,7 @@ protobuf
 mock
 twisted (at least 12.1; tested with 13.2)
 cryptography
+ecdsa (needed for deterministic ECDSA signatures in ct/crypto/signing)
 
 If you use pip, simply run `pip install -r requirements.txt`
 

--- a/python/ct/crypto/signing/signer_ecdsa.py
+++ b/python/ct/crypto/signing/signer_ecdsa.py
@@ -1,0 +1,37 @@
+"""ECDSA signatures suitable for CT logs"""
+from ct.proto import client_pb2
+import hashlib
+import ecdsa
+
+class EcdsaSigner(object):
+    """Signs using deterministic ECDSA signatures."""
+
+    def __init__(self, key_pem):
+        """Creates a signer from a PEM-encoded ECDSA private key.
+
+        Args:
+            - key_pem: Private key, in PEM format.
+        """
+        self.__key = ecdsa.SigningKey.from_pem(key_pem)
+
+    def sign_raw(self, data_to_sign):
+        """Returns the raw signature bytes over |data_to_sign|.
+
+        The signature is deterministic and output is DER encoded.
+        """
+        return self.__key.sign_deterministic(
+                data_to_sign, hashfunc=hashlib.sha256,
+                sigencode=ecdsa.util.sigencode_der)
+
+    def sign(self, data_to_sign):
+        """Returns a signature over |data_to_sign|.
+
+        The returned value is a DigitallySigned protobuf instance with the
+        right signature and hash algorithms set, in addition to the signature
+        itself.
+        """
+        dsig = client_pb2.DigitallySigned()
+        dsig.hash_algorithm = client_pb2.DigitallySigned.SHA256
+        dsig.sig_algorithm = client_pb2.DigitallySigned.ECDSA
+        dsig.signature = self.sign_raw(data_to_sign)
+        return dsig

--- a/python/ct/crypto/signing/signer_ecdsa_test.py
+++ b/python/ct/crypto/signing/signer_ecdsa_test.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+"""Tests for signer_ecdsa."""
+
+import unittest
+
+from ct.proto import client_pb2
+
+from ct.crypto.signing import signer_ecdsa
+
+PRIVATE_KEY_PEM = ("-----BEGIN EC PRIVATE KEY-----\n"
+"MHcCAQEEIFLw4uhuCruGKjrS9MoNeXFbypqZe+Sgh+EL1gnRn1d4oAoGCCqGSM49\n"
+"AwEHoUQDQgAEmXg8sUUzwBYaWrRb+V0IopzQ6o3UyEJ04r5ZrRXGdpYM8K+hB0pX\n"
+"rGRLI0eeWz+3skXrS0IO83AhA3GpRL6s6w==\n"
+                   "-----END EC PRIVATE KEY-----\n")
+
+class SignerEcdsaTest(unittest.TestCase):
+    TEST_DATA = "test"
+    TEST_DATA_SIGNATURE = (
+            "3045022100a5a59ee846fef2e8020bf69cf538cbd61a2b3b3745508d7239dbc094b8"
+            "da0c4c0220256db7344f3ecd13c2040542b5be5335311780b0ab024878352259c3e9"
+            "a2fd4c").decode("hex")
+
+    def testKnownSignatureValue(self):
+        signer = signer_ecdsa.EcdsaSigner(PRIVATE_KEY_PEM)
+        sig = signer.sign_raw(SignerEcdsaTest.TEST_DATA)
+        self.assertEqual(SignerEcdsaTest.TEST_DATA_SIGNATURE, sig)
+
+    def testSignatureIntoDigitallySigned(self):
+        signer = signer_ecdsa.EcdsaSigner(PRIVATE_KEY_PEM)
+        dsig = signer.sign(SignerEcdsaTest.TEST_DATA)
+        self.assertEqual(dsig.hash_algorithm, client_pb2.DigitallySigned.SHA256)
+        self.assertEqual(dsig.sig_algorithm, client_pb2.DigitallySigned.ECDSA)
+        self.assertEqual(SignerEcdsaTest.TEST_DATA_SIGNATURE, dsig.signature)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,5 @@
 dnspython
+ecdsa
 git+https://github.com/google/google-visualization-python.git@04e4c03909980bc12be2ebb3ecf476716d9855d4
 mock>=1.0
 protobuf


### PR DESCRIPTION
Add a module for producing ECDSA signatures that are suitable for use in
CT log implementations (both 6962 and 6962-bis):

* Produce deterministic signatures.
* Signature bytes are DER-encoded.
* Signature is wrapped in a DigitallySigned protobuf for easy TLS
  serialization.

This is necessary for a reference implementation of a 6962-bis log.