### PR TITLE
Mutable tree based on API proposal originated by Google

### DIFF
--- a/cpp/merkletree/merkle_tree.cc
+++ b/cpp/merkletree/merkle_tree.cc
@@ -295,11 +295,6 @@ MutableMerkleTree::MutableMerkleTree(unique_ptr<SerialHasher> hasher)
 
 MutableMerkleTree::~MutableMerkleTree() {}
 
-bool MutableMerkleTree::UpdateLeaf(size_t leaf, const string& data) {
-  // Optimized for success: hash computed before validating the leaf's position.
-  return UpdateLeafHash(leaf, treehasher_.HashLeaf(data));
-}
-
 bool MutableMerkleTree::UpdateLeafHash(size_t leaf, const string& hash) {
   if (leaf == 0 || leaf > LeafCount()) return false;
 

--- a/cpp/merkletree/merkle_tree.cc
+++ b/cpp/merkletree/merkle_tree.cc
@@ -336,11 +336,9 @@ bool MutableMerkleTree::Truncate(size_t leaf) {
   if (leaf > LeafCount()) return false;
 
   if (leaf == 0) {
-    if (leaves_processed_ > 0) {
       tree_.clear();
       leaves_processed_ = 0;
       level_count_ = 0;
-    }
 
     return true;
   }

--- a/cpp/merkletree/merkle_tree.cc
+++ b/cpp/merkletree/merkle_tree.cc
@@ -291,19 +291,23 @@ size_t MerkleTree::LazyLevelCount() const {
 }
 
 MutableMerkleTree::MutableMerkleTree(unique_ptr<SerialHasher> hasher)
-    : MerkleTree(move(hasher)) {}
+    : MerkleTree(move(hasher)) {
+}
 
-MutableMerkleTree::~MutableMerkleTree() {}
+MutableMerkleTree::~MutableMerkleTree() {
+}
 
 bool MutableMerkleTree::UpdateLeafHash(size_t leaf, const string& hash) {
-  if (leaf == 0 || leaf > LeafCount()) return false;
+  if (leaf == 0 || leaf > LeafCount())
+    return false;
 
   // Update the leaf node.
   size_t child = leaf - 1;
   tree_[0].replace(treehasher_.DigestSize() * child, treehasher_.DigestSize(),
                    hash);
 
-  if (leaf > leaves_processed_) return true;
+  if (leaf > leaves_processed_)
+    return true;
 
   // Update the parents chain, level by level.
   size_t child_level = 0;
@@ -333,12 +337,13 @@ bool MutableMerkleTree::UpdateLeafHash(size_t leaf, const string& hash) {
 }
 
 bool MutableMerkleTree::Truncate(size_t leaf) {
-  if (leaf > LeafCount()) return false;
+  if (leaf > LeafCount())
+    return false;
 
   if (leaf == 0) {
-      tree_.clear();
-      leaves_processed_ = 0;
-      level_count_ = 0;
+    tree_.clear();
+    leaves_processed_ = 0;
+    level_count_ = 0;
 
     return true;
   }
@@ -354,7 +359,8 @@ bool MutableMerkleTree::Truncate(size_t leaf) {
     child = MerkleTreeMath::Parent(child);
   }
 
-  if (leaf > leaves_processed_) return true;
+  if (leaf > leaves_processed_)
+    return true;
 
   // Truncate each level above the leaves level.
   child = leaf - 1;

--- a/cpp/merkletree/merkle_tree.cc
+++ b/cpp/merkletree/merkle_tree.cc
@@ -289,3 +289,99 @@ void MerkleTree::AddLevel() {
 size_t MerkleTree::LazyLevelCount() const {
   return tree_.size();
 }
+
+MutableMerkleTree::MutableMerkleTree(unique_ptr<SerialHasher> hasher)
+    : MerkleTree(move(hasher)) {}
+
+MutableMerkleTree::~MutableMerkleTree() {}
+
+bool MutableMerkleTree::UpdateLeaf(size_t leaf, const string& data) {
+  // Optimized for success: hash computed before validating the leaf's position.
+  return UpdateLeafHash(leaf, treehasher_.HashLeaf(data));
+}
+
+bool MutableMerkleTree::UpdateLeafHash(size_t leaf, const string& hash) {
+  if (leaf == 0 || leaf > LeafCount()) return false;
+
+  // Update the leaf node.
+  size_t child = leaf - 1;
+  tree_[0].replace(treehasher_.DigestSize() * child, treehasher_.DigestSize(),
+                   hash);
+
+  if (leaf > leaves_processed_) return true;
+
+  // Update the parents chain, level by level.
+  size_t child_level = 0;
+  size_t parent = MerkleTreeMath::Parent(child);
+  string parent_hash;
+  while (child) {
+    if (MerkleTreeMath::IsRightChild(child)) {
+      parent_hash = treehasher_.HashChildren(Node(child_level, child - 1),
+                                             Node(child_level, child));
+    } else if (child < NodeCount(child_level) - 1) {
+      parent_hash = treehasher_.HashChildren(Node(child_level, child),
+                                             Node(child_level, child + 1));
+    } else {
+      // Propagate the "dummy" node.
+      parent_hash = Node(child_level, child);
+    }
+
+    tree_[child_level + 1].replace(treehasher_.DigestSize() * parent,
+                                   treehasher_.DigestSize(), parent_hash);
+
+    child = parent;
+    parent = MerkleTreeMath::Parent(parent);
+    ++child_level;
+  }
+
+  return true;
+}
+
+bool MutableMerkleTree::Truncate(size_t leaf) {
+  if (leaf > LeafCount()) return false;
+
+  if (leaf == 0) {
+    if (leaves_processed_ > 0) {
+      tree_.clear();
+      leaves_processed_ = 0;
+      level_count_ = 0;
+    }
+
+    return true;
+  }
+
+  // Truncate leaves level.
+  size_t child = leaf - 1;
+  tree_[0].erase(treehasher_.DigestSize() * (child + 1));
+
+  // Update levels count.
+  level_count_ = 1;
+  while (child) {
+    ++level_count_;
+    child = MerkleTreeMath::Parent(child);
+  }
+
+  if (leaf > leaves_processed_) return true;
+
+  // Truncate each level above the leaves level.
+  child = leaf - 1;
+  size_t child_level = 0;
+  size_t parent = MerkleTreeMath::Parent(child);
+  while (child) {
+    tree_[child_level + 1].erase(treehasher_.DigestSize() * (parent + 1));
+
+    child = parent;
+    parent = MerkleTreeMath::Parent(parent);
+    ++child_level;
+  }
+
+  // The current child_level value corresponds to the root level - remove empty
+  // levels.
+  if (child_level + 1 < tree_.size())
+    tree_.erase(tree_.begin() + child_level + 1, tree_.end());
+
+  // Update rightmost chain of nodes.
+  assert(UpdateLeafHash(leaf, LeafHash(leaf)));
+
+  return true;
+}

--- a/cpp/merkletree/merkle_tree.h
+++ b/cpp/merkletree/merkle_tree.h
@@ -217,10 +217,6 @@ class MutableMerkleTree : public MerkleTree {
   explicit MutableMerkleTree(std::unique_ptr<SerialHasher> hasher);
   virtual ~MutableMerkleTree();
 
-  // Update |leaf|th leaf in the tree. Indexing starts from 1.
-  // Returns false if |leaf| is out of bounds.
-  bool UpdateLeaf(size_t leaf, const std::string& data);
-
   // Update |leaf|th leaf hash in the tree. Indexing starts from 1.
   // Returns false if |leaf| is out of bounds.
   bool UpdateLeafHash(size_t leaf, const std::string& hash);

--- a/cpp/merkletree/merkle_tree.h
+++ b/cpp/merkletree/merkle_tree.h
@@ -130,7 +130,7 @@ class MerkleTree : public cert_trans::MerkleTreeInterface {
   std::vector<std::string> SnapshotConsistency(size_t snapshot1,
                                                size_t snapshot2);
 
- private:
+ protected:
   // Update to a given snapshot, return the root.
   std::string UpdateToSnapshot(size_t snapshot);
   // Return the root of a past snapshot.
@@ -207,6 +207,27 @@ class MerkleTree : public cert_trans::MerkleTreeInterface {
   size_t leaves_processed_;
   // The "true" level count for a fully evaluated tree.
   size_t level_count_;
+};
+
+// Mutable Merkle Tree, supports updating nodes and truncating the tree.
+class MutableMerkleTree : public MerkleTree {
+ public:
+  // The constructor takes a pointer to some concrete hash function
+  // instantiation of the SerialHasher abstract class.
+  explicit MutableMerkleTree(std::unique_ptr<SerialHasher> hasher);
+  virtual ~MutableMerkleTree();
+
+  // Update |leaf|th leaf in the tree. Indexing starts from 1.
+  // Returns false if |leaf| is out of bounds.
+  bool UpdateLeaf(size_t leaf, const string& data);
+
+  // Update |leaf|th leaf hash in the tree. Indexing starts from 1.
+  // Returns false if |leaf| is out of bounds.
+  bool UpdateLeafHash(size_t leaf, const string& hash);
+
+  // Truncate the tree by removing all leafs beyond |leaf|th leaf. Indexing
+  // starts from 1. Returns false if |leaf| is out of bounds.
+  bool Truncate(size_t leaf);
 };
 
 #endif  // CERT_TRANS_MERKLETREE_MERKLE_TREE_H_

--- a/cpp/merkletree/merkle_tree.h
+++ b/cpp/merkletree/merkle_tree.h
@@ -219,11 +219,11 @@ class MutableMerkleTree : public MerkleTree {
 
   // Update |leaf|th leaf in the tree. Indexing starts from 1.
   // Returns false if |leaf| is out of bounds.
-  bool UpdateLeaf(size_t leaf, const string& data);
+  bool UpdateLeaf(size_t leaf, const std::string& data);
 
   // Update |leaf|th leaf hash in the tree. Indexing starts from 1.
   // Returns false if |leaf| is out of bounds.
-  bool UpdateLeafHash(size_t leaf, const string& hash);
+  bool UpdateLeafHash(size_t leaf, const std::string& hash);
 
   // Truncate the tree by removing all leafs beyond |leaf|th leaf. Indexing
   // starts from 1. Returns false if |leaf| is out of bounds.


### PR DESCRIPTION
The new API supports applications that need to be able to modify leaf data. This never happens in CT hence there is an additional interface for those that need it.

An example usage is committing to a large data set that evolves slowly over time. Instead of building a tree each time and then throwing it away and rebuilding it next time the tree can be updated to the current state and the new root hash obtained.