### PR TITLE
Use absl.app in print_log_list.py and improve flag checks

### DIFF
--- a/python/utilities/log_list/print_log_list.py
+++ b/python/utilities/log_list/print_log_list.py
@@ -88,8 +88,7 @@ def print_formatted_log_list(json_log_list):
         print "-" * 80
 
 
-def main(argv):
-    del argv  # Unused; all arguments provided via flags.
+def main(_unused_argv):
     with open(FLAGS.log_list, "rb") as f:
         json_data = f.read()
 

--- a/python/utilities/log_list/print_log_list.py
+++ b/python/utilities/log_list/print_log_list.py
@@ -55,7 +55,9 @@ def is_signature_valid(log_list_data, signature_file, public_key_file):
     pubkey = serialization.load_pem_public_key(pubkey_pem)
     try:
         pubkey.verify(
-            open(signature_file, "rb").read(), log_list_data, padding.PKCS1v15(),
+            open(signature_file, "rb").read(),
+            log_list_data,
+            padding.PKCS1v15(),
             hashes.SHA256())
         return True
     except InvalidSignature:


### PR DESCRIPTION
Using absl.app causes flags to be handled automatically and gives us nice things like `app.UsageError`. I've added extra checks for unspecified flags, since otherwise the error messages caused by these flags being unset were quite obtuse.

I've removed the default value for `--log_list_schema` since there is no schema file found at "data/log_list_schema.json".