### PR TITLE
Remove bits of temporal validity test relating to wall clock time.

### DIFF
--- a/python/ct/crypto/cert_test.py
+++ b/python/ct/crypto/cert_test.py
@@ -415,11 +415,6 @@ class CertificateTest(unittest.TestCase):
         # notBefore: Sat Aug 22 16:41:51 1998 GMT
         # notAfter: Wed Aug 22 16:41:51 2018 GMT
         c = certs[2]
-        # These two will start failing in 2018.
-        self.assertTrue(c.is_temporally_valid_now())
-        self.assertFalse(c.is_expired())
-
-        self.assertFalse(c.is_not_yet_valid())
 
         # Aug 22 16:41:51 2018
         self.assertTrue(c.is_temporally_valid_at(time.gmtime(1534956111)))


### PR DESCRIPTION
Because:
a) the passage of time should not cause a test to start exploding at some arbitrary point in time.
b) the _now() function just delegates to the _at() functions which are tested explicitly here anyway.