### PR TITLE
Add missing include to cpp/monitoring/latency.h

### DIFF
--- a/cpp/monitoring/latency.h
+++ b/cpp/monitoring/latency.h
@@ -1,6 +1,7 @@
 #ifndef CERT_TRANS_MONITORING_LATENCY_H_
 #define CERT_TRANS_MONITORING_LATENCY_H_
 
+#include <functional>
 #include <string>
 
 #include "monitoring/counter.h"


### PR DESCRIPTION
Required for std::function.