### PR TITLE
Update GCE log/mirror Dockerfiles & docs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,9 @@ RUN echo 'Building new CT Log Docker image...'
 COPY test/testdata/ca-cert.pem /tmp/
 RUN apt-get update && \
     apt-get install -y software-properties-common && \
-    apt-add-repository -y ppa:jbboehr/coreos && \
     apt-get update && \
     apt-get install -qqy \
-        ca-certificates \
-        etcdctl
+        ca-certificates
 RUN update-ca-certificates && \
     cat /etc/ssl/certs/* /tmp/ca-cert.pem > /usr/local/etc/ctlog_ca_roots.pem
 RUN groupadd -r ctlog && useradd -r -g ctlog ctlog

--- a/Dockerfile-ct-mirror
+++ b/Dockerfile-ct-mirror
@@ -2,11 +2,9 @@ FROM ubuntu:14.04
 RUN echo 'Building new CT Mirror Docker image...'
 RUN apt-get update && \
     apt-get install -y software-properties-common && \
-    apt-add-repository -y ppa:jbboehr/coreos && \
     apt-get update && \
     apt-get install -qqy \
-        ca-certificates \
-        etcdctl
+        ca-certificates
 RUN groupadd -r ctlog && useradd -r -g ctlog ctlog
 RUN mkdir /mnt/ctmirror
 COPY cpp/server/ct-mirror /usr/local/bin/

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -410,11 +410,11 @@ For each software release:
    images by running the following commands.
 
    ```bash
-   % gcloud docker push gcr.io/${PROJECT}/ct-log:${TAG}
-   % gcloud docker push gcr.io/${PROJECT}/ct-mirror:${TAG}
-   % gcloud docker push gcr.io/${PROJECT}/etcd:${TAG}
-   % gcloud docker push gcr.io/${PROJECT}/prometheus:${TAG}
-   % gcloud docker search gcr.io/${PROJECT}
+   % gcloud docker -- push gcr.io/${PROJECT}/ct-log:${TAG}
+   % gcloud docker -- push gcr.io/${PROJECT}/ct-mirror:${TAG}
+   % gcloud docker -- push gcr.io/${PROJECT}/etcd:${TAG}
+   % gcloud docker -- push gcr.io/${PROJECT}/prometheus:${TAG}
+   % gcloud docker -- search gcr.io/${PROJECT}
    NAME                         DESCRIPTION   STARS     OFFICIAL   AUTOMATED
    ct-log-docs-test/ct-log                    0
    ct-log-docs-test/ct-mirror                 0
@@ -534,7 +534,7 @@ from above to make an updated Docker image available to GCP:
  - re-generate the appropriate Docker image (e.g.
    `docker build -f Dockerfile -t gcr.io/${PROJECT}/ct-log:${TAG} .`)
  - push the Docker image to **gcr.io** (e.g.
-   `gcloud docker push gcr.io/${PROJECT}/ct-log:${TAG}`)
+   `gcloud docker -- push gcr.io/${PROJECT}/ct-log:${TAG}`)
 
 The running instances can then be updated with the appropriate
 `cloud/google/update_<type>.sh` script using the Log configuration file


### PR DESCRIPTION
- remove coreos PPA because it's gone away and we don't really need it
  anyway
- gcloud now requires a "--" to separate gcloud and command args.