### PR TITLE
python: Switch to single-shot verify functions

### DIFF
--- a/python/ct/crypto/verify_ecdsa.py
+++ b/python/ct/crypto/verify_ecdsa.py
@@ -60,11 +60,9 @@ class EcdsaVerifier(object):
         Raises:
         - error.SignatureError: If the signature fails verification.
         """
-        verifier = self.__key.verifier(signature, ec.ECDSA(hashes.SHA256()))
-        verifier.update(signature_input)
-
         try:
-            verifier.verify()
+            self.__key.verify(signature, signature_input,
+                              ec.ECDSA(hashes.SHA256()))
         except cryptography.exceptions.InvalidSignature:
             raise error.SignatureError("Signature did not verify: %s" %
                                        signature.encode("hex"))

--- a/python/ct/crypto/verify_rsa.py
+++ b/python/ct/crypto/verify_rsa.py
@@ -60,11 +60,9 @@ class RsaVerifier(object):
         Raises:
         - error.SignatureError: If the signature fails verification.
         """
-        verifier = self.__key.verifier(signature, padding.PKCS1v15(), hashes.SHA256())
-        verifier.update(signature_input)
-
         try:
-            verifier.verify()
+            self.__key.verify(signature, signature_input, padding.PKCS1v15(),
+                              hashes.SHA256())
         except cryptography.exceptions.InvalidSignature:
             raise error.SignatureError("Signature did not verify: %s" %
                                        signature.encode("hex"))

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,4 +8,4 @@ requests>=1.0
 Twisted[tls]>=12.1
 bitstring
 jsonschema
-cryptography>=1.0
+cryptography>=1.5


### PR DESCRIPTION
cryptography.io has since deprecated the streaming verifier function in
favor of the single-shot one. This should clear the stderr output seen
in Travis:

../Users/travis/build/google/certificate-transparency/python/ct/crypto/verify_ecdsa.py:63: CryptographyDeprecationWarning: signer and verifier have been deprecated. Please use sign and verify instead.
  verifier = self.__key.verifier(signature, ec.ECDSA(hashes.SHA256()))
................................/Users/travis/build/google/certificate-transparency/python/ct/crypto/verify_rsa.py:63: CryptographyDeprecationWarning: signer and verifier have been deprecated. Please use sign and verify instead.
  verifier = self.__key.verifier(signature, padding.PKCS1v15(), hashes.SHA256())
........

Note this does bump the minimum cryptography.io version. The single-shot
functions for ECDSA exist as of 1.5, released just shy of two years ago.