### PR TITLE
Check for the sqlite3 headers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,8 @@ AC_CHECK_HEADER([leveldb/db.h],,
                 [AC_MSG_ERROR([leveldb headers could not be found])])
 AC_CHECK_HEADER([ldns/ldns.h],, [missing_ldns=yes])
 AC_CHECK_HEADER([objecthash.h],, [missing_objecthash=yes])
+AC_CHECK_HEADER([sqlite3.h],,
+                [AC_MSG_ERROR([sqlite3 headers could not be found])])
 
 # Check for working GTest/GMock.
 saved_CPPFLAGS="$CPPFLAGS"


### PR DESCRIPTION
The configure script checks for the presense of a few other libraries
(such as OpenSSL), but not sqlite3. This change adds a check for the
sqlite3 header, and bails if it can't find it.

Signed-off-by: Paul Tagliamonte <paultag@dds.mil>