### PR TITLE
go/client: make test more resilient

### DIFF
--- a/go/client/logclient_test.go
+++ b/go/client/logclient_test.go
@@ -227,6 +227,7 @@ func TestAddChainRetries(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 	leeway := time.Millisecond * 100
+	leewayRatio := 0.1 // 10%
 	instant := time.Millisecond
 	fiveSeconds := time.Second * 5
 	sevenSeconds := time.Second * 7 // = 1 + 2 + 4
@@ -258,7 +259,9 @@ func TestAddChainRetries(t *testing.T) {
 		started := time.Now()
 		sct, err := client.AddChain(deadline, chain)
 		took := time.Since(started)
-		if math.Abs(float64(took-test.expected)) > float64(leeway) {
+		delta := math.Abs(float64(took - test.expected))
+		ratio := delta / float64(test.expected.Nanoseconds())
+		if delta > float64(leeway) && ratio > leewayRatio {
 			t.Errorf("#%d Submission took an unexpected length of time: %s, expected ~%s", i, took, test.expected)
 		}
 		if test.success && err != nil {

--- a/go/client/logclient_test.go
+++ b/go/client/logclient_test.go
@@ -226,11 +226,11 @@ func TestAddChainRetries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
-	leeway := time.Millisecond * 100
-	leewayRatio := 0.1 // 10%
-	instant := time.Millisecond
-	fiveSeconds := time.Second * 5
-	sevenSeconds := time.Second * 7 // = 1 + 2 + 4
+	const leeway = time.Millisecond * 100
+	const leewayRatio = 0.1 // 10%
+	const instant = time.Millisecond
+	const fiveSeconds = time.Second * 5
+	const sevenSeconds = time.Second * 7 // = 1 + 2 + 4
 
 	tests := []struct {
 		deadlineLength        int
@@ -260,7 +260,7 @@ func TestAddChainRetries(t *testing.T) {
 		sct, err := client.AddChain(deadline, chain)
 		took := time.Since(started)
 		delta := math.Abs(float64(took - test.expected))
-		ratio := delta / float64(test.expected.Nanoseconds())
+		ratio := delta / float64(test.expected)
 		if delta > float64(leeway) && ratio > leewayRatio {
 			t.Errorf("#%d Submission took an unexpected length of time: %s, expected ~%s", i, took, test.expected)
 		}


### PR DESCRIPTION
Only fail the retry timing test if the difference in timings is
both:
 - more than 100ms out
 - more than 10% out.

Hopefully this will reduce test flakes and fix #1360.