### PR TITLE
Remove "invalid-url" test from jsonclient

### DIFF
--- a/go/jsonclient/client_test.go
+++ b/go/jsonclient/client_test.go
@@ -129,7 +129,6 @@ func TestGetAndParse(t *testing.T) {
 		result TestStruct
 		errstr *regexp.Regexp
 	}{
-		{uri: "[invalid-uri]", errstr: rc("too many colons|unexpected .* in address")},
 		{uri: "/short%", errstr: rc("invalid URL escape")},
 		{uri: "/malformed", status: http.StatusOK, errstr: rc("unexpected EOF")},
 		{uri: "/error", params: map[string]string{"rc": "404"}, status: http.StatusNotFound},
@@ -186,7 +185,6 @@ func TestPostAndParse(t *testing.T) {
 		result  TestStruct
 		errstr  *regexp.Regexp
 	}{
-		{uri: "[invalid-uri]", errstr: rc("too many colons|unexpected .* in address")},
 		{uri: "/short%", errstr: rc("invalid URL escape")},
 		{uri: "/struct/params", request: json.Number(`invalid`), errstr: rc("invalid number literal")},
 		{uri: "/malformed", status: http.StatusOK, errstr: rc("unexpected end of JSON")},


### PR DESCRIPTION
That URL is actually not invalid, plus the test breaks the IPv6 compliance
tests I'm working on.

I tried coming up with a really invalid URL, but it's harder than it seems
(libs tend to fix things silently, by adding escapes, for example). In the end I
decided the test doesn't add much value, as it's attempting to test net/http and
not the client logic itself, so I removed it instead.