### PR TITLE
Support for resubmitted certs and SCTs from a special purpose authority

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
   include:
     - compiler: clang
       os: osx
+      osx_image: xcode7.3
       env: SSL=openssl
     - compiler: clang
       os: linux
@@ -105,11 +106,7 @@ install:
  - gclient sync --disable-syntax-validation
  - popd
  - export PYTHONPATH=$(python -m site --user-site)
- - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-     pip2 install --upgrade -r python/requirements.txt;
-   else
-     pip install --user --upgrade -r python/requirements.txt;
-   fi
+ - pip install --user --upgrade -r python/requirements.txt
 
 script:
  - getconf _NPROCESSORS_ONLN

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,10 @@ matrix:
   include:
     - compiler: clang
       os: osx
-      env: SSL=openssl PIP=pip2
+      env: SSL=openssl
     - compiler: clang
       os: linux
-      env: SSL=boringssl PIP=pip LLVM=3.6.2
+      env: SSL=boringssl LLVM=3.6.2
       addons:
         apt:
           sources: *common_sources
@@ -37,7 +37,7 @@ matrix:
           - *common_packages
     - compiler: clang
       os: linux
-      env: SSL=openssl PIP=pip LLVM=3.6.2
+      env: SSL=openssl LLVM=3.6.2
       addons:
         apt:
           sources: *common_sources
@@ -45,7 +45,7 @@ matrix:
           - *common_packages
     - compiler: clang
       os: linux
-      env: SSL=openssl PIP=pip LLVM=3.6.2 SANITIZE="-fsanitize=address -fno-omit-frame-pointer" ASAN_OPTIONS="detect_leaks=1:check_initialization_order=1" LSAN_OPTIONS="suppressions=${HOME}/lsan.supp"
+      env: SSL=openssl LLVM=3.6.2 SANITIZE="-fsanitize=address -fno-omit-frame-pointer" ASAN_OPTIONS="detect_leaks=1:check_initialization_order=1" LSAN_OPTIONS="suppressions=${HOME}/lsan.supp"
       addons:
         apt:
           sources: *common_sources
@@ -105,7 +105,7 @@ install:
  - gclient sync --disable-syntax-validation
  - popd
  - export PYTHONPATH=$(python -m site --user-site)
- - "${PIP}" install --user --upgrade -r python/requirements.txt
+ - python -m pip install --user --upgrade -r python/requirements.txt
 
 script:
  - getconf _NPROCESSORS_ONLN

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,10 @@ matrix:
   include:
     - compiler: clang
       os: osx
-      env: SSL=openssl
+      env: SSL=openssl PIP=pip2
     - compiler: clang
       os: linux
-      env: SSL=boringssl LLVM=3.6.2
+      env: SSL=boringssl PIP=pip LLVM=3.6.2
       addons:
         apt:
           sources: *common_sources
@@ -37,7 +37,7 @@ matrix:
           - *common_packages
     - compiler: clang
       os: linux
-      env: SSL=openssl LLVM=3.6.2
+      env: SSL=openssl PIP=pip LLVM=3.6.2
       addons:
         apt:
           sources: *common_sources
@@ -45,7 +45,7 @@ matrix:
           - *common_packages
     - compiler: clang
       os: linux
-      env: SSL=openssl LLVM=3.6.2 SANITIZE="-fsanitize=address -fno-omit-frame-pointer" ASAN_OPTIONS="detect_leaks=1:check_initialization_order=1" LSAN_OPTIONS="suppressions=${HOME}/lsan.supp"
+      env: SSL=openssl PIP=pip LLVM=3.6.2 SANITIZE="-fsanitize=address -fno-omit-frame-pointer" ASAN_OPTIONS="detect_leaks=1:check_initialization_order=1" LSAN_OPTIONS="suppressions=${HOME}/lsan.supp"
       addons:
         apt:
           sources: *common_sources
@@ -105,7 +105,7 @@ install:
  - gclient sync --disable-syntax-validation
  - popd
  - export PYTHONPATH=$(python -m site --user-site)
- - pip install --user --upgrade -r python/requirements.txt
+ - "${PIP}" install --user --upgrade -r python/requirements.txt
 
 script:
  - getconf _NPROCESSORS_ONLN

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,11 @@ install:
  - gclient sync --disable-syntax-validation
  - popd
  - export PYTHONPATH=$(python -m site --user-site)
- - python -m pip install --user --upgrade -r python/requirements.txt
+ - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+     pip2 install --upgrade -r python/requirements.txt;
+   else
+     pip install --user --upgrade -r python/requirements.txt;
+   fi
 
 script:
  - getconf _NPROCESSORS_ONLN

--- a/cpp/log/cert_submission_handler.cc
+++ b/cpp/log/cert_submission_handler.cc
@@ -82,19 +82,19 @@ Status CertSubmissionHandler::X509ChainToEntries(
                   "Failed to check embedded SCT extension.");
   }
 
-  // Always create the full entry for the whole X509. It can be always used
-  // for SCTs provided in TLS handshake or in stapled OCSP response.
+  // Always create the full entry for the whole X509 certificate.
+  // It can be always used for SCTs provided in TLS handshake or in stapled
+  // OCSP response.
   LogEntry full_entry;
-  vector<LogEntry> tmp_entries;
   full_entry.set_type(ct::X509_ENTRY);
   string der_cert;
   if (chain.LeafCert()->DerEncoding(&der_cert) != ::util::OkStatus()) {
     return Status(util::error::INVALID_ARGUMENT,
                   "Encoding of the leaf cert to DER failed.");
   }
-
   full_entry.mutable_x509_entry()->set_leaf_certificate(der_cert);
 
+  vector<LogEntry> tmp_entries;
   if (has_embedded_proof.ValueOrDie() && chain.Length() > 1) {
     // Issuer (the second certificate in the chain) can always create a
     // precert entry (2nd option in RFC 6962, section 3.1). The other

--- a/cpp/log/cert_submission_handler.cc
+++ b/cpp/log/cert_submission_handler.cc
@@ -64,6 +64,85 @@ CertSubmissionHandler::CertSubmissionHandler(const CertChecker* cert_checker)
     : cert_checker_(CHECK_NOTNULL(cert_checker)) {
 }
 
+// static
+StatusOr<size_t> CertSubmissionHandler::X509ChainToEntries(
+    const CertChain& chain,
+    std::vector<LogEntry>* entries) {
+  if (!chain.IsLoaded()) {
+    return util::Status(util::error::INVALID_ARGUMENT,
+                        "Certificate chain not loaded");
+  }
+
+  const StatusOr<bool> has_embedded_proof = chain.LeafCert()->HasExtension(
+      cert_trans::NID_ctEmbeddedSignedCertificateTimestampList);
+  if (!has_embedded_proof.ok()) {
+    return util::Status(util::error::INVALID_ARGUMENT,
+                        "Failed to check embedded SCT extension.");
+  }
+
+  // Always create the full entry for the whole X509. It can be always used
+  // for SCTs provided in TLS handshake or in stapled OCSP response.
+  LogEntry full_entry;
+  std::vector<LogEntry> tmp_entries;
+  full_entry.set_type(ct::X509_ENTRY);
+  string der_cert;
+  if (chain.LeafCert()->DerEncoding(&der_cert) != ::util::OkStatus()) {
+    return util::Status(util::error::INVALID_ARGUMENT,
+                        "Encoding of the leaf cert to DER failed.");
+  }
+
+  full_entry.mutable_x509_entry()->set_leaf_certificate(der_cert);
+  tmp_entries.push_back(full_entry);
+
+  if (has_embedded_proof.ValueOrDie() && chain.Length() > 1) {
+    // Issuer (the second certificate in the chain) can always create a
+    // precert entry (2nd option in RFC 6962, section 3.1). The other
+    // certificates only when they have the 1.3.6.1.4.1.11129.2.4.4 extension.
+    for (size_t i = 1; i < chain.Length(); ++i) {
+      StatusOr<bool> is_special_signer;
+
+      if (i != 1) {
+        is_special_signer = chain.CertAt(i)->HasExtendedKeyUsage(
+            cert_trans::NID_ctPrecertificateSigning);
+        if (!is_special_signer.ok()) {
+          return util::Status(util::error::INVALID_ARGUMENT,
+                              "Failed to check special signer extension.");
+        }
+      }
+
+      if (i == 1 || is_special_signer.ValueOrDie()) {
+        LogEntry entry;
+        entry.set_type(ct::PRECERT_ENTRY);
+        string key_hash;
+        if (chain.CertAt(i)->SPKISha256Digest(&key_hash) !=
+            ::util::OkStatus()) {
+          return util::Status(util::error::INVALID_ARGUMENT,
+                              "SHA256 fingerprint computation failed.");
+        }
+
+        entry.mutable_precert_entry()->mutable_pre_cert()->set_issuer_key_hash(
+            key_hash);
+
+        string tbs;
+        if (!SerializedTbs(*chain.LeafCert(), &tbs)) {
+          return util::Status(util::error::UNKNOWN,
+                              "TBS certificate serialization failed.");
+        }
+
+        entry.mutable_precert_entry()->mutable_pre_cert()->set_tbs_certificate(
+            tbs);
+        tmp_entries.push_back(entry);
+      }
+    }
+  }
+
+  // Everything was successful, copy entries to the result and report the count.
+  for (const auto &log_entry : tmp_entries) {
+    entries->push_back(log_entry);
+  }
+
+  return tmp_entries.size();
+}
 
 // static
 bool CertSubmissionHandler::X509ChainToEntry(const CertChain& chain,

--- a/cpp/log/cert_submission_handler.cc
+++ b/cpp/log/cert_submission_handler.cc
@@ -68,7 +68,7 @@ CertSubmissionHandler::CertSubmissionHandler(const CertChecker* cert_checker)
 // static
 Status CertSubmissionHandler::X509ChainToEntries(
     const CertChain& chain,
-    LogEntry *x509_entries,
+    LogEntry *x509_entry,
     vector<LogEntry>* precert_entries) {
   if (!chain.IsLoaded()) {
     return Status(util::error::INVALID_ARGUMENT,
@@ -145,7 +145,7 @@ Status CertSubmissionHandler::X509ChainToEntries(
   }
 
   // Everything was successful, write the results.
-  *x509_entries = full_entry;
+  *x509_entry = full_entry;
   for (const auto &log_entry : tmp_entries) {
     precert_entries->push_back(log_entry);
   }

--- a/cpp/log/cert_submission_handler.h
+++ b/cpp/log/cert_submission_handler.h
@@ -32,8 +32,7 @@ class CertSubmissionHandler {
 
   // For clients, to reconstruct all possible bytestrings under the signature
   // from the observed chain. Does not check whether the entry has valid format
-  // (i.e., does not check length limits). Returns the number of entries
-  // written or an error meesage.
+  // (i.e., does not check length limits).
   static util::Status X509ChainToEntries(
       const cert_trans::CertChain& chain,
       ct::LogEntry *x509_entry,
@@ -42,7 +41,7 @@ class CertSubmissionHandler {
   // Deprecated version, please use X509ChainToEntries.
   // Same as X509ChainToEntries, but does not support log entries that are
   // signed by a special-purpose certificate (the 1st option in RFC6962,
-  // section 3.1) neither certificates with embedded SCTs that were again
+  // section 3.1) nor certificates with embedded SCTs that were again
   // submitted to a certificate log in order to get new SCTs that can be
   // sent in a TLS handshake extension or in a stapled OCSP response.
   static bool X509ChainToEntry(const cert_trans::CertChain& chain,

--- a/cpp/log/cert_submission_handler.h
+++ b/cpp/log/cert_submission_handler.h
@@ -36,7 +36,7 @@ class CertSubmissionHandler {
   // written or an error meesage.
   static util::Status X509ChainToEntries(
       const cert_trans::CertChain& chain,
-      ct::LogEntry *x509_entries,
+      ct::LogEntry *x509_entry,
       std::vector<ct::LogEntry>* precert_entries);
 
   // Deprecated version, please use X509ChainToEntries.

--- a/cpp/log/cert_submission_handler.h
+++ b/cpp/log/cert_submission_handler.h
@@ -34,9 +34,10 @@ class CertSubmissionHandler {
   // from the observed chain. Does not check whether the entry has valid format
   // (i.e., does not check length limits). Returns the number of entries
   // written or an error meesage.
-  static util::StatusOr<size_t> X509ChainToEntries(
+  static util::Status X509ChainToEntries(
       const cert_trans::CertChain& chain,
-      std::vector<ct::LogEntry>* entries);
+      ct::LogEntry *x509_entries,
+      std::vector<ct::LogEntry>* precert_entries);
 
   // Deprecated version, please use X509ChainToEntries.
   // Same as X509ChainToEntries, but does not support log entries that are

--- a/cpp/log/cert_submission_handler.h
+++ b/cpp/log/cert_submission_handler.h
@@ -2,6 +2,7 @@
 #define CERT_TRANS_LOG_CERT_SUBMISSION_HANDLER_H_
 
 #include <string>
+#include <vector>
 
 #include "log/cert_checker.h"
 #include "proto/ct.pb.h"
@@ -29,9 +30,20 @@ class CertSubmissionHandler {
   util::Status ProcessPreCertSubmission(cert_trans::PreCertChain* chain,
                                         ct::LogEntry* entry) const;
 
-  // For clients, to reconstruct the bytestring under the signature
-  // from the observed chain. Does not check whether the entry
-  // has valid format (i.e., does not check length limits).
+  // For clients, to reconstruct all possible bytestrings under the signature
+  // from the observed chain. Does not check whether the entry has valid format
+  // (i.e., does not check length limits). Returns the number of entries
+  // written or an error meesage.
+  static util::StatusOr<size_t> X509ChainToEntries(
+      const cert_trans::CertChain& chain,
+      std::vector<ct::LogEntry>* entries);
+
+  // Deprecated version, please use X509ChainToEntries.
+  // Same as X509ChainToEntries, but does not support log entries that are
+  // signed by a special-purpose certificate (the 1st option in RFC6962,
+  // section 3.1) neither certificates with embedded SCTs that were again
+  // submitted to a certificate log in order to get new SCTs that can be
+  // sent in a TLS handshake extension or in a stapled OCSP response.
   static bool X509ChainToEntry(const cert_trans::CertChain& chain,
                                ct::LogEntry* entry);
 

--- a/cpp/log/cert_submission_handler_test.cc
+++ b/cpp/log/cert_submission_handler_test.cc
@@ -217,15 +217,15 @@ TEST_F(CertSubmissionHandlerTest, SubmitInvalidPreCertChain) {
 
 TEST_F(CertSubmissionHandlerTest, ConvertChainWithoutEmbeddedSCTs) {
   CertChain chain(leaf_ + ca_);
-  ct::LogEntry x509_entries;
+  ct::LogEntry x509_entry;
   std::vector<ct::LogEntry> precert_entries;
   EXPECT_EQ(CertSubmissionHandler::X509ChainToEntries(
-      chain, &x509_entries, &precert_entries), util::OkStatus());
+      chain, &x509_entry, &precert_entries), util::OkStatus());
 
-  EXPECT_EQ(ct::LogEntryType::X509_ENTRY, x509_entries.type());
-  EXPECT_TRUE(x509_entries.has_x509_entry());
-  EXPECT_FALSE(x509_entries.has_precert_entry());
-  EXPECT_TRUE(x509_entries.x509_entry().has_leaf_certificate());
+  EXPECT_EQ(ct::LogEntryType::X509_ENTRY, x509_entry.type());
+  EXPECT_TRUE(x509_entry.has_x509_entry());
+  EXPECT_FALSE(x509_entry.has_precert_entry());
+  EXPECT_TRUE(x509_entry.x509_entry().has_leaf_certificate());
 
   EXPECT_EQ(0, precert_entries.size());
 }
@@ -233,15 +233,15 @@ TEST_F(CertSubmissionHandlerTest, ConvertChainWithoutEmbeddedSCTs) {
 TEST_F(CertSubmissionHandlerTest, ConvertChainWithSCTsPresignedByIssuer) {
   CertChain chain(embedded_ + ca_);
   std::vector<ct::LogEntry> entries;
-  ct::LogEntry x509_entries;
+  ct::LogEntry x509_entry;
   std::vector<ct::LogEntry> precert_entries;
   EXPECT_EQ(CertSubmissionHandler::X509ChainToEntries(
-      chain, &x509_entries, &precert_entries), util::OkStatus());
+      chain, &x509_entry, &precert_entries), util::OkStatus());
 
-  EXPECT_EQ(ct::LogEntryType::X509_ENTRY, x509_entries.type());
-  EXPECT_TRUE(x509_entries.has_x509_entry());
-  EXPECT_FALSE(x509_entries.has_precert_entry());
-  EXPECT_TRUE(x509_entries.x509_entry().has_leaf_certificate());
+  EXPECT_EQ(ct::LogEntryType::X509_ENTRY, x509_entry.type());
+  EXPECT_TRUE(x509_entry.has_x509_entry());
+  EXPECT_FALSE(x509_entry.has_precert_entry());
+  EXPECT_TRUE(x509_entry.x509_entry().has_leaf_certificate());
 
   EXPECT_EQ(1, precert_entries.size());
 
@@ -257,15 +257,15 @@ TEST_F(CertSubmissionHandlerTest, ConvertChainWithSCTsPresignedByIssuer) {
 TEST_F(CertSubmissionHandlerTest, ConvertChainWithSCTsPresignedBySpecialCrt) {
   CertChain chain(embedded_preca_ + ca_ + ca_precert_);
   std::vector<ct::LogEntry> entries;
-  ct::LogEntry x509_entries;
+  ct::LogEntry x509_entry;
   std::vector<ct::LogEntry> precert_entries;
   EXPECT_EQ(CertSubmissionHandler::X509ChainToEntries(
-      chain, &x509_entries, &precert_entries), util::OkStatus());
+      chain, &x509_entry, &precert_entries), util::OkStatus());
 
-  EXPECT_EQ(ct::LogEntryType::X509_ENTRY, x509_entries.type());
-  EXPECT_TRUE(x509_entries.has_x509_entry());
-  EXPECT_FALSE(x509_entries.has_precert_entry());
-  EXPECT_TRUE(x509_entries.x509_entry().has_leaf_certificate());
+  EXPECT_EQ(ct::LogEntryType::X509_ENTRY, x509_entry.type());
+  EXPECT_TRUE(x509_entry.has_x509_entry());
+  EXPECT_FALSE(x509_entry.has_precert_entry());
+  EXPECT_TRUE(x509_entry.x509_entry().has_leaf_certificate());
 
   EXPECT_EQ(2, precert_entries.size());
 


### PR DESCRIPTION
Current implementation of X509ChainToEntry does not support certificates with embedded SCTs that were submitted to a certificate log again in order to get SCTs that can be additionally used in TLS handshake extensions or in stapled OCSP responses.

The same implementation also supports only embedded SCTs, whose precertificates were issued directly by the issuer of the certificate. However, according to RFC 6962, section 3.1, those precertificates can be also issued by a special-purpose certification authority.

This change addresses both these issues.