### PR TITLE
Skip syntax validation for DEPS file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ install:
  - ln -s ../certificate-transparency certificate-transparency
  - |-
    gclient config --spec "solutions=[{\"name\": \"certificate-transparency\", \"url\": \"https://github.com/google/certificate-transparency.git\", \"deps_file\": \"DEPS\", \"managed\": False, \"custom_deps\": {}, \"safesync_url\": \"\", \"custom_vars\": { \"ssl_impl\": \"${SSL}\" } },]"
- - gclient sync
+ - gclient sync --disable-syntax-validation
  - popd
  - export PYTHONPATH=$(python -m site --user-site)
  - pip install --user --upgrade -r python/requirements.txt

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ export CXX=clang++ CC=clang
 mkdir ct  # or whatever directory you prefer
 cd ct
 gclient config --name="certificate-transparency" https://github.com/google/certificate-transparency.git
-gclient sync  # retrieve and build dependencies
+gclient sync --disable-syntax-validation  # retrieve and build dependencies
 # substitute gmake or gnumake below if that's what your platform calls it:
 make -C certificate-transparency check  # build the CT software & self-test
 ```


### PR DESCRIPTION
The DEPS file includes plain Python code to retrieve
platform & num CPUs.  The DEPS syntax checker does not
allow this, as of:
  https://chromium-review.googlesource.com/c/497848/

So disable the validation option.

Fixes #1398.