### PR TITLE
Add "tls" extra to Twisted requirement

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,7 +5,7 @@ git+https://github.com/google/google-visualization-python.git@04e4c03909980bc12b
 mock>=1.0
 protobuf
 requests>=1.0
-Twisted>=12.1
+Twisted[tls]>=12.1
 bitstring
 jsonschema
 cryptography>=1.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -9,4 +9,3 @@ Twisted[tls]>=12.1
 bitstring
 jsonschema
 cryptography>=1.0
-pyopenssl


### PR DESCRIPTION
This is required to install dependencies required for TLS support in Twisted >= 15.1.0 (see https://github.com/twisted/twisted/blob/twisted-15.1.0/NEWS).