### PR TITLE
Fix issues preventing build on OSX and Travis tests on Linux

### DIFF
--- a/build/Makefile.openssl
+++ b/build/Makefile.openssl
@@ -11,6 +11,6 @@ $(INSTALL_DIR)/bin/openssl: Makefile
 
 Makefile: config Configure Makefile.org
 	# Force a 64 bit build on MacOS
-	KERNEL_BITS=64 ./config --install_prefix=$(INSTALL_DIR) --prefix=/ --libdir=lib --openssldir=$(OPENSSLDIR) no-shared enable-static-engine -fPIC
+	KERNEL_BITS=64 ./config --install_prefix=$(INSTALL_DIR) --prefix=/ --libdir=lib --openssldir=$(OPENSSLDIR) no-asm no-shared enable-static-engine -fPIC
 	# just to be sure we don't have dregs left over
 	$(MAKE) clean

--- a/build/Makefile.openssl
+++ b/build/Makefile.openssl
@@ -4,6 +4,11 @@ OPENSSLDIR := $(shell openssl version -d | awk '{ print $$2 }')
 
 all: $(INSTALL_DIR)/bin/openssl
 
+# Work around issues with aes-related instructions crashing on Travis builds.
+ifeq ($(TRAVIS),true)
+EXTRA_CONFIG="no-asm"
+endif
+
 $(INSTALL_DIR)/bin/openssl: Makefile
 	$(MAKE)
 	$(MAKE) test
@@ -11,6 +16,6 @@ $(INSTALL_DIR)/bin/openssl: Makefile
 
 Makefile: config Configure Makefile.org
 	# Force a 64 bit build on MacOS
-	KERNEL_BITS=64 ./config --install_prefix=$(INSTALL_DIR) --prefix=/ --libdir=lib --openssldir=$(OPENSSLDIR) no-asm no-shared enable-static-engine -fPIC
+	KERNEL_BITS=64 ./config --install_prefix=$(INSTALL_DIR) --prefix=/ --libdir=lib --openssldir=$(OPENSSLDIR) $(EXTRA_CONFIG) no-shared enable-static-engine -fPIC
 	# just to be sure we don't have dregs left over
 	$(MAKE) clean

--- a/cpp/util/etcd.cc
+++ b/cpp/util/etcd.cc
@@ -1033,7 +1033,7 @@ void EtcdClient::MaybeLogEtcdVersion() {
                                     to_string(etcds_.front().second) +
                                     "/version"));
   UrlFetcher::Response* const resp(new UrlFetcher::Response);
-  fetcher_->Fetch(req, resp, log_version_task_->task()->AddChild([this, resp](
+  fetcher_->Fetch(req, resp, log_version_task_->task()->AddChild([resp](
                                  Task* child_task) {
     unique_ptr<UrlFetcher::Response> resp_deleter(resp);
     if (!child_task->status().ok()) {


### PR DESCRIPTION
* Fix unused lambda 'this' param error on OSX build
* Build openssl with `no-asm` to fix illegal instruction error on AES tests on Travis