### PR TITLE
Migrate from gflags to absl.flags.

### DIFF
--- a/python/README
+++ b/python/README
@@ -1,7 +1,7 @@
 To run the python scripts
 
 1. Install the following additional packages
-gflags (python_gflags if using easy_install)
+absl-py
 gviz-api-py (easy_install 'https://google-visualization-python.googlecode.com/files/gviz_api_py-1.8.2.tar.gz')
 requests (at least version 1.0)
 protobuf

--- a/python/ct/client/async_log_client.py
+++ b/python/ct/client/async_log_client.py
@@ -1,8 +1,8 @@
 """RFC 6962 client API."""
 
+from absl import flags as gflags
 from ct.client import log_client
 from ct.client.db import database
-import gflags
 import logging
 import random
 

--- a/python/ct/client/async_log_client_test.py
+++ b/python/ct/client/async_log_client_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env trial
-import gflags
+from absl import flags as gflags
 import json
 import mock
 import sys

--- a/python/ct/client/db/cert_desc_test.py
+++ b/python/ct/client/db/cert_desc_test.py
@@ -4,11 +4,11 @@ import unittest
 
 import time
 import sys
+from absl import flags as gflags
 from ct.client.db import cert_desc
 from ct.crypto import cert
 from ct.test import test_config
 from ct.test import time_utils
-import gflags
 
 CERT = cert.Certificate.from_der_file(
         test_config.get_test_file_path("google_cert.der"))

--- a/python/ct/client/db/sqlite_cert_db.py
+++ b/python/ct/client/db/sqlite_cert_db.py
@@ -1,6 +1,6 @@
 import sqlite3
-import gflags
 
+from absl import flags as gflags
 from ct.client.db import cert_db
 from ct.client.db import cert_desc
 

--- a/python/ct/client/db/sqlite_cert_db_test.py
+++ b/python/ct/client/db/sqlite_cert_db_test.py
@@ -3,10 +3,10 @@
 import unittest
 
 import sys
+from absl import flags as gflags
 from ct.client.db import sqlite_connection as sqlitecon
 from ct.client.db import sqlite_cert_db
 from ct.client.db import cert_db_test
-import gflags
 
 class SQLiteCertDBTest(unittest.TestCase, cert_db_test.CertDBTest):
     def setUp(self):

--- a/python/ct/client/db_reporter.py
+++ b/python/ct/client/db_reporter.py
@@ -1,6 +1,6 @@
 import logging
 import threading
-import gflags
+from absl import flags as gflags
 from ct.client import reporter
 from Queue import Queue
 

--- a/python/ct/client/db_reporter_test.py
+++ b/python/ct/client/db_reporter_test.py
@@ -3,8 +3,8 @@ import unittest
 
 import mock
 import sys
+from absl import flags as gflags
 from ct.client import db_reporter
-import gflags
 
 
 class DbReporterTest(unittest.TestCase):

--- a/python/ct/client/log_client.py
+++ b/python/ct/client/log_client.py
@@ -2,9 +2,9 @@
 import base64
 import json
 
+from absl import flags as gflags
 from ct.crypto import verify
 from ct.proto import client_pb2
-import gflags
 import logging
 import requests
 import urllib

--- a/python/ct/client/log_client_test.py
+++ b/python/ct/client/log_client_test.py
@@ -8,11 +8,11 @@ import mock
 import requests
 import sys
 
+from absl import flags as gflags
 from ct.client import log_client
 from ct.client import log_client_test_util as test_util
 from ct.crypto import merkle
 from ct.proto import client_pb2
-import gflags
 
 FLAGS = gflags.FLAGS
 

--- a/python/ct/client/monitor.py
+++ b/python/ct/client/monitor.py
@@ -1,6 +1,6 @@
-import gflags
 import logging
 
+from absl import flags as gflags
 from ct.client import entry_decoder
 from ct.client import state
 from ct.client import aggregated_reporter

--- a/python/ct/client/monitor_test.py
+++ b/python/ct/client/monitor_test.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env trial
 import copy
 import difflib
-import gflags
 import logging
 import mock
 import os
 import sys
 
+from absl import flags as gflags
 from ct.client import log_client
 from ct.client.db import sqlite_connection as sqlitecon
 from ct.client.db import sqlite_log_db

--- a/python/ct/client/prober.py
+++ b/python/ct/client/prober.py
@@ -1,7 +1,8 @@
-import gflags
 import logging
 import threading
 import time
+
+from absl import flags as gflags
 
 FLAGS = gflags.FLAGS
 

--- a/python/ct/client/reporter.py
+++ b/python/ct/client/reporter.py
@@ -1,5 +1,4 @@
 import abc
-import gflags
 import hashlib
 import logging
 import multiprocessing
@@ -7,6 +6,7 @@ import sys
 import threading
 import traceback
 
+from absl import flags as gflags
 from ct.client.db import cert_desc
 from ct.crypto import cert
 from ct.crypto import error

--- a/python/ct/client/reporter_test.py
+++ b/python/ct/client/reporter_test.py
@@ -3,6 +3,7 @@ import unittest
 
 import sys
 from collections import defaultdict
+from absl import flags as gflags
 from ct.client import reporter
 from ct.client.db import cert_desc
 from ct.client.db import sqlite_cert_db
@@ -11,7 +12,6 @@ from ct.crypto import cert
 from ct.proto import certificate_pb2
 from ct.proto import client_pb2
 from ct.test import test_config
-import gflags
 
 STRICT_DER = cert.Certificate.from_der_file(
         test_config.get_test_file_path('google_cert.der'), False).to_der()

--- a/python/ct/client/text_reporter.py
+++ b/python/ct/client/text_reporter.py
@@ -1,6 +1,6 @@
-import gflags
 import logging
 
+from absl import flags as gflags
 from collections import defaultdict
 from ct.client import reporter
 

--- a/python/ct/client/tools/simple_scan.py
+++ b/python/ct/client/tools/simple_scan.py
@@ -3,7 +3,7 @@
 import os
 import sys
 
-import gflags
+from absl import flags as gflags
 
 from ct.client import scanner
 

--- a/python/ct/client/tools/verify_single_proof.py
+++ b/python/ct/client/tools/verify_single_proof.py
@@ -4,12 +4,12 @@
 import struct
 import sys
 
+from absl import flags as gflags
 from ct.client import log_client
 from ct.crypto import cert
 from ct.crypto import merkle
 from ct.proto import client_pb2
 from ct.serialization import tls_message
-import gflags
 
 FLAGS = gflags.FLAGS
 

--- a/python/ct/crypto/tools/cert_util.py
+++ b/python/ct/crypto/tools/cert_util.py
@@ -29,11 +29,11 @@ Known commands:
 """
 
 import sys
+from absl import flags as gflags
 from ct.crypto import cert
 from ct.crypto import error
 from ct.crypto import pem
 from ct.crypto.asn1 import print_util
-import gflags
 
 FLAGS = gflags.FLAGS
 gflags.DEFINE_bool("subject", False, "Print option: prints certificate subject")
@@ -46,7 +46,7 @@ gflags.DEFINE_bool("debug", False,
 gflags.DEFINE_string("filetype", "", "Read option: specify an input file "
                      "format (pem or der). If no format is specified, the "
                      "parser attempts to detect the format automatically.")
-gflags.RegisterValidator("filetype", lambda value: not value or
+gflags.register_validator("filetype", lambda value: not value or
                          value.lower() in {"pem", "der"},
                          message="--filetype must be one of pem or der")
 
@@ -115,14 +115,14 @@ def main(argv):
         try:
             argv = FLAGS(argv)
             exit_with_message("No command")
-        except gflags.FlagsError as e:
+        except gflags.Error as e:
             exit_with_message("Error parsing flags: %s" % e)
 
     argv = argv[1:]
 
     try:
         argv = FLAGS(argv)
-    except gflags.FlagsError as e:
+    except gflags.Error as e:
         exit_with_message("Error parsing flags: %s" % e)
 
     command, argv = argv[0], argv[1:]

--- a/python/ct/crypto/tools/verify_util.py
+++ b/python/ct/crypto/tools/verify_util.py
@@ -17,12 +17,12 @@ Known commands:
 """
 
 import sys
+from absl import flags as gflags
 from ct.crypto import cert
 from ct.crypto import pem
 from ct.crypto import verify
 from ct.proto import client_pb2
 from ct.serialization import tls_message
-import gflags
 
 FLAGS = gflags.FLAGS
 gflags.DEFINE_string("sct", None, "TLS-encoded SCT file")
@@ -51,14 +51,14 @@ def main(argv):
         try:
             argv = FLAGS(argv)
             exit_with_message("No command")
-        except gflags.FlagsError as e:
+        except gflags.Error as e:
             exit_with_message("Error parsing flags: %s" % e)
 
     argv = argv[1:]
 
     try:
         argv = FLAGS(argv)
-    except gflags.FlagsError as e:
+    except gflags.Error as e:
         exit_with_message("Error parsing flags: %s" % e)
 
     command, cert_file = argv[0:2]

--- a/python/ct/crypto/verify_test.py
+++ b/python/ct/crypto/verify_test.py
@@ -3,10 +3,10 @@
 import unittest
 
 import base64
-import gflags
 import os
 import sys
 
+from absl import flags as gflags
 from ct.crypto import cert
 from ct.crypto import error
 from ct.crypto import pem

--- a/python/ct/dashboard/dashboard.py
+++ b/python/ct/dashboard/dashboard.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import gflags
+from absl import flags as gflags
 from google.protobuf import text_format
 import logging
 import os

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,9 +1,9 @@
+absl-py
 dnspython
 ecdsa
 git+https://github.com/google/google-visualization-python.git@04e4c03909980bc12be2ebb3ecf476716d9855d4
 mock>=1.0
 protobuf
-python-gflags
 requests>=1.0
 Twisted>=12.1
 bitstring

--- a/python/utilities/log_list/print_log_list.py
+++ b/python/utilities/log_list/print_log_list.py
@@ -8,7 +8,7 @@ import os
 import sys
 import time
 
-import gflags
+from absl import flags as gflags
 import jsonschema
 import M2Crypto
 
@@ -19,7 +19,7 @@ from openssl_generator import generate_openssl_conf
 FLAGS = gflags.FLAGS
 
 gflags.DEFINE_string("log_list", None, "Logs list file to parse and print.")
-gflags.MarkFlagAsRequired("log_list")
+gflags.mark_flag_as_required("log_list")
 gflags.DEFINE_string("signature", None, "Signature file over the list of logs.")
 gflags.DEFINE_string("signer_key", None, "Public key of the log list signer.")
 gflags.DEFINE_string("log_list_schema",

--- a/python/utilities/logobserver/logobserver.py
+++ b/python/utilities/logobserver/logobserver.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import gflags
+from absl import flags as gflags
 from google.protobuf import text_format
 import logging
 import os

--- a/python/utilities/precerts_finder/precerts_finder.py
+++ b/python/utilities/precerts_finder/precerts_finder.py
@@ -4,7 +4,7 @@
 import os
 import sys
 
-import gflags
+from absl import flags as gflags
 
 from ct.client import scanner
 from ct.proto import client_pb2

--- a/python/utilities/submit_chain/submit_chain.py
+++ b/python/utilities/submit_chain/submit_chain.py
@@ -7,7 +7,7 @@ import sys
 
 import json
 import logging
-import gflags
+from absl import flags as gflags
 
 from ct.client import log_client
 from ct.crypto import cert
@@ -25,9 +25,9 @@ gflags.DEFINE_string("log_list", None, "File containing the list of logs "
 gflags.DEFINE_string("chain", None, "Certificate chain to submit (PEM).")
 gflags.DEFINE_string("log_scheme", "http", "Log scheme (http/https)")
 gflags.DEFINE_string("output", None, "output file for sct_list")
-gflags.MarkFlagAsRequired("log_list")
-gflags.MarkFlagAsRequired("chain")
-gflags.MarkFlagAsRequired("output")
+gflags.mark_flag_as_required("log_list")
+gflags.mark_flag_as_required("chain")
+gflags.mark_flag_as_required("output")
 
 def _read_ct_log_list(log_list_file):
     """Parses the log list JSON, returns a log url to key map."""


### PR DESCRIPTION
[python-gflags](https://github.com/google/python-gflags) was merged into [abseil-py](https://github.com/abseil/abseil-py) and no longer maintained.

Tested with `make test` following [python/README](https://github.com/google/certificate-transparency/blob/master/python/README).