### PR TITLE
openssl_generator.py: Replace ':' in log identifier with '_'

### DIFF
--- a/python/utilities/log_list/openssl_generator.py
+++ b/python/utilities/log_list/openssl_generator.py
@@ -8,7 +8,8 @@ def _log_id(log):
     # Use log URL as its ID because it should be unique and is probably
     # shorter and more readable in a comma-separated list than the log
     # description.
-    return log["url"].replace(",", "")
+    # Replace ':' with '_' because ':' is not allowed by the CONF format.
+    return log["url"].replace(":", "_").replace(",", "")
 
 def _openssl_list(items):
     '''


### PR DESCRIPTION
Colons are not allowed in keys, according to the OpenSSL CONF documentation: https://www.openssl.org/docs/manmaster/man5/config.html