### PR TITLE
Cert::OctetStringExtensionData crashes if extension is invalid

### DIFF
--- a/cpp/log/cert.cc
+++ b/cpp/log/cert.cc
@@ -644,11 +644,8 @@ util::Status Cert::OctetStringExtensionData(int extension_nid,
                                             string* result) const {
   CHECK(x509_);
 
-  // Callers don't care whether extension is missing or invalid as they
-  // usually call this method after confirming it to be present.
   const StatusOr<void*> ext_struct = ExtensionStructure(extension_nid);
-  if (!ext_struct.ok() &&
-      ext_struct.status().CanonicalCode() == Code::NOT_FOUND) {
+  if (!ext_struct.ok()) {
     return ext_struct.status();
   }
 


### PR DESCRIPTION
If the extension is invalid, the error code returned by `ExtensionStructure()` is `FAILED_PRECONDITION`, so the method continues until calling `ext_struct.ValueOrDie()`, resulting in a crash.

Originally, this check was `!ext_struct.ok() || !ext_struct.ValueOrDie()`, which correctly handled invalid extensions, but https://github.com/google/certificate-transparency/pull/949 changed this. Rather than just reverting this change, I've opted to:
- Not re-introduce `!ext_struct.ValueOrDie()`, since the value should never be null if ext_struct.ok().
- Return the actual status code returned by ExtensionStructure(), rather than just NOT_FOUND, since callers may actually be interested to know whether the extension was invalid.