### PR TITLE
Stop etcd VMs trying to monitor ct-mirror log files

### DIFF
--- a/cloud/google/node_init.sh
+++ b/cloud/google/node_init.sh
@@ -42,11 +42,16 @@ fi
 sudo bash ./${AGENT_INSTALL_SCRIPT}
 
 # Examine what kind of Docker image is on this machine to determine what to log.
-if docker images | grep ct-server; then
+DOCKER_REPOS_FILE=$(mktemp)
+docker images --format '{{ .Repository }}' > "${DOCKER_REPOS_FILE}"
+
+if grep '/ct-server$' "${DOCKER_REPOS_FILE}"; then
   CT_LOGS_PREFIX="${DATA_DIR}/ctlog/logs/ct-server"
-elif docker images | grep ct-mirror; then
+elif grep '/ct-mirror$' "${DOCKER_REPOS_FILE}"; then
   CT_LOGS_PREFIX="${DATA_DIR}/ctmirror/logs/ct-mirror"
 fi
+
+rm "${DOCKER_REPOS_FILE}"
 
 if [[ -n "${CT_LOGS_PREFIX}" ]]; then
   sudo cat > /etc/google-fluentd/config.d/ct-info.conf <<EOF


### PR DESCRIPTION
The previous grep would match "ct-mirror" part was through the etcd image name, e.g. "gcr.io/ct-mirror-pilot/etcd". Now, it should only match the intended image, e.g. "gcr.io/ct-mirror-pilot/ct-mirror".