### PR TITLE
Fix TypeError: load_pem_public_key() takes exactly 2 arguments (1 given)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,12 +9,12 @@
 # Please keep the list sorted.
 
 Comodo CA Limited
+Dmitrii Kovalkov <kovalkov.dmitriy@gmail.com>
 Ed Maste <emaste@freebsd.org>
 Fiaz Hossain <fiaz.hossain@salesforce.com>
 Google Inc.
 Jeff Trawick <trawick@gmail.com>
 Katriel Cohn-Gordon <katriel.cohn-gordon@cybersecurity.ox.ac.uk>
-Kovalkov Dmitrii <kovalkov@fastvps.ru>
 Laël Cellier <lael.cellier@gmail.com>
 Mark Schloesser <ms@mwcollect.org>
 NORDUnet A/S

--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@ Fiaz Hossain <fiaz.hossain@salesforce.com>
 Google Inc.
 Jeff Trawick <trawick@gmail.com>
 Katriel Cohn-Gordon <katriel.cohn-gordon@cybersecurity.ox.ac.uk>
+Kovalkov Dmitrii <kovalkov@fastvps.ru>
 Laël Cellier <lael.cellier@gmail.com>
 Mark Schloesser <ms@mwcollect.org>
 NORDUnet A/S

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -40,6 +40,7 @@ Kat Joyce <katjoyce@google.com>
 Katriel Cohn-Gordon <katriel.cohn-gordon@cybersecurity.ox.ac.uk>
 Kiril Nikolov <kiril.nikolov@venafi.com>
 Konrad Kraszewski <kraszewski@google.com> <laiquendir@gmail.com>
+Kovalkov Dmitrii <kovalkov@fastvps.ru>
 Laël Cellier <lael.cellier@gmail.com>
 Linus Nordberg <linus@nordu.net>
 Mark Schloesser <ms@mwcollect.org>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -29,6 +29,7 @@ Chris Kennelly <ckennelly@google.com> <ckennelly@ckennelly.com>
 David Benjamin <davidben@google.com>
 David Drysdale <drysdale@google.com>
 Deyan Bektchiev <deyan.bektchiev@venafi.com> <deyan@bektchiev.net>
+Dmitrii Kovalkov <kovalkov.dmitriy@gmail.com>
 Ed Maste <emaste@freebsd.org>
 Emilia Kasper <ekasper@google.com>
 Eran Messeri <eranm@google.com> <eran.mes@gmail.com>
@@ -40,7 +41,6 @@ Kat Joyce <katjoyce@google.com>
 Katriel Cohn-Gordon <katriel.cohn-gordon@cybersecurity.ox.ac.uk>
 Kiril Nikolov <kiril.nikolov@venafi.com>
 Konrad Kraszewski <kraszewski@google.com> <laiquendir@gmail.com>
-Kovalkov Dmitrii <kovalkov@fastvps.ru>
 Laël Cellier <lael.cellier@gmail.com>
 Linus Nordberg <linus@nordu.net>
 Mark Schloesser <ms@mwcollect.org>

--- a/python/utilities/log_list/print_log_list.py
+++ b/python/utilities/log_list/print_log_list.py
@@ -11,6 +11,7 @@ import time
 from absl import app
 from absl import flags as gflags
 from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 import jsonschema
@@ -52,7 +53,7 @@ def is_log_list_valid(json_log_list, schema_file):
 
 def is_signature_valid(log_list_data, signature_file, public_key_file):
     pubkey_pem = open(public_key_file, "rb").read()
-    pubkey = serialization.load_pem_public_key(pubkey_pem)
+    pubkey = serialization.load_pem_public_key(pubkey_pem, backend=default_backend())
     try:
         pubkey.verify(
             open(signature_file, "rb").read(),


### PR DESCRIPTION
Fix
```
./print_log_list.py --log_list=log_list.json --log_list_schema=log_list_schema.json --signature=log_list.sig --signer_key=log_list_pubkey.pem
Traceback (most recent call last):
  File "./print_log_list.py", line 129, in <module>
    app.run(main)
  File "/home/kovalkov/.local/lib/python2.7/site-packages/absl/app.py", line 300, in run
    _run_main(main, args)
  File "/home/kovalkov/.local/lib/python2.7/site-packages/absl/app.py", line 251, in _run_main
    sys.exit(main(argv))
  File "./print_log_list.py", line 102, in main
    if not is_signature_valid(json_data, FLAGS.signature, FLAGS.signer_key):
  File "./print_log_list.py", line 55, in is_signature_valid
    pubkey = serialization.load_pem_public_key(pubkey_pem)
TypeError: load_pem_public_key() takes exactly 2 arguments (1 given)
```