### PR TITLE
Support for resubmitted certificates and SCTs from a special purpose authority.

### DIFF
--- a/cpp/log/cert_submission_handler.cc
+++ b/cpp/log/cert_submission_handler.cc
@@ -64,6 +64,85 @@ CertSubmissionHandler::CertSubmissionHandler(const CertChecker* cert_checker)
     : cert_checker_(CHECK_NOTNULL(cert_checker)) {
 }
 
+// static
+StatusOr<size_t> CertSubmissionHandler::X509ChainToEntries(
+    const CertChain& chain,
+    std::vector<LogEntry>* entries) {
+  if (!chain.IsLoaded()) {
+    return util::Status(util::error::INVALID_ARGUMENT,
+                        "Certificate chain not loaded");
+  }
+
+  const StatusOr<bool> has_embedded_proof = chain.LeafCert()->HasExtension(
+      cert_trans::NID_ctEmbeddedSignedCertificateTimestampList);
+  if (!has_embedded_proof.ok()) {
+    return util::Status(util::error::INVALID_ARGUMENT,
+                        "Failed to check embedded SCT extension.");
+  }
+
+  // Always create the full entry for the whole X509. It can be always used
+  // for SCTs provided in TLS handshake or in stapled OCSP response.
+  LogEntry full_entry;
+  std::vector<LogEntry> tmp_entries;
+  full_entry.set_type(ct::X509_ENTRY);
+  string der_cert;
+  if (chain.LeafCert()->DerEncoding(&der_cert) != ::util::OkStatus()) {
+    return util::Status(util::error::INVALID_ARGUMENT,
+                        "Encoding of the leaf cert to DER failed.");
+  }
+
+  full_entry.mutable_x509_entry()->set_leaf_certificate(der_cert);
+  tmp_entries.push_back(full_entry);
+
+  if (has_embedded_proof.ValueOrDie() && chain.Length() > 1) {
+    // Issuer (the second certificate in the chain) can always create a
+    // precert entry (2nd option in RFC 6962, section 3.1). The other
+    // certificates only when they have the 1.3.6.1.4.1.11129.2.4.4 extension.
+    for (size_t i = 1; i < chain.Length(); ++i) {
+      StatusOr<bool> is_special_signer;
+
+      if (i != 1) {
+        is_special_signer = chain.CertAt(i)->HasExtendedKeyUsage(
+            cert_trans::NID_ctPrecertificateSigning);
+        if (!is_special_signer.ok()) {
+          return util::Status(util::error::INVALID_ARGUMENT,
+                              "Failed to check special signer extension.");
+        }
+      }
+
+      if (i == 1 || is_special_signer.ValueOrDie()) {
+        LogEntry entry;
+        entry.set_type(ct::PRECERT_ENTRY);
+        string key_hash;
+        if (chain.CertAt(i)->SPKISha256Digest(&key_hash) !=
+            ::util::OkStatus()) {
+          return util::Status(util::error::INVALID_ARGUMENT,
+                              "SHA256 fingerprint computation failed.");
+        }
+
+        entry.mutable_precert_entry()->mutable_pre_cert()->set_issuer_key_hash(
+            key_hash);
+
+        string tbs;
+        if (!SerializedTbs(*chain.LeafCert(), &tbs)) {
+          return util::Status(util::error::INVALID_ARGUMENT,
+                              "TBS certificate serialization failed.");
+        }
+
+        entry.mutable_precert_entry()->mutable_pre_cert()->set_tbs_certificate(
+            tbs);
+        tmp_entries.push_back(entry);
+      }
+    }
+  }
+
+  // Everything was successful, copy entries to the result and report the count.
+  for (const auto &log_entry : tmp_entries) {
+    entries->push_back(log_entry);
+  }
+
+  return tmp_entries.size();
+}
 
 // static
 bool CertSubmissionHandler::X509ChainToEntry(const CertChain& chain,

--- a/cpp/log/cert_submission_handler.cc
+++ b/cpp/log/cert_submission_handler.cc
@@ -125,7 +125,7 @@ StatusOr<size_t> CertSubmissionHandler::X509ChainToEntries(
 
         string tbs;
         if (!SerializedTbs(*chain.LeafCert(), &tbs)) {
-          return util::Status(util::error::INVALID_ARGUMENT,
+          return util::Status(util::error::UNKNOWN,
                               "TBS certificate serialization failed.");
         }
 

--- a/cpp/log/cert_submission_handler.h
+++ b/cpp/log/cert_submission_handler.h
@@ -2,6 +2,7 @@
 #define CERT_TRANS_LOG_CERT_SUBMISSION_HANDLER_H_
 
 #include <string>
+#include <vector>
 
 #include "log/cert_checker.h"
 #include "proto/ct.pb.h"
@@ -29,9 +30,20 @@ class CertSubmissionHandler {
   util::Status ProcessPreCertSubmission(cert_trans::PreCertChain* chain,
                                         ct::LogEntry* entry) const;
 
-  // For clients, to reconstruct the bytestring under the signature
-  // from the observed chain. Does not check whether the entry
-  // has valid format (i.e., does not check length limits).
+  // For clients, to reconstruct all possible bytestrings under the signature
+  // from the observed chain. Does not check whether the entry has valid format
+  // (i.e., does not check length limits). Returns the number of entries
+  // written or an error meesage.
+  static util::StatusOr<size_t> X509ChainToEntries(
+      const cert_trans::CertChain& chain,
+      std::vector<ct::LogEntry>* entries);
+
+  // Deprecated version, please use X509ChainToEntries.
+  // Same as X509ChainToEntries, but does not support log entries that are
+  // signed by a special-purpose certificate (the 1st option in RFC6962,
+  // section 3.1) neither certificates with embedded SCTs that were again
+  // submitted to a certificate log in order to get new SCTs that can be
+  // sent in a TLS handshake extension or in a stapled OCSP response.
   static bool X509ChainToEntry(const cert_trans::CertChain& chain,
                                ct::LogEntry* entry);
 


### PR DESCRIPTION
Current implementation of X509ChainToEntry does not support certificates with embedded SCTs that were submitted to a certificate log again in order to get SCTs that can be additionally used in TLS handshake extensions or in stapled OCSP responses.

The same implementation also supports only embedded SCTs, whose precertificates were issued directly by the issuer of the certificate. However, according to RFC 6962, section 3.1, those precertificates can be also issued by a special-purpose certification authority.

This change addresses both these issues.